### PR TITLE
fix(aichat): several usability improvements in the ai chat dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Message selection and copying capabilities with a context menu.
   - Automatic message height adjustment based on content and removal of visible scrollbars.
   - Improved scrolling behavior.
+  - Allow only one chat dialog to be open per AI Chat Component. When running the component again, if there is a linked chat dialog, it will be focused instead of opening a new one.
 - Enhanced About dialog:
   - Decreased font size.
   - Defined a minimum size.
@@ -91,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes "Bug: AI Chat component freezes all Rhino!" ([#85](https://github.com/architects-toolkit/SmartHopper/issues/85)).
 - Fixes "Bug: Settings Menu is incompatible with Mac" ([#12](https://github.com/architects-toolkit/SmartHopper/issues/12)).
 - Fixes "AI disclaimer in chat and about" ([#114](https://github.com/architects-toolkit/SmartHopper/issues/114)).
+- Fixed a bug opening the chat dialog that eventually froze the application.
+- Fixed a bug where the chat dialog was not on top when clicking on it from the windows taskbar. 
 
 ## [0.1.2-alpha] - 2025-03-17
 

--- a/src/SmartHopper.Components/AI/AIChatComponent.cs
+++ b/src/SmartHopper.Components/AI/AIChatComponent.cs
@@ -161,7 +161,8 @@ namespace SmartHopper.Components.AI
                         actualProvider,
                         _component.GetModel(),
                         _component.GetEndpoint(),
-                        _progressReporter);
+                        _progressReporter,
+                        _component.InstanceGuid); // Pass the component's instance GUID
 
                     // Process the chat
                     await chatWorker.ProcessChatAsync(token);

--- a/src/SmartHopper.Core/AI/Chat/WebChatDialog.cs
+++ b/src/SmartHopper.Core/AI/Chat/WebChatDialog.cs
@@ -177,6 +177,40 @@ namespace SmartHopper.Core.AI.Chat
                     Debug.WriteLine($"[WebChatDialog] Error waiting for WebView initialization: {ex.Message}");
                 }
             });
+
+            // Handle window focus events
+            this.GotFocus += (sender, e) => {
+                Debug.WriteLine("[WebChatDialog] Window got focus");
+                EnsureVisibility();
+            };
+            
+            // Also ensure visibility when the window is shown
+            this.Shown += (sender, e) => {
+                Debug.WriteLine("[WebChatDialog] Window shown");
+                EnsureVisibility();
+            };
+        }
+
+        /// <summary>
+        /// Ensures the dialog is visible and in the foreground using cross-platform methods.
+        /// </summary>
+        public void EnsureVisibility()
+        {
+            Application.Instance.AsyncInvoke(() => {
+                Debug.WriteLine("[WebChatDialog] Ensuring window visibility");
+                
+                // Restore window if minimized
+                if (WindowState == WindowState.Minimized)
+                {
+                    WindowState = WindowState.Normal;
+                }
+                
+                // Use Eto's built-in methods to bring window to front
+                BringToFront();
+                Focus();
+                
+                Debug.WriteLine("[WebChatDialog] Window visibility ensured");
+            });
         }
         
         /// <summary>

--- a/src/SmartHopper.Core/AI/Chat/WebChatUtils.cs
+++ b/src/SmartHopper.Core/AI/Chat/WebChatUtils.cs
@@ -76,9 +76,8 @@ namespace SmartHopper.Core.AI.Chat
                         {
                             Debug.WriteLine("[WebChatUtils] Reusing existing dialog for component");
                             
-                            // Ensure the dialog is visible and active
-                            existingDialog.BringToFront();
-                            existingDialog.Focus();
+                            // Use the cross-platform EnsureVisibility method to make the dialog visible
+                            existingDialog.EnsureVisibility();
                             
                             // Complete the task with null to indicate no new response
                             tcs.TrySetResult(null);


### PR DESCRIPTION
## Description

- [fix(aichat): allow only one open chat dialog per component](https://github.com/architects-toolkit/SmartHopper/pull/117/commits/0da4d6e9b364b1cdea6469b118b98d848d283711)
- [fix(aichat): issue when chat dialog remained hidden behind other rhin…](https://github.com/architects-toolkit/SmartHopper/pull/117/commits/b01f230b7a72fffd686acff2a8f4573e53c202f0)
- [fix(aichat): eventual freezing of all Rhino-related dialogs on init t…](https://github.com/architects-toolkit/SmartHopper/pull/117/commits/8273c6e043b7dc1b38016324e086ac07838cea82)

## Breaking Changes

AI Chat no longer opens multiple dialogs.

## Testing Done

RH8.17 on windows

## Checklist

- [ ] This PR is focused on a single feature or bug fix
- [ ] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [ ] CHANGELOG.md has been updated
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] PR description follows [Pull Request Description Template](#pull-request-description-template)
