### PR TITLE
feat(aicomponents): Fix issue #11 - Add "model used" and "provider" to output metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added metrics for AI Provider and AI Model in AI-Powered components ([#11](https://github.com/architects-toolkit/SmartHopper/issues/11))
+
 ### Fixed
 - Fixed bug with the Model input in AI-Powered components ([#3](https://github.com/architects-toolkit/SmartHopper/issues/3))
-- Fixed model parameter handling in IAIProvider interface to ensure proper model selection across providers
+- Fixed model parameter handling in IAIProvider interface to ensure proper model selection across providers ([#3](https://github.com/architects-toolkit/SmartHopper/issues/3))
 
 ## [0.0.0-dev.250101] - 2025-01-01
 

--- a/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
+++ b/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
@@ -32,6 +32,8 @@ namespace SmartHopper.Components.Misc
 
         protected override void RegisterOutputParams(GH_OutputParamManager pManager)
         {
+            pManager.AddTextParameter("AI Provider", "P", "AI provider used", GH_ParamAccess.item);
+            pManager.AddTextParameter("AI Model", "M", "AI model used", GH_ParamAccess.item);
             pManager.AddIntegerParameter("Input Tokens", "I", "Number of input tokens", GH_ParamAccess.item);
             pManager.AddIntegerParameter("Output Tokens", "O", "Number of output tokens", GH_ParamAccess.item);
             pManager.AddTextParameter("Finish Reason", "F", "Reason for finishing", GH_ParamAccess.item);
@@ -50,6 +52,8 @@ namespace SmartHopper.Components.Misc
             {
                 var metricsObject = JObject.Parse(jsonMetrics);
 
+                string aiProvider = metricsObject["ai_provider"]?.Value<string>() ?? "Unknown";
+                string aiModel = metricsObject["ai_model"]?.Value<string>() ?? "Unknown";
                 int inputTokens = metricsObject["tokens_input"]?.Value<int>() ?? 0;
                 int outputTokens = metricsObject["tokens_output"]?.Value<int>() ?? 0;
                 string finishReason = metricsObject["finish_reason"]?.Value<string>() ?? "Unknown";
@@ -59,27 +63,35 @@ namespace SmartHopper.Components.Misc
 
 
                 // Checks to see if the values were actually present
+                bool hasAIProvider = metricsObject["ai_provider"] != null;
+                bool hasAIModel = metricsObject["ai_model"] != null;
                 bool hasInputTokens = metricsObject["tokens_input"] != null;
                 bool hasOutputTokens = metricsObject["tokens_output"] != null;
                 bool hasFinishReason = metricsObject["finish_reason"] != null;
                 bool hasCompletionTime = metricsObject["completion_time"] != null;
 
                 // Set the data, potentially with warnings if values were missing
-                DA.SetData(0, inputTokens);
+                DA.SetData(0, aiProvider);
+                if (!hasAIProvider) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "AI provider not found in JSON");
+                
+                DA.SetData(1, aiModel);
+                if (!hasAIModel) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "AI model not found in JSON");
+
+                DA.SetData(2, inputTokens);
                 if (!hasInputTokens) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Input tokens not found in JSON");
 
-                DA.SetData(1, outputTokens);
+                DA.SetData(3, outputTokens);
                 if (!hasOutputTokens) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Output tokens not found in JSON");
 
-                DA.SetData(2, finishReason);
+                DA.SetData(4, finishReason);
                 if (!hasFinishReason) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Finish reason not found in JSON");
 
-                DA.SetData(3, completionTime);
+                DA.SetData(5, completionTime);
                 if (!hasCompletionTime) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Completion time not found in JSON");
 
-                DA.SetData(4, branchesInput);
+                DA.SetData(6, branchesInput);
 
-                DA.SetData(5, branchesProcessed);
+                DA.SetData(7, branchesProcessed);
             }
             catch (Exception ex)
             {

--- a/src/SmartHopper.Components/Text/AITextGenerateComponent.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerateComponent.cs
@@ -92,7 +92,7 @@ namespace SmartHopper.Components.Text
                 return false;
             }
 
-            Debug.WriteLine($"[AITextGenerate] ProcessAIResponse - Response received. InTokens: {response.InTokens}, OutTokens: {response.OutTokens}");
+            Debug.WriteLine($"[AITextGenerate] ProcessAIResponse - Response received. InTokens: {response.InTokens}, OutTokens: {response.OutTokens}, Model: {response.Model}");
 
             // Get the worker's processed response tree
             var worker = (AITextGenerateWorker)CurrentWorker;

--- a/src/SmartHopper.Config/Interfaces/IAIProvider.cs
+++ b/src/SmartHopper.Config/Interfaces/IAIProvider.cs
@@ -19,12 +19,15 @@ namespace SmartHopper.Config.Interfaces
     public interface IAIProvider
     {
         string Name { get; }
+        string DefaultModel { get; }
 
         IEnumerable<SettingDescriptor> GetSettingDescriptors();
 
         bool ValidateSettings(Dictionary<string, object> settings);
 
         Task<AIResponse> GetResponse(JArray messages, string model, string jsonSchema = "", string endpoint = "");
+        
+        string GetModel(Dictionary<string, object> settings, string requestedModel = "");
     }
 
     public interface IAIProviderSettings

--- a/src/SmartHopper.Config/Models/AIResponse.cs
+++ b/src/SmartHopper.Config/Models/AIResponse.cs
@@ -19,5 +19,7 @@ namespace SmartHopper.Config.Models
         public double CompletionTime { get; set; }
         public string ToolFunction { get; set; }
         public string ToolArguments { get; set; }
+        public string Provider { get; set; }
+        public string Model { get; set; }
     }
 }

--- a/src/SmartHopper.Config/Providers/MistralAI.cs
+++ b/src/SmartHopper.Config/Providers/MistralAI.cs
@@ -170,10 +170,10 @@ namespace SmartHopper.Config.Providers
                             {
                                 Response = choice["message"]["content"].ToString().Trim(),
                                 Provider = _name,
-                                Model = modelToUse,
+                                Model = json["model"]?.Value<string>() ?? "Unknown",
                                 InTokens = json["usage"]?["prompt_tokens"]?.Value<int>() ?? 0,
                                 OutTokens = json["usage"]?["completion_tokens"]?.Value<int>() ?? 0,
-                                FinishReason = choice["finish_reason"]?.ToString().Trim() ?? "unknown",
+                                FinishReason = choice["finish_reason"]?.ToString().Trim() ?? "Unknown",
                             };
                         }
                     }

--- a/src/SmartHopper.Config/Providers/MistralAI.cs
+++ b/src/SmartHopper.Config/Providers/MistralAI.cs
@@ -166,6 +166,8 @@ namespace SmartHopper.Config.Providers
                             return new AIResponse
                             {
                                 Response = choice["message"]["content"].ToString().Trim(),
+                                Provider = ProviderName,
+                                Model = modelToUse,
                                 InTokens = json["usage"]?["prompt_tokens"]?.Value<int>() ?? 0,
                                 OutTokens = json["usage"]?["completion_tokens"]?.Value<int>() ?? 0,
                                 FinishReason = choice["finish_reason"]?.ToString().Trim() ?? "unknown",

--- a/src/SmartHopper.Config/Providers/MistralAISettings.cs
+++ b/src/SmartHopper.Config/Providers/MistralAISettings.cs
@@ -76,7 +76,7 @@ namespace SmartHopper.Config.Providers
             return new Dictionary<string, object>
             {
                 ["ApiKey"] = apiKeyTextBox.Text,
-                ["Model"] = string.IsNullOrWhiteSpace(modelTextBox.Text) ? MistralAI.DefaultModelName : modelTextBox.Text,
+                ["Model"] = string.IsNullOrWhiteSpace(modelTextBox.Text) ? provider.DefaultModel : modelTextBox.Text,
                 ["MaxTokens"] = (int)maxTokensNumeric.Value
             };
         }
@@ -89,7 +89,7 @@ namespace SmartHopper.Config.Providers
             if (settings.ContainsKey("Model"))
                 modelTextBox.Text = settings["Model"].ToString();
             else
-                modelTextBox.Text = MistralAI.DefaultModelName;
+                modelTextBox.Text = provider.DefaultModel;
 
             if (settings.ContainsKey("MaxTokens"))
                 maxTokensNumeric.Value = Convert.ToInt32(settings["MaxTokens"]);
@@ -98,11 +98,11 @@ namespace SmartHopper.Config.Providers
         private void LoadSettings()
         {
             var settings = SmartHopperSettings.Load();
-            if (!settings.ProviderSettings.ContainsKey(MistralAI.ProviderName))
+            if (!settings.ProviderSettings.ContainsKey(provider.Name))
             {
-                settings.ProviderSettings[MistralAI.ProviderName] = new Dictionary<string, object>();
+                settings.ProviderSettings[provider.Name] = new Dictionary<string, object>();
             }
-            LoadSettings(settings.ProviderSettings[MistralAI.ProviderName]);
+            LoadSettings(settings.ProviderSettings[provider.Name]);
         }
 
         public bool ValidateSettings()

--- a/src/SmartHopper.Config/Providers/OpenAI.cs
+++ b/src/SmartHopper.Config/Providers/OpenAI.cs
@@ -148,7 +148,7 @@ namespace SmartHopper.Config.Providers
                     {
                         Response = json["choices"][0]["message"]["content"].ToString().Trim(),
                         Provider = _name,
-                        Model = modelToUse,
+                        Model = json["model"]?.Value<string>() ?? "Unknown",
                         InTokens = (int)json["usage"]["prompt_tokens"],
                         OutTokens = (int)json["usage"]["completion_tokens"],
                         FinishReason = json["choices"][0]["finish_reason"].ToString().Trim(),

--- a/src/SmartHopper.Config/Providers/OpenAI.cs
+++ b/src/SmartHopper.Config/Providers/OpenAI.cs
@@ -144,6 +144,8 @@ namespace SmartHopper.Config.Providers
                     return new AIResponse
                     {
                         Response = json["choices"][0]["message"]["content"].ToString().Trim(),
+                        Provider = ProviderName,
+                        Model = modelToUse,
                         InTokens = (int)json["usage"]["prompt_tokens"],
                         OutTokens = (int)json["usage"]["completion_tokens"],
                         FinishReason = json["choices"][0]["finish_reason"].ToString().Trim(),

--- a/src/SmartHopper.Config/Providers/OpenAI.cs
+++ b/src/SmartHopper.Config/Providers/OpenAI.cs
@@ -23,16 +23,17 @@ namespace SmartHopper.Config.Providers
 {
     public sealed class OpenAI : IAIProvider
     {
-        public const string ProviderName = "OpenAI";
+        public const string _name = "OpenAI";
         private const string ApiURL = "https://api.openai.com/v1/chat/completions";
-        public const string DefaultModelName = "gpt-4o-mini";
+        private const string _defaultModel = "gpt-4o-mini";
 
         private static readonly Lazy<OpenAI> _instance = new Lazy<OpenAI>(() => new OpenAI());
         public static OpenAI Instance => _instance.Value;
 
         private OpenAI() { }
 
-        public string Name => ProviderName;
+        public string Name => _name;
+        public string DefaultModel => _defaultModel;
 
         public IEnumerable<SettingDescriptor> GetSettingDescriptors()
         {
@@ -51,7 +52,7 @@ namespace SmartHopper.Config.Providers
                 {
                     Name = "Model",
                     Type = typeof(string),
-                    DefaultValue = DefaultModelName,
+                    DefaultValue = _defaultModel,
                     IsSecret = false,
                     DisplayName = "Model",
                     Description = "The model to use for completions"
@@ -79,20 +80,22 @@ namespace SmartHopper.Config.Providers
         public async Task<AIResponse> GetResponse(JArray messages, string model, string jsonSchema = "", string endpoint = "")
         {
             var settings = SmartHopperSettings.Load();
-            if (!settings.ProviderSettings.ContainsKey(ProviderName))
+            if (!settings.ProviderSettings.ContainsKey(_name))
             {
-                settings.ProviderSettings[ProviderName] = new Dictionary<string, object>();
+                settings.ProviderSettings[_name] = new Dictionary<string, object>();
             }
-            var providerSettings = settings.ProviderSettings[ProviderName];
+            var providerSettings = settings.ProviderSettings[_name];
+            if (!ValidateSettings(providerSettings))
+                throw new InvalidOperationException("Invalid provider settings");
+
+            var modelToUse = GetModel(providerSettings, model);
 
             string apiKey = providerSettings.ContainsKey("ApiKey") ? providerSettings["ApiKey"].ToString() : "";
-            string modelToUse = !string.IsNullOrEmpty(model) ? model : 
-                              (providerSettings.ContainsKey("Model") ? providerSettings["Model"].ToString() : DefaultModelName);
             int maxTokens = providerSettings.ContainsKey("MaxTokens") ? Convert.ToInt32(providerSettings["MaxTokens"]) : 150;
 
             if (modelToUse == "" || modelToUse == "openai")
             {
-                modelToUse = DefaultModelName;
+                modelToUse = _defaultModel;
                 Debug.WriteLine($"Using default model: {modelToUse}");
             }
 
@@ -144,7 +147,7 @@ namespace SmartHopper.Config.Providers
                     return new AIResponse
                     {
                         Response = json["choices"][0]["message"]["content"].ToString().Trim(),
-                        Provider = ProviderName,
+                        Provider = _name,
                         Model = modelToUse,
                         InTokens = (int)json["usage"]["prompt_tokens"],
                         OutTokens = (int)json["usage"]["completion_tokens"],
@@ -161,6 +164,12 @@ namespace SmartHopper.Config.Providers
                     };
                 }
             }
+        }
+
+        public string GetModel(Dictionary<string, object> providerSettings, string model)
+        {
+            return !string.IsNullOrEmpty(model) ? model :
+                   (providerSettings.ContainsKey("Model") ? providerSettings["Model"].ToString() : _defaultModel);
         }
     }
 }

--- a/src/SmartHopper.Config/Providers/OpenAISettings.cs
+++ b/src/SmartHopper.Config/Providers/OpenAISettings.cs
@@ -76,7 +76,7 @@ namespace SmartHopper.Config.Providers
             return new Dictionary<string, object>
             {
                 ["ApiKey"] = apiKeyTextBox.Text,
-                ["Model"] = string.IsNullOrWhiteSpace(modelTextBox.Text) ? OpenAI.DefaultModelName : modelTextBox.Text,
+                ["Model"] = string.IsNullOrWhiteSpace(modelTextBox.Text) ? provider.DefaultModel : modelTextBox.Text,
                 ["MaxTokens"] = (int)maxTokensNumeric.Value
             };
         }
@@ -89,7 +89,7 @@ namespace SmartHopper.Config.Providers
             if (settings.ContainsKey("Model"))
                 modelTextBox.Text = settings["Model"].ToString();
             else
-                modelTextBox.Text = OpenAI.DefaultModelName;
+                modelTextBox.Text = provider.DefaultModel;
 
             if (settings.ContainsKey("MaxTokens"))
                 maxTokensNumeric.Value = Convert.ToInt32(settings["MaxTokens"]);
@@ -98,11 +98,11 @@ namespace SmartHopper.Config.Providers
         private void LoadSettings()
         {
             var settings = SmartHopperSettings.Load();
-            if (!settings.ProviderSettings.ContainsKey(OpenAI.ProviderName))
+            if (!settings.ProviderSettings.ContainsKey(provider.Name))
             {
-                settings.ProviderSettings[OpenAI.ProviderName] = new Dictionary<string, object>();
+                settings.ProviderSettings[provider.Name] = new Dictionary<string, object>();
             }
-            LoadSettings(settings.ProviderSettings[OpenAI.ProviderName]);
+            LoadSettings(settings.ProviderSettings[provider.Name]);
         }
 
         public bool ValidateSettings()

--- a/src/SmartHopper.Core/AI/AIMessageBuilder.cs
+++ b/src/SmartHopper.Core/AI/AIMessageBuilder.cs
@@ -22,8 +22,8 @@ namespace SmartHopper.Core.AI
         {
             return new Dictionary<string, string>()
             {
-                { OpenAI.ProviderName, "assistant" },
-                { MistralAI.ProviderName, "assistant" },
+                { OpenAI._name, "assistant" },
+                { MistralAI._name, "assistant" },
                 { "User", "user" }
             };
         }

--- a/src/SmartHopper.Core/AI/AIUtils.cs
+++ b/src/SmartHopper.Core/AI/AIUtils.cs
@@ -60,8 +60,8 @@ namespace SmartHopper.Core.Utils
         {
             return new Dictionary<string, string>()
             {
-                { OpenAI.ProviderName, "assistant" },
-                { MistralAI.ProviderName, "assistant" },
+                { OpenAI._name, "assistant" },
+                { MistralAI._name, "assistant" },
                 { "User", "user" }
             };
         }

--- a/src/SmartHopper.Core/AI/AIUtils.cs
+++ b/src/SmartHopper.Core/AI/AIUtils.cs
@@ -118,8 +118,6 @@ namespace SmartHopper.Core.Utils
                 var response = await selectedProvider.GetResponse(messages, model, jsonSchema, endpoint);
                 stopwatch.Stop();
                 response.CompletionTime = stopwatch.Elapsed.TotalSeconds;
-                response.Provider = providerName;
-                response.Model = model;
                 return response;
             }
             catch (HttpRequestException ex)

--- a/src/SmartHopper.Core/AI/AIUtils.cs
+++ b/src/SmartHopper.Core/AI/AIUtils.cs
@@ -118,6 +118,8 @@ namespace SmartHopper.Core.Utils
                 var response = await selectedProvider.GetResponse(messages, model, jsonSchema, endpoint);
                 stopwatch.Stop();
                 response.CompletionTime = stopwatch.Elapsed.TotalSeconds;
+                response.Provider = providerName;
+                response.Model = model;
                 return response;
             }
             catch (HttpRequestException ex)

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -134,6 +134,8 @@ namespace SmartHopper.Core.Async.Components
 
             // Create JSON object with metrics
             var metricsJson = new JObject(
+                new JProperty("ai_provider", response.Provider),
+                new JProperty("ai_model", response.Model),
                 new JProperty("tokens_input", inTokenValue),
                 new JProperty("tokens_output", outTokenValue),
                 new JProperty("finish_reason", response.FinishReason),

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -39,7 +39,6 @@ namespace SmartHopper.Core.Async.Components
     public abstract class AIStatefulComponentBase : AsyncStatefulComponentBase
     {
         protected GH_Structure<GH_String> LastMetrics { get; private set; } // Useless? Move metrics here?
-        protected string ApiKey { get; set; }
         protected string Model { get; private set; }
         protected string SelectedProvider { get; private set; }
         
@@ -175,6 +174,11 @@ namespace SmartHopper.Core.Async.Components
             Debug.WriteLine($"[AIStatefulComponentBase] SetModel - Setting model to: {model}");
             Model = model;
         }
+        protected string GetModel()
+        {
+            // Let the provider handle the default model
+            return Model ?? "";
+        }
 
         protected static int GetDebounceTime()
         {
@@ -182,23 +186,7 @@ namespace SmartHopper.Core.Async.Components
             return Math.Max(settingsDebounceTime, MIN_DEBOUNCE_TIME);
         }
 
-        protected (string apiKey, string model) GetAIConfiguration()
-        {
-            var settings = SmartHopperSettings.Load();
-            string apiKey = null;
-
-            // Use the provider selected from menu
-            string providerName = SelectedProvider;
-
-            if (settings.ProviderSettings.TryGetValue(providerName, out var providerSettings) &&
-                providerSettings.TryGetValue("ApiKey", out var apiKeyObj))
-            {
-                apiKey = apiKeyObj.ToString();
-            }
-
-            // Let the provider handle the default model
-            return (apiKey, Model ?? "");
-        }
+        
 
         protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
         {
@@ -268,7 +256,6 @@ namespace SmartHopper.Core.Async.Components
         protected abstract class AIWorkerBase : StatefulWorker
         {
             protected AIResponse _lastAIResponse;
-            protected string ApiKey { get; private set; }
             protected string Prompt { get; private set; }
 
             protected AIWorkerBase(
@@ -319,7 +306,7 @@ namespace SmartHopper.Core.Async.Components
                 try
                 {
                     Debug.WriteLine($"[AIWorkerBase] GetResponse - Using Provider: {((AIStatefulComponentBase)_parent).SelectedProvider}");
-                    var (apiKey, modelToUse) = ((AIStatefulComponentBase)_parent).GetAIConfiguration();
+                    var modelToUse = ((AIStatefulComponentBase)_parent).GetModel();
 
                     Debug.WriteLine("[AIWorkerBase] Number of messages: " + messages.Count);
                     Debug.WriteLine("[AIWorkerBase] Prompt: " + Prompt);

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Async.Components
             : base(name, nickname, description, category, subCategory)
         {
             LastMetrics = new GH_Structure<GH_String>(); // Useless? Move metrics here?
-            SelectedProvider = MistralAI.ProviderName; // Default to SmartHopper
+            SelectedProvider = MistralAI._name; // Default to SmartHopper/MistralAI
         }
 
         protected override sealed void RegisterInputParams(GH_InputParamManager pManager)

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Async.Components
             : base(name, nickname, description, category, subCategory)
         {
             LastMetrics = new GH_Structure<GH_String>(); // Useless? Move metrics here?
-            SelectedProvider = MistralAI._name; // Default to SmartHopper/MistralAI
+            SelectedProvider = MistralAI._name; // Default to MistralAI
         }
 
         protected override sealed void RegisterInputParams(GH_InputParamManager pManager)
@@ -308,11 +308,9 @@ namespace SmartHopper.Core.Async.Components
                 try
                 {
                     Debug.WriteLine($"[AIWorkerBase] GetResponse - Using Provider: {((AIStatefulComponentBase)_parent).SelectedProvider}");
-                    var modelToUse = ((AIStatefulComponentBase)_parent).GetModel();
 
                     Debug.WriteLine("[AIWorkerBase] Number of messages: " + messages.Count);
                     Debug.WriteLine("[AIWorkerBase] Prompt: " + Prompt);
-                    Debug.WriteLine("[AIWorkerBase] Model: " + modelToUse);
 
                     if (messages == null || !messages.Any())
                     {
@@ -327,7 +325,7 @@ namespace SmartHopper.Core.Async.Components
 
                     var response = await AIUtils.GetResponse(
                         ((AIStatefulComponentBase)_parent).SelectedProvider,
-                        modelToUse,
+                        ((AIStatefulComponentBase)_parent).GetModel(),
                         messages,
                         endpoint: endpoint);
 
@@ -335,8 +333,6 @@ namespace SmartHopper.Core.Async.Components
                     if (_lastAIResponse == null || string.IsNullOrEmpty(_lastAIResponse.Response))
                     {
                         _lastAIResponse = response;
-                        //_lastAIResponse.InTokens += prevInTokens;
-                        //_lastAIResponse.OutTokens += prevOutTokens;
                     }
 
                     _lastAIResponse.InTokens += response.InTokens;


### PR DESCRIPTION
## Description

This PR includes two extra metrics, "AI Provider" and "AI Model", passed directly from the AI provider to the AI-powered components.

## Breaking Changes

The Deconstruct Metrics component now has two extra outputs.

## Testing Done

Windows, RH8.13, with AITextGenerate component

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)