### PR TITLE
fix(component): enable AI Chat component to run regardless of input changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the new AiChat component with interactive chat interface.
 - Added ChatDialog class using Eto.Forms for a modern chat UI experience.
 - Added ChatUtils class with helper methods for AI chat interactions.
+- Added RunOnlyOnInputChanges property to StatefulAsyncComponentBase to control component execution behavior.
+
+### Changed
+
+- Modified AIChatComponent to always run when the Run parameter is true, regardless of input changes.
 
 ## [0.1.1-alpha] - 2025-03-03
 

--- a/src/SmartHopper.Components/AI/AIChatComponent.cs
+++ b/src/SmartHopper.Components/AI/AIChatComponent.cs
@@ -40,6 +40,8 @@ namespace SmartHopper.Components.AI
                 "SmartHopper",
                 "AI")
         {
+            // Set RunOnlyOnInputChanges to false to ensure the component always runs when the Run parameter is true
+            RunOnlyOnInputChanges = false;
         }
 
         /// <summary>

--- a/src/SmartHopper.Core/ComponentBase/StatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/StatefulAsyncComponentBase.cs
@@ -42,6 +42,13 @@ namespace SmartHopper.Core.ComponentBase
     /// </summary>
     public abstract class StatefulAsyncComponentBase : AsyncComponentBase
     {
+        /// <summary>
+        /// Controls whether the component should only run when inputs change.
+        /// If true (default), the component will only run when inputs have changed and Run is true.
+        /// If false, the component will run whenever the Run parameter is set to true,
+        /// regardless of whether inputs have changed.
+        /// </summary>
+        public bool RunOnlyOnInputChanges { get; set; } = true;
 
         #region CONSTRUCTOR
 
@@ -226,7 +233,18 @@ namespace SmartHopper.Core.ComponentBase
                     else if (InputsChanged("Run?", true) && _run)
                     {
                         Debug.WriteLine($"[{GetType().Name}] Only Run parameter changed to true, restarting debounce timer with target state Waiting");
-                        TransitionTo(ComponentState.Waiting, DA);
+                        
+                        if (!RunOnlyOnInputChanges)
+                        {
+                            // Always transition to Processing state regardless of input changes
+                            Debug.WriteLine($"[{GetType().Name}] Component set to always run when Run is true, transitioning to Processing state");
+                            TransitionTo(ComponentState.Processing, DA);
+                        }
+                        else
+                        {
+                            // Default behavior - transition to Waiting state
+                            TransitionTo(ComponentState.Waiting, DA);
+                        }
                     }
                     // If any other input changed, and run is false
                     else if (changedInputs.Any() && !_run)


### PR DESCRIPTION
## Description

This PR fixes an issue with the AI Chat component where it wouldn't open the chat dialog when the Run parameter was set to true but no input values had changed. The component should always run when the Run parameter is set to true, regardless of input changes.

The fix adds a new RunOnlyOnInputChanges property to the StatefulAsyncComponentBase class that controls whether a component should only run when inputs change. This property is set to true by default for most components, but is set to false for the AI Chat component, allowing it to run every time the Run parameter is set to true.

Key changes:

- Added RunOnlyOnInputChanges property to StatefulAsyncComponentBase
- Modified StatefulAsyncComponentBase.SolveInstance to check this property
- Set RunOnlyOnInputChanges = false in the AIChatComponent constructor

## Breaking Changes

No breaking changes. All existing components will maintain their current behavior with the default value of RunOnlyOnInputChanges = true.

## Testing Done

- Verified that the AI Chat component now runs every time the Run parameter is set to true
- Confirmed that other components still only run when their inputs change

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
