### PR TITLE
refactor(aimetrics): rename deconstructmetrics parameters and properly calculate the datacount parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed the 'Branches Input' and 'Processed Branches' parameters to 'Data Count' and 'Iterations Count' in DeconstructMetricsComponents. Improved descriptions for both parameters.
+
 ### Fixed
 
 - Fixed a bug in DataProcessor where results were being duplicated when multiple branches were grouped together to unsuccessfully prevent unnecessary API calls [#32](https://github.com/architects-toolkit/SmartHopper/issues/32)

--- a/src/SmartHopper.Components/List/AIListEvaluate.cs
+++ b/src/SmartHopper.Components/List/AIListEvaluate.cs
@@ -105,10 +105,10 @@ namespace SmartHopper.Components.List
 
                     _result = await DataTreeProcessor.RunFunctionAsync<GH_String, GH_Boolean>(
                         _inputTree,
-                        async branches => 
+                        async (branches, reuseCount) => 
                         {
-                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches");
-                            return await ProcessData(branches, _parent);
+                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches, reuse count: {reuseCount}");
+                            return await ProcessData(branches, _parent, reuseCount);
                         },
                         onlyMatchingPaths: false,
                         groupIdenticalBranches: true,
@@ -122,7 +122,7 @@ namespace SmartHopper.Components.List
                 }
             }
 
-            private static async Task<Dictionary<string, List<GH_Boolean>>> ProcessData(Dictionary<string, List<GH_String>> branches, AIListEvaluate parent)
+            private static async Task<Dictionary<string, List<GH_Boolean>>> ProcessData(Dictionary<string, List<GH_String>> branches, AIListEvaluate parent, int reuseCount = 1)
             {
                 /*
                  * Inputs will be available as a dictionary
@@ -133,7 +133,7 @@ namespace SmartHopper.Components.List
                  * the output values.
                  */
 
-                Debug.WriteLine($"[Worker] Processing {branches.Count} trees");
+                Debug.WriteLine($"[Worker] Processing {branches.Count} trees with reuse count: {reuseCount}");
                 Debug.WriteLine($"[Worker] Items per tree: {branches.Values.Max(branch => branch.Count)}");
 
                 // Get the trees
@@ -169,7 +169,7 @@ namespace SmartHopper.Components.List
                     var evaluationResult = await ListTools.EvaluateListAsync(
                         currentList.Value,
                         question,
-                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time"));
+                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time", reuseCount: reuseCount));
 
                     if (!evaluationResult.Success)
                     {

--- a/src/SmartHopper.Components/List/AIListFilter.cs
+++ b/src/SmartHopper.Components/List/AIListFilter.cs
@@ -106,10 +106,10 @@ namespace SmartHopper.Components.List
 
                     _result = await DataTreeProcessor.RunFunctionAsync<GH_String, GH_String>(
                         _inputTree,
-                        async branches => 
+                        async (branches, reuseCount) => 
                         {
-                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches");
-                            return await ProcessData(branches, _parent);
+                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches, reuse count: {reuseCount}");
+                            return await ProcessData(branches, _parent, reuseCount);
                         },
                         onlyMatchingPaths: false,
                         groupIdenticalBranches: true,
@@ -123,7 +123,7 @@ namespace SmartHopper.Components.List
                 }
             }
 
-            private static async Task<Dictionary<string, List<GH_String>>> ProcessData(Dictionary<string, List<GH_String>> branches, AIListFilter parent)
+            private static async Task<Dictionary<string, List<GH_String>>> ProcessData(Dictionary<string, List<GH_String>> branches, AIListFilter parent, int reuseCount = 1)
             {
                 /*
                  * Inputs will be available as a dictionary
@@ -134,7 +134,7 @@ namespace SmartHopper.Components.List
                  * the output values.
                  */
 
-                Debug.WriteLine($"[Worker] Processing {branches.Count} trees");
+                Debug.WriteLine($"[Worker] Processing {branches.Count} trees with reuse count: {reuseCount}");
                 Debug.WriteLine($"[Worker] Items per tree: {branches.Values.Max(branch => branch.Count)}");
 
                 // Get the trees
@@ -168,7 +168,7 @@ namespace SmartHopper.Components.List
                     var filterResult = await ListTools.FilterListAsync(
                         listTreeOriginal,
                         criterion,
-                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time"));
+                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time", reuseCount: reuseCount));
 
                     if (!filterResult.Success)
                     {

--- a/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
+++ b/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
@@ -38,8 +38,8 @@ namespace SmartHopper.Components.Misc
             pManager.AddIntegerParameter("Output Tokens", "O", "Number of output tokens", GH_ParamAccess.item);
             pManager.AddTextParameter("Finish Reason", "F", "Reason for finishing", GH_ParamAccess.item);
             pManager.AddNumberParameter("Completion Time", "T", "Time taken for completion, in seconds", GH_ParamAccess.item);
-            pManager.AddIntegerParameter("Input Items", "II", "Number of input items to process", GH_ParamAccess.item);
-            pManager.AddIntegerParameter("Processed Items", "PI", "Number of final processed items. This value can differ from input items when the component detects that there are identical item combinations.", GH_ParamAccess.item);
+            pManager.AddIntegerParameter("Data Count", "DC", "The number of data items that were processed by the component. This may not match the total number of items in your input lists. If the component is configured to process data in batches, this value indicates how many batches (or groups) of results the component needs to process.", GH_ParamAccess.item);
+            pManager.AddIntegerParameter("Iterations Count", "IC", "The number of times the component ran its calculation. If the component was set to recognize and group identical combinations of input items, it only processed each unique combination once and applied the results to all matching outputs. As a result, the iteration count may be less than the total data count.", GH_ParamAccess.item);
 
         }
 
@@ -58,8 +58,8 @@ namespace SmartHopper.Components.Misc
                 int outputTokens = metricsObject["tokens_output"]?.Value<int>() ?? 0;
                 string finishReason = metricsObject["finish_reason"]?.Value<string>() ?? "Unknown";
                 double completionTime = metricsObject["completion_time"]?.Value<double>() ?? 0.0;
-                int branchesInput = metricsObject["branches_input"]?.Value<int>() ?? 0;
-                int branchesProcessed = metricsObject["branches_processed"]?.Value<int>() ?? 0;
+                int inputDataCount = metricsObject["data_count"]?.Value<int>() ?? 0;
+                int iterationsCount = metricsObject["iterations_count"]?.Value<int>() ?? 0;
 
 
                 // Checks to see if the values were actually present
@@ -89,9 +89,9 @@ namespace SmartHopper.Components.Misc
                 DA.SetData(5, completionTime);
                 if (!hasCompletionTime) AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Completion time not found in JSON");
 
-                DA.SetData(6, branchesInput);
+                DA.SetData(6, inputDataCount);
 
-                DA.SetData(7, branchesProcessed);
+                DA.SetData(7, iterationsCount);
             }
             catch (Exception ex)
             {

--- a/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
+++ b/src/SmartHopper.Components/Misc/DeconstructMetricsComponents.cs
@@ -38,8 +38,8 @@ namespace SmartHopper.Components.Misc
             pManager.AddIntegerParameter("Output Tokens", "O", "Number of output tokens", GH_ParamAccess.item);
             pManager.AddTextParameter("Finish Reason", "F", "Reason for finishing", GH_ParamAccess.item);
             pManager.AddNumberParameter("Completion Time", "T", "Time taken for completion, in seconds", GH_ParamAccess.item);
-            pManager.AddIntegerParameter("Input Branches", "BI", "Number of input branches", GH_ParamAccess.item);
-            pManager.AddIntegerParameter("Processed Branches", "BP", "Number of processed branches. This value can differ from input branches when the component detects that there are identical branch combinations.", GH_ParamAccess.item);
+            pManager.AddIntegerParameter("Input Items", "II", "Number of input items to process", GH_ParamAccess.item);
+            pManager.AddIntegerParameter("Processed Items", "PI", "Number of final processed items. This value can differ from input items when the component detects that there are identical item combinations.", GH_ParamAccess.item);
 
         }
 

--- a/src/SmartHopper.Components/Text/AITextEvaluate.cs
+++ b/src/SmartHopper.Components/Text/AITextEvaluate.cs
@@ -103,10 +103,10 @@ namespace SmartHopper.Components.Text
 
                     _result = await DataTreeProcessor.RunFunctionAsync<GH_String, GH_Boolean>(
                         _inputTree,
-                        async branches => 
+                        async (branches, reuseCount) => 
                         {
-                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches");
-                            return await ProcessData(branches, _parent);
+                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches, reuse count: {reuseCount}");
+                            return await ProcessData(branches, _parent, reuseCount);
                         },
                         onlyMatchingPaths: false,
                         groupIdenticalBranches: true,
@@ -120,7 +120,7 @@ namespace SmartHopper.Components.Text
                 }
             }
 
-            private static async Task<Dictionary<string, List<GH_Boolean>>> ProcessData(Dictionary<string, List<GH_String>> branches, AITextEvaluate parent)
+            private static async Task<Dictionary<string, List<GH_Boolean>>> ProcessData(Dictionary<string, List<GH_String>> branches, AITextEvaluate parent, int reuseCount = 1)
             {
                 /*
                  * Inputs will be available as a dictionary
@@ -131,7 +131,7 @@ namespace SmartHopper.Components.Text
                  * the output values.
                  */
 
-                Debug.WriteLine($"[Worker] Processing {branches.Count} trees");
+                Debug.WriteLine($"[Worker] Processing {branches.Count} trees with reuse count: {reuseCount}");
                 Debug.WriteLine($"[Worker] Items per tree: {branches.Values.Max(branch => branch.Count)}");
 
                 // Get the trees
@@ -158,9 +158,9 @@ namespace SmartHopper.Components.Text
                 {
                     Debug.WriteLine($"[ProcessData] Processing text {i + 1}/{textTree.Count}");
 
-                    // Evaluate text using AI with the component's GetResponse
+                    // Evaluate text using AI with the component's GetResponse, passing the reuseCount
                     var result = await TextTools.EvaluateTextAsync(textTree[i], questionTree[i], 
-                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time"));
+                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time", reuseCount: reuseCount));
 
                     if (!result.Success)
                     {

--- a/src/SmartHopper.Components/Text/AITextGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerate.cs
@@ -102,10 +102,10 @@ namespace SmartHopper.Components.Text
 
                     _result = await DataTreeProcessor.RunFunctionAsync<GH_String, GH_String>(
                         _inputTree,
-                        async branches => 
+                        async (branches, reuseCount) => 
                         {
-                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} trees");
-                            return await ProcessData(branches, _parent);
+                            Debug.WriteLine($"[Worker] ProcessData called with {branches.Count} branches, reuse count: {reuseCount}");
+                            return await ProcessData(branches, _parent, reuseCount);
                         },
                         onlyMatchingPaths: false,
                         groupIdenticalBranches: true,
@@ -119,7 +119,7 @@ namespace SmartHopper.Components.Text
                 }
             }
 
-            private static async Task<Dictionary<string, List<GH_String>>> ProcessData(Dictionary<string, List<GH_String>> branches, AITextGenerate parent)
+            private static async Task<Dictionary<string, List<GH_String>>> ProcessData(Dictionary<string, List<GH_String>> branches, AITextGenerate parent, int reuseCount = 1)
             {
                 /*
                  * Inputs will be available as a dictionary
@@ -130,7 +130,7 @@ namespace SmartHopper.Components.Text
                  * the output values.
                  */
 
-                Debug.WriteLine($"[Worker] Processing {branches.Count} trees");
+                Debug.WriteLine($"[Worker] Processing {branches.Count} trees with reuse count: {reuseCount}");
                 Debug.WriteLine($"[Worker] Items per tree: {branches.Values.Max(branch => branch.Count)}");
 
                 // Get the trees
@@ -159,7 +159,10 @@ namespace SmartHopper.Components.Text
 
                     // Use the new generic tool to generate text
                     var result = await TextTools.GenerateTextAsync(promptTree[i], instructionsTree[i], 
-                        messages => parent.GetResponse(messages, contextProviderFilter: "-environment,-time"));
+                        messages => parent.GetResponse(messages, 
+                            contextProviderFilter: "-environment,-time",
+                            contextKeyFilter: "-environment,-time",
+                            reuseCount: reuseCount));
 
                     if (!result.Success)
                     {

--- a/src/SmartHopper.Config/Models/AIResponse.cs
+++ b/src/SmartHopper.Config/Models/AIResponse.cs
@@ -21,5 +21,11 @@ namespace SmartHopper.Config.Models
         public string ToolArguments { get; set; }
         public string Provider { get; set; }
         public string Model { get; set; }
+        
+        /// <summary>
+        /// Tracks how many times this response is reused across different data tree branches.
+        /// Default is 1 (used once).
+        /// </summary>
+        public int ReuseCount { get; set; } = 1;
     }
 }

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
@@ -378,8 +378,8 @@ namespace SmartHopper.Core.ComponentBase
                 new JProperty("tokens_output", totalOutTokens),
                 new JProperty("finish_reason", finishReason),
                 new JProperty("completion_time", totalCompletionTime),
-                new JProperty("branches_input", _responseMetrics.Sum(r => r.ReuseCount)),
-                new JProperty("branches_processed", _responseMetrics.Count)
+                new JProperty("data_count", _responseMetrics.Sum(r => r.ReuseCount)),
+                new JProperty("iterations_count", _responseMetrics.Count)
             );
 
             // Convert metricsJson to GH_String

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
@@ -247,11 +247,13 @@ namespace SmartHopper.Core.ComponentBase
         /// <param name="messages">The messages to send to the AI provider.</param>
         /// <param name="contextProviderFilter">Optional filter for context providers (comma-separated list).</param>
         /// <param name="contextKeyFilter">Optional filter for context keys (comma-separated list).</param>
+        /// <param name="reuseCount">Optional. The number of times this response will be reused across different branches. Default is 1.</param>
         /// <returns>The AI response from the provider.</returns>
         protected async Task<AIResponse> GetResponse(
             List<KeyValuePair<string, string>> messages, 
             string contextProviderFilter = null, 
-            string contextKeyFilter = null)
+            string contextKeyFilter = null,
+            int reuseCount = 1)
         {
             try
             {
@@ -274,7 +276,8 @@ namespace SmartHopper.Core.ComponentBase
                     contextProviderFilter: contextProviderFilter,
                     contextKeyFilter: contextKeyFilter);
 
-                StoreResponseMetrics(response);
+                // Store response metrics with the provided reuse count
+                StoreResponseMetrics(response, reuseCount);
 
                 return response;
             }
@@ -327,13 +330,17 @@ namespace SmartHopper.Core.ComponentBase
         /// Stores the given AI response metrics in the component's internal metrics list.
         /// </summary>
         /// <param name="response">The AI response to store metrics from.</param>
-        public void StoreResponseMetrics(AIResponse response)
+        /// <param name="reuseCount">Optional. The number of times this response is reused across different branches. Default is 1.</param>
+        public void StoreResponseMetrics(AIResponse response, int reuseCount = 1)
         {
             if (response != null)
             {
+                // Set the reuse count on the response
+                response.ReuseCount = reuseCount;
+                
                 _responseMetrics.Add(response);
 
-                Debug.WriteLine("[AIStatefulAsyncComponentBase] [StoreResponseMetrics] Added response to metrics list");
+                Debug.WriteLine($"[AIStatefulAsyncComponentBase] [StoreResponseMetrics] Added response to metrics list with reuse count: {reuseCount}");
             }
         }
 
@@ -371,7 +378,7 @@ namespace SmartHopper.Core.ComponentBase
                 new JProperty("tokens_output", totalOutTokens),
                 new JProperty("finish_reason", finishReason),
                 new JProperty("completion_time", totalCompletionTime),
-                new JProperty("branches_input", 0),
+                new JProperty("branches_input", _responseMetrics.Sum(r => r.ReuseCount)),
                 new JProperty("branches_processed", _responseMetrics.Count)
             );
 

--- a/src/SmartHopper.Core/DataTree/DataTreeProcessor.cs
+++ b/src/SmartHopper.Core/DataTree/DataTreeProcessor.cs
@@ -359,7 +359,7 @@ namespace SmartHopper.Core.DataTree
 
         public static async Task<Dictionary<string, GH_Structure<U>>> RunFunctionAsync<T, U>(
             Dictionary<string, GH_Structure<T>> trees,
-            Func<Dictionary<string, List<T>>, Task<Dictionary<string, List<U>>>> function,
+            Func<Dictionary<string, List<T>>, int, Task<Dictionary<string, List<U>>>> function,
             bool onlyMatchingPaths = false,
             bool groupIdenticalBranches = false,
             CancellationToken token = default)
@@ -412,12 +412,16 @@ namespace SmartHopper.Core.DataTree
                 
                 try 
                 {
-                    // Apply the function to the current branch and await its completion
-                    var branchResult = await function(branches);
-                    
                     // Get the paths to apply the result to (could be multiple if they have identical branch data)
                     var pathsToApply = pathsToApplyMap[path];
-
+                    
+                    // Calculate the reuse count as the number of paths this result will be applied to
+                    int reuseCount = pathsToApply.Count;
+                    Debug.WriteLine($"[DataTreeProcessor] Result for path {path} will be reused {reuseCount} times");
+                    
+                    // Apply the function to the current branch and await its completion, passing the reuse count
+                    var branchResult = await function(branches, reuseCount);
+                    
                     // For each path in pathsToApply, convert the branch result to a GH_Structure<T> with the appropriate paths
                     foreach (var applyPath in pathsToApply)
                     {


### PR DESCRIPTION
## Description

This PR refactors the DeconstructMetrics components by renaming parameters and updating related usages to improve clarity regarding how branch data is processed.

- Updated the function signature of RunFunctionAsync to include a reuse count parameter for improved metric tracking.
- Renamed output parameters in DeconstructMetricsComponents from "Branches Input" and "Processed Branches" to "Data Count" and "Iterations Count" and updated their descriptions.
- Propagated the reuseCount parameter through supporting components and their logging, ensuring consistent behavior.

## Breaking Changes

Output names changed. Might not be compatible with previous saved versions of the DeconstructMetrics component.

## Testing Done

RH8.17 on windows.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
