### PR TITLE
ci(workflows): update GitHub Actions to latest secure versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
     
@@ -76,7 +76,7 @@ jobs:
         & $ilmerge.FullName /out:"$outputDir/$($mainAssembly.Name)" /targetplatform:"v4" "$($mainAssembly.FullName)" $dependencyList
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: plugin-package
         path: merged/

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3
+      - uses: actions/checkout@v4
 
       - name: Validate Version in Solution.props
         run: |
@@ -33,10 +33,10 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3
+      - uses: actions/checkout@v4
 
       - name: Check CHANGELOG.md is Updated
-        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        uses: tj-actions/changed-files@v46.0.1
         id: changelog-check
         with:
           files: CHANGELOG.md

--- a/.github/workflows/remove-status-labels.yml
+++ b/.github/workflows/remove-status-labels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove status labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,11 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
       
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
+      - uses: micnncim/action-label-syncer@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:

--- a/.github/workflows/update-version-badge.yml
+++ b/.github/workflows/update-version-badge.yml
@@ -15,7 +15,7 @@ jobs:
   update-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
 
+- Updated several github workflows to use the latest version of actions:
+  - Updated tj-actions/changed-files from v45.0 to v46.0.1
+  - Updated actions/checkout to v4 across all workflows
+  - Updated actions/setup-dotnet to v4
+  - Updated actions/upload-artifact to v4
+  - Updated actions/github-script to v7
 
 ## [0.1.1-alpha] - 2025-03-03
 

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>0.1.1-alpha</SolutionVersion>
+    <SolutionVersion>0.1.2-alpha</SolutionVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

This PR updates all GitHub Actions in our workflows to their latest secure versions, addressing a critical security vulnerability in the tj-actions/changed-files action. The security alert warned about a compromised commit in version 45.0 that could potentially expose sensitive information.

The following changes were made:

- Updated tj-actions/changed-files from v45.0 to v46.0.1
- Updated actions/checkout to v4 across all workflows
- Updated actions/setup-dotnet to v4
- Updated actions/upload-artifact to v4
- Updated actions/github-script to v7
- Standardized all action references to use version tags instead of commit hashes

## Breaking Changes

No breaking changes. All updated actions maintain backward compatibility with our existing workflow configurations.

## Testing Done

PR to test the execution of the new actions.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
