### PR TITLE
refactor(text): migrate AITextGenerate functionality to TextTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added generic `AIEvaluationResult<T>` for standardized tool-component communication
   - Created `ParsingTools` class for reusable AI response parsing
   - Created `TextTools` with method `EvaluateTextAsync` (replacement of `AiTextEvaluate` main function)
+  - Added `GenerateTextAsync` methods to `TextTools` (migrated from `AITextGenerate` component)
+  - Updated `AITextGenerate` component to use the new generic tools
+  - Added regions in `TextTools` to improve code organization
 
 ### Fixed
 

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>0.1.1-dev.250222</SolutionVersion>
+    <SolutionVersion>0.1.1-dev.250302</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/src/SmartHopper.Components/Text/AITextGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerate.cs
@@ -21,6 +21,7 @@ using Grasshopper.Kernel.Types;
 using System.Collections.Generic;
 using Grasshopper.Documentation;
 using System.Linq;
+using SmartHopper.Core.Grasshopper.Tools;
 
 namespace SmartHopper.Components.Text
 {
@@ -157,30 +158,26 @@ namespace SmartHopper.Components.Text
                 {
                     Debug.WriteLine($"[ProcessData] Processing prompt {i + 1}/{promptTree.Count}");
 
-                    // Initiate the messages array
-                    var messages = new List<KeyValuePair<string, string>>();
+                    // Use the new generic tool to generate text
+                    var result = await TextTools.GenerateTextAsync(promptTree[i], instructionsTree[i], 
+                        messages => parent.GetResponse(messages));
 
-                    // Add system prompt if available
-                    var systemPrompt = instructionsTree[i].Value;
-                    if (!string.IsNullOrWhiteSpace(systemPrompt))
+                    if (!result.Success)
                     {
-                        messages.Add(new KeyValuePair<string, string>("system", systemPrompt));
-                    }
-
-                    // Add the user prompt
-                    messages.Add(new KeyValuePair<string, string>("user", prompt.Value));
-
-                    var response = await parent.GetResponse(messages);
-
-                    if (response.FinishReason == "error")
-                    {
-                        parent.AIErrorToPersistentRuntimeMessage(response);
+                        if (result.Response?.FinishReason == "error")
+                        {
+                            parent.AIErrorToPersistentRuntimeMessage(result.Response);
+                        }
+                        else
+                        {
+                            parent.SetPersistentRuntimeMessage("ai_error", result.ErrorLevel, result.ErrorMessage, false);
+                        }
                         outputs["Result"].Add(new GH_String(string.Empty));
                         i++;
                         continue;
                     }
 
-                    outputs["Result"].Add(new GH_String(response.Response));
+                    outputs["Result"].Add(result.Result);
                     i++;
                 }
 

--- a/src/SmartHopper.Core.Grasshopper/Tools/TextTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/TextTools.cs
@@ -24,6 +24,8 @@ namespace SmartHopper.Core.Grasshopper.Tools
     /// </summary>
     public static class TextTools
     {
+        #region Text Evaluation
+
         /// <summary>
         /// Evaluates text against a true/false question using AI with a custom GetResponse function
         /// </summary>
@@ -106,5 +108,82 @@ namespace SmartHopper.Core.Grasshopper.Tools
             return EvaluateTextAsync(text, question, 
                 messages => AIUtils.GetResponse(provider, model, messages));
         }
+
+        #endregion
+
+        #region Text Generation
+
+        /// <summary>
+        /// Generates text from a prompt and optional instructions using AI with a custom GetResponse function
+        /// </summary>
+        /// <param name="prompt">The user's prompt</param>
+        /// <param name="instructions">Optional instructions for the AI</param>
+        /// <param name="getResponse">Custom function to get AI response</param>
+        /// <returns>The generated text as a GH_String</returns>
+        public static async Task<AIEvaluationResult<GH_String>> GenerateTextAsync(
+            GH_String prompt,
+            GH_String instructions,
+            Func<List<KeyValuePair<string, string>>, Task<AIResponse>> getResponse)
+        {
+            try
+            {
+                // Initiate the messages array
+                var messages = new List<KeyValuePair<string, string>>();
+
+                // Add system prompt if available
+                var systemPrompt = instructions.Value;
+                if (!string.IsNullOrWhiteSpace(systemPrompt))
+                {
+                    messages.Add(new KeyValuePair<string, string>("system", systemPrompt));
+                }
+
+                // Add the user prompt
+                messages.Add(new KeyValuePair<string, string>("user", prompt.Value));
+
+                // Get response using the provided function
+                var response = await getResponse(messages);
+
+                // Check for API errors
+                if (response.FinishReason == "error")
+                {
+                    return AIEvaluationResult<GH_String>.CreateError(
+                        response.Response,
+                        GH_RuntimeMessageLevel.Error,
+                        response);
+                }
+
+                // Success case
+                return AIEvaluationResult<GH_String>.CreateSuccess(
+                    response,
+                    new GH_String(response.Response));
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TextTools] Error in GenerateTextAsync: {ex.Message}");
+                return AIEvaluationResult<GH_String>.CreateError(
+                    $"Error generating text: {ex.Message}",
+                    GH_RuntimeMessageLevel.Error);
+            }
+        }
+
+        /// <summary>
+        /// Generates text from a prompt and optional instructions using AI with the default AIUtils.GetResponse
+        /// </summary>
+        /// <param name="prompt">The user's prompt</param>
+        /// <param name="instructions">Optional instructions for the AI</param>
+        /// <param name="provider">The AI provider to use</param>
+        /// <param name="model">The model to use, or empty for default</param>
+        /// <returns>The generated text as a GH_String</returns>
+        public static Task<AIEvaluationResult<GH_String>> GenerateTextAsync(
+            GH_String prompt,
+            GH_String instructions,
+            string provider,
+            string model = "")
+        {
+            return GenerateTextAsync(prompt, instructions,
+                messages => AIUtils.GetResponse(provider, model, messages));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Description

This PR migrates the text generation functionality from the AITextGenerate component to the generic TextTools class. This continues our effort to move component-specific code to reusable tools.

The changes include:

- Added GenerateTextAsync methods to TextTools class
- Updated version in Solution.props to today's date
- Updated CHANGELOG.md to document the changes

## Breaking Changes

No breaking changes. This is a refactoring that maintains the same functionality.

## Testing Done

RH8.15 on windows.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)