### PR TITLE
feat(tools): add ghtogglepreview AI tool for toggling component preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConnectionGraphUtils` class in `SmartHopper.Core.Graph` namespace with method `ExpandByDepth` to expand a set of component IDs by following connections up to the given depth.
 - Added `GhRetrieveComponents` component and `ghretrievecomponents` AI tool for listing Grasshopper component types with descriptions, keywords, category filters, and list of inputs and outputs.
 - Added `ghcategories` AI tool in `GhTools` to list Grasshopper component categories and subcategories with optional soft string filter.
+- Added new `ghtogglepreview` AI tool in `GhVisTools` for toggling Grasshopper component preview by GUID.
 
 ### Changed
 
@@ -33,9 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug in `DataProcessor` where results were being duplicated when multiple branches were grouped together to unsuccessfully prevent unnecessary API calls [#32](https://github.com/architects-toolkit/SmartHopper/issues/32)
 - Fixed inconsistent list format handling between `AIListEvaluate` and `AIListFilter` components.
-
-### Fixed
-- Fixes "Bug: Unmatching paths in list components return duplicated values" ([#32](https://github.com/architects-toolkit/SmartHopper/issues/32)).
 
 ## [0.2.0-alpha] - 2025-04-06
 

--- a/src/SmartHopper.Core.Grasshopper/Tools/GhTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/GhTools.cs
@@ -364,7 +364,7 @@ namespace SmartHopper.Core.Grasshopper.Tools
             var distinct = resultObjects.Distinct().ToList();
             var document = GHDocumentUtils.GetObjectsDetails(distinct);
             var names = document.Components.Select(c => c.Name).Distinct().ToList();
-            var guids = document.Components.Select(c => c.ComponentGuid.ToString()).Distinct().ToList();
+            var guids = document.Components.Select(c => c.InstanceGuid.ToString()).Distinct().ToList();
             var json = JsonConvert.SerializeObject(document, Formatting.None);
 
             // Package result with classifications

--- a/src/SmartHopper.Core.Grasshopper/Tools/GhVisTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/GhVisTools.cs
@@ -1,0 +1,84 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2025 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using SmartHopper.Config.Interfaces;
+using SmartHopper.Config.Models;
+using SmartHopper.Core.Grasshopper.Utils;
+
+namespace SmartHopper.Core.Grasshopper.Tools
+{
+    /// <summary>
+    /// Tool provider for toggling Grasshopper component preview by GUID.
+    /// </summary>
+    public class GhVisTools : IAIToolProvider
+    {
+        #region ToolRegistration
+        /// <summary>
+        /// Returns AI tools for component visibility control.
+        /// </summary>
+        public IEnumerable<AITool> GetTools()
+        {
+            yield return new AITool(
+                name: "ghtogglepreview",
+                description: "Toggle Grasshopper component preview on or off by GUID.",
+                parametersSchema: @"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""guids"": {
+                            ""type"": ""array"",
+                            ""items"": { ""type"": ""string"" },
+                            ""description"": ""List of component GUIDs to toggle preview.""
+                        },
+                        ""previewOn"": {
+                            ""type"": ""boolean"",
+                            ""description"": ""True to enable preview, false to disable preview.""
+                        }
+                    },
+                    ""required"": [ ""guids"", ""previewOn"" ]
+                }",
+                execute: this.ExecuteTogglePreviewAsync
+            );
+        }
+        #endregion
+
+        #region Preview
+        private async Task<object> ExecuteTogglePreviewAsync(JObject parameters)
+        {
+            var guids = parameters["guids"]?.ToObject<List<string>>() ?? new List<string>();
+            var previewOn = parameters["previewOn"]?.ToObject<bool>() ?? false;
+            Debug.WriteLine($"[GhVisTools] ExecuteTogglePreviewAsync: previewOn={previewOn}, guids count={guids.Count}");
+            var updated = new List<string>();
+
+            foreach (var s in guids)
+            {
+                Debug.WriteLine($"[GhVisTools] Processing GUID string: {s}");
+                if (Guid.TryParse(s, out var guid))
+                {
+                    Debug.WriteLine($"[GhVisTools] Parsed GUID: {guid}");
+                    GHComponentUtils.SetComponentPreview(guid, previewOn);
+                    Debug.WriteLine($"[GhVisTools] Set preview to {previewOn} for GUID: {guid}");
+                    updated.Add(guid.ToString());
+                }
+                else
+                {
+                    Debug.WriteLine($"[GhVisTools] Invalid GUID: {s}");
+                }
+            }
+
+            return new { success = true, updated };
+        }
+        #endregion
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/GHCanvasUtils.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/GHCanvasUtils.cs
@@ -13,6 +13,7 @@ using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace SmartHopper.Core.Grasshopper.Utils
 {
@@ -50,9 +51,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
 
         public static IGH_DocumentObject FindInstance(Guid guid)
         {
-            GH_Document doc = GetCurrentCanvas();
-
-            IGH_DocumentObject obj = doc.FindObject(guid, true);
+            IGH_DocumentObject obj = GetCurrentObjects().FirstOrDefault(o => o.InstanceGuid == guid);
 
             if (obj is IGH_Component)
             {
@@ -89,4 +88,3 @@ namespace SmartHopper.Core.Grasshopper.Utils
         }
     }
 }
-

--- a/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
@@ -1,0 +1,71 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2025 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Diagnostics;
+using Grasshopper;
+using Grasshopper.Kernel;
+
+namespace SmartHopper.Core.Grasshopper.Utils
+{
+    /// <summary>
+    /// Utilities for manipulating Grasshopper component preview state.
+    /// </summary>
+    public static class GHComponentUtils
+    {
+        /// <summary>
+        /// Set preview state of a Grasshopper component by GUID.
+        /// </summary>
+        /// <param name="guid">GUID of the component</param>
+        /// <param name="previewOn">True to show preview, false to hide</param>
+        /// <param name="redraw">True to redraw canvas immediately</param>
+        public static void SetComponentPreview(Guid guid, bool previewOn, bool redraw = true)
+        {
+            Debug.WriteLine($"[GHComponentUtils] SetComponentPreview: guid={guid}, previewOn={previewOn}");
+            var obj = GHCanvasUtils.FindInstance(guid);
+            Debug.WriteLine(obj != null
+                ? $"[GHComponentUtils] Found object of type {obj.GetType().Name}" 
+                : "[GHComponentUtils] Found null object");
+            if (obj is GH_Component component)
+            {
+                Debug.WriteLine($"[GHComponentUtils] Component.IsPreviewCapable={component.IsPreviewCapable}, Hidden={component.Hidden}");
+                if (component.IsPreviewCapable)
+                {
+                    component.Hidden = !previewOn;
+                    Debug.WriteLine($"[GHComponentUtils] New Hidden={component.Hidden}");
+                    if (redraw)
+                    {
+                        Instances.RedrawCanvas();
+                        Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine("[GHComponentUtils] Component is not preview capable");
+                }
+            }
+            //else if (obj is IGH_DocumentObject docObj)
+            //{
+            //    Debug.WriteLine($"[GHComponentUtils] GH_DocumentObject.Hidden={docObj.Hidden}");
+            //    docObj.Hidden = !previewOn;
+            //    Debug.WriteLine($"[GHComponentUtils] New Hidden={docObj.Hidden}");
+            //    if (redraw)
+            //    {
+            //        Instances.RedrawCanvas();
+            //        Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
+            //    }
+            //}
+            else
+            {
+                Debug.WriteLine("[GHComponentUtils] Object is not previewable (not a GH_DocumentObject)");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Introduces a new `ghtogglepreview` tool in `GhVisTools` allowing users to programmatically turn Grasshopper component preview on or off by GUID. Utilizes `GHCanvasUtils.FindInstance` and `GHComponentUtils.SetComponentPreview` with debug logging for tracing.

## Breaking Changes

None.

## Testing Done

- Manually invoked `ghtogglepreview` via AIChatComponent with valid component GUIDs.
- Verified preview state toggles and canvas redraw occurs without errors.
- Checked debug output to confirm object lookup and state changes.

## Checklist

- [ ] This PR is focused on a single feature or bug fix
- [ ] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [ ] CHANGELOG.md has been updated
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] PR description follows [Pull Request Description Template](#pull-request-description-template)
