### PR TITLE
fix(aistatefulcomponentbase): Sum tokens from all branches in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug with the Model input in AI-Powered components ([#3](https://github.com/architects-toolkit/SmartHopper/issues/3))
 - Fixed model parameter handling in IAIProvider interface to ensure proper model selection across providers ([#3](https://github.com/architects-toolkit/SmartHopper/issues/3))
+- Fixed issue with AI response metrics not returning the tokens used in all branches, but only the last one ([#2](https://github.com/architects-toolkit/SmartHopper/issues/2))
 
 ## [0.0.0-dev.250101] - 2025-01-01
 

--- a/src/SmartHopper.Components/List/AIListCheckComponent.cs
+++ b/src/SmartHopper.Components/List/AIListCheckComponent.cs
@@ -112,7 +112,7 @@ namespace SmartHopper.Components.List
             {
                 lastResult = worker.result;
                 DA.SetDataTree(0, lastResult);
-                SetMetricsOutput(DA, response, branches_input, branches_processed);
+                SetMetricsOutput(DA, branches_input, branches_processed);
                 RestoreMetrics();
                 return true;
             }

--- a/src/SmartHopper.Components/List/AIListFilterComponent.cs
+++ b/src/SmartHopper.Components/List/AIListFilterComponent.cs
@@ -112,7 +112,7 @@ namespace SmartHopper.Components.List
             {
                 lastResult = worker.result;
                 DA.SetDataTree(0, lastResult);
-                SetMetricsOutput(DA, response, branches_input, branches_processed);
+                SetMetricsOutput(DA, branches_input, branches_processed);
                 RestoreMetrics();
                 return true;
             }

--- a/src/SmartHopper.Components/Text/AITextGenerateComponent.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerateComponent.cs
@@ -100,7 +100,7 @@ namespace SmartHopper.Components.Text
             {
                 lastResponse = worker.response;
                 DA.SetDataTree(0, lastResponse);
-                SetMetricsOutput(DA, response, branches_input, branches_processed);
+                SetMetricsOutput(DA, branches_input, branches_processed);
                 RestoreMetrics();
                 return true;
             }
@@ -126,7 +126,7 @@ namespace SmartHopper.Components.Text
             private GH_Structure<GH_String> promptTree;
             internal GH_Structure<GH_String> response;
             private readonly IGH_DataAccess _dataAccess;
-            private AIResponse _lastAIResponse;
+            //private AIResponse _lastAIResponse;
 
             public AITextGenerateWorker(AITextGenerate parent)
                 : this(null, parent, null, null)

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -257,7 +257,7 @@ namespace SmartHopper.Core.Async.Components
         // <param name="addRuntimeMessage">Action to add runtime messages</param>
         protected abstract class AIWorkerBase : StatefulWorker
         {
-            protected AIResponse _lastAIResponse;
+            //protected AIResponse _lastAIResponse;
             protected string Prompt { get; private set; }
 
             protected AIWorkerBase(
@@ -320,8 +320,8 @@ namespace SmartHopper.Core.Async.Components
                     // Get endpoint based on component type
                     string endpoint = "";
 
-                    var prevInTokens = _lastAIResponse?.InTokens ?? 0;
-                    var prevOutTokens = _lastAIResponse?.OutTokens ?? 0;
+                    //var prevInTokens = _lastAIResponse?.InTokens ?? 0;
+                    //var prevOutTokens = _lastAIResponse?.OutTokens ?? 0;
 
                     var response = await AIUtils.GetResponse(
                         ((AIStatefulComponentBase)_parent).SelectedProvider,
@@ -330,13 +330,13 @@ namespace SmartHopper.Core.Async.Components
                         endpoint: endpoint);
 
                     // if _lastAIResponse is empty or null, set it to the response
-                    if (_lastAIResponse == null || string.IsNullOrEmpty(_lastAIResponse.Response))
-                    {
-                        _lastAIResponse = response;
-                    }
+                    //if (_lastAIResponse == null || string.IsNullOrEmpty(_lastAIResponse.Response))
+                    //{
+                    //    _lastAIResponse = response;
+                    //}
 
-                    _lastAIResponse.InTokens += response.InTokens;
-                    _lastAIResponse.OutTokens += response.OutTokens;
+                    //_lastAIResponse.InTokens += response.InTokens;
+                    //_lastAIResponse.OutTokens += response.OutTokens;
 
                     return response;
                 }

--- a/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
+++ b/src/SmartHopper.Core/Async/Components/AIStatefulComponentBase.cs
@@ -38,18 +38,17 @@ namespace SmartHopper.Core.Async.Components
     /// </summary>
     public abstract class AIStatefulComponentBase : AsyncStatefulComponentBase
     {
-        protected GH_Structure<GH_String> LastMetrics { get; private set; } // Useless? Move metrics here?
         protected string Model { get; private set; }
         protected string SelectedProvider { get; private set; }
         
         private const int MIN_DEBOUNCE_TIME = 1000;
         private volatile bool _isDebouncing;
         private System.Threading.Timer _debounceTimer;
-        
+        private List<AIResponse> _responseMetrics = new List<AIResponse>();
+
         protected AIStatefulComponentBase(string name, string nickname, string description, string category, string subCategory)
             : base(name, nickname, description, category, subCategory)
         {
-            LastMetrics = new GH_Structure<GH_String>(); // Useless? Move metrics here?
             SelectedProvider = MistralAI._name; // Default to MistralAI
         }
 
@@ -97,49 +96,68 @@ namespace SmartHopper.Core.Async.Components
         protected abstract bool ProcessFinalResponse(AIResponse response, IGH_DataAccess DA);
 
         /// <summary>
+        /// Stores the given AI response metrics in the component's internal metrics list.
+        /// </summary>
+        /// <param name="response">The AI response to store metrics from.</param>
+        public void StoreResponseMetrics(AIResponse response)
+        {
+            if (response != null)
+            {
+                _responseMetrics.Add(response);
+            }
+        }
+
+        /// <summary>
         /// Sets the metrics output parameters (input tokens, output tokens, finish reason)
         /// </summary>
         /// <param name="DA">The data access object</param>
         /// <param name="baseOutputIndex">The index of the first metrics output parameter</param>
-        protected void SetMetricsOutput(IGH_DataAccess DA, AIResponse response, int initialBranches = 0, int processedBranches = 0)
+        protected void SetMetricsOutput(IGH_DataAccess DA, int initialBranches = 0, int processedBranches = 0)
         {
             Debug.WriteLine("[AIStatefulComponentBase] SetMetricsOutput - Start");
-            if (response == null)
+            
+            if (!_responseMetrics.Any())
             {
                 Debug.WriteLine("[AIStatefulComponentBase] SetMetricsOutput - No response, skipping metrics");
                 return;
             }
 
+            // Aggregate metrics
+            int totalInTokens = _responseMetrics.Sum(r => r.InTokens);
+            int totalOutTokens = _responseMetrics.Sum(r => r.OutTokens);
+            string finishReason = _responseMetrics.Last().FinishReason;
+            double totalCompletionTime = _responseMetrics.Sum(r => r.CompletionTime);
+
             // Handle potential non-numeric token values
-            int inTokenValue;
-            int outTokenValue;
+            //int inTokenValue;
+            //int outTokenValue;
 
-            if (response.InTokens is int inTokenInt)
-            {
-                inTokenValue = inTokenInt;
-            }
-            else
-            {
-                int.TryParse(response.InTokens.ToString(), out inTokenValue);
-            }
+            //if (response.InTokens is int inTokenInt)
+            //{
+            //    inTokenValue = inTokenInt;
+            //}
+            //else
+            //{
+            //    int.TryParse(response.InTokens.ToString(), out inTokenValue);
+            //}
 
-            if (response.OutTokens is int outTokenInt)
-            {
-                outTokenValue = outTokenInt;
-            }
-            else
-            {
-                int.TryParse(response.OutTokens.ToString(), out outTokenValue);
-            }
+            //if (response.OutTokens is int outTokenInt)
+            //{
+            //    outTokenValue = outTokenInt;
+            //}
+            //else
+            //{
+            //    int.TryParse(response.OutTokens.ToString(), out outTokenValue);
+            //}
 
             // Create JSON object with metrics
             var metricsJson = new JObject(
-                new JProperty("ai_provider", response.Provider),
-                new JProperty("ai_model", response.Model),
-                new JProperty("tokens_input", inTokenValue),
-                new JProperty("tokens_output", outTokenValue),
-                new JProperty("finish_reason", response.FinishReason),
-                new JProperty("completion_time", response.CompletionTime)
+                new JProperty("ai_provider", _responseMetrics.First().Provider),
+                new JProperty("ai_model", _responseMetrics.First().Model),
+                new JProperty("tokens_input", totalInTokens),
+                new JProperty("tokens_output", totalOutTokens),
+                new JProperty("finish_reason", finishReason),
+                new JProperty("completion_time", totalCompletionTime)
             );
 
             // If initialBranches are provided, add them to the JSON object
@@ -169,6 +187,9 @@ namespace SmartHopper.Core.Async.Components
 
             DA.SetData(additionalOutputCount, metricsJson);
             Debug.WriteLine($"[AIStatefulComponentBase] SetMetricsOutput - Set metrics at index {additionalOutputCount}. JSON: {metricsJson}");
+
+            // Clear the stored metrics after setting the output
+            _responseMetrics.Clear();
         }
 
         protected void SetModel(string model)
@@ -187,8 +208,6 @@ namespace SmartHopper.Core.Async.Components
             var settingsDebounceTime = SmartHopperSettings.Load().DebounceTime;
             return Math.Max(settingsDebounceTime, MIN_DEBOUNCE_TIME);
         }
-
-        
 
         protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
         {
@@ -257,7 +276,7 @@ namespace SmartHopper.Core.Async.Components
         // <param name="addRuntimeMessage">Action to add runtime messages</param>
         protected abstract class AIWorkerBase : StatefulWorker
         {
-            //protected AIResponse _lastAIResponse;
+            protected AIResponse _lastAIResponse;
             protected string Prompt { get; private set; }
 
             protected AIWorkerBase(
@@ -320,23 +339,13 @@ namespace SmartHopper.Core.Async.Components
                     // Get endpoint based on component type
                     string endpoint = "";
 
-                    //var prevInTokens = _lastAIResponse?.InTokens ?? 0;
-                    //var prevOutTokens = _lastAIResponse?.OutTokens ?? 0;
-
                     var response = await AIUtils.GetResponse(
                         ((AIStatefulComponentBase)_parent).SelectedProvider,
                         ((AIStatefulComponentBase)_parent).GetModel(),
                         messages,
                         endpoint: endpoint);
 
-                    // if _lastAIResponse is empty or null, set it to the response
-                    //if (_lastAIResponse == null || string.IsNullOrEmpty(_lastAIResponse.Response))
-                    //{
-                    //    _lastAIResponse = response;
-                    //}
-
-                    //_lastAIResponse.InTokens += response.InTokens;
-                    //_lastAIResponse.OutTokens += response.OutTokens;
+                    ((AIStatefulComponentBase)_parent).StoreResponseMetrics(response);
 
                     return response;
                 }


### PR DESCRIPTION
## Description

Refactored AIStatefulComponentBase to improve metrics tracking and remove legacy response handling. Key changes include:

- Introduced _responseMetrics list to aggregate AI response metrics
- Removed _lastAIResponse from worker
- Enhanced SetMetricsOutput method to handle aggregated metrics
- Simplified token and metrics calculation logic

Fixes #2 

## Breaking Changes

- Removed _lastAIResponse from worker components
- Modified SetMetricsOutput method signature and implementation

## Testing Done

Tested on Windows, RH8.13, with components AITextGenerate and AIListCheck.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
