### PR TITLE
feat(tools): new ghtooglelocked ai tool to toogle locked (enabled/disabled) of components in canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConnectionGraphUtils` class in `SmartHopper.Core.Graph` namespace with method `ExpandByDepth` to expand a set of component IDs by following connections up to the given depth.
 - Added `GhRetrieveComponents` component and `ghretrievecomponents` AI tool for listing Grasshopper component types with descriptions, keywords, category filters, and list of inputs and outputs.
 - Added `ghcategories` AI tool in `GhTools` to list Grasshopper component categories and subcategories with optional soft string filter.
-- Added new `ghtogglepreview` AI tool in `GhVisTools` for toggling Grasshopper component preview by GUID.
+- Added new `ghtogglepreview` AI tool in `GhObjTools` for toggling Grasshopper component preview by GUID.
+- Added new `ghtogglelock` AI tool in `GhObjTools` for toggling Grasshopper component lock state by GUID.
 
 ### Changed
 

--- a/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
@@ -22,7 +22,7 @@ namespace SmartHopper.Core.Grasshopper.Tools
     /// <summary>
     /// Tool provider for toggling Grasshopper component preview by GUID.
     /// </summary>
-    public class GhVisTools : IAIToolProvider
+    public class GhObjTools : IAIToolProvider
     {
         #region ToolRegistration
         /// <summary>
@@ -50,6 +50,28 @@ namespace SmartHopper.Core.Grasshopper.Tools
                 }",
                 execute: this.ExecuteTogglePreviewAsync
             );
+
+            // New tool to toggle component locked state
+            yield return new AITool(
+                name: "ghtogglelock",
+                description: "Toggle Grasshopper component locked state (enable/disable) by GUID.",
+                parametersSchema: @"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""guids"": {
+                            ""type"": ""array"",
+                            ""items"": { ""type"": ""string"" },
+                            ""description"": ""List of component GUIDs to toggle lock state.""
+                        },
+                        ""locked"": {
+                            ""type"": ""boolean"",
+                            ""description"": ""True to lock (disable), false to unlock (enable) the component.""
+                        }
+                    },
+                    ""required"": [ ""guids"", ""locked"" ]
+                }",
+                execute: this.ExecuteToggleLockAsync
+            );
         }
         #endregion
 
@@ -58,22 +80,50 @@ namespace SmartHopper.Core.Grasshopper.Tools
         {
             var guids = parameters["guids"]?.ToObject<List<string>>() ?? new List<string>();
             var previewOn = parameters["previewOn"]?.ToObject<bool>() ?? false;
-            Debug.WriteLine($"[GhVisTools] ExecuteTogglePreviewAsync: previewOn={previewOn}, guids count={guids.Count}");
+            Debug.WriteLine($"[GhObjTools] ExecuteTogglePreviewAsync: previewOn={previewOn}, guids count={guids.Count}");
             var updated = new List<string>();
 
             foreach (var s in guids)
             {
-                Debug.WriteLine($"[GhVisTools] Processing GUID string: {s}");
+                Debug.WriteLine($"[GhObjTools] Processing GUID string: {s}");
                 if (Guid.TryParse(s, out var guid))
                 {
-                    Debug.WriteLine($"[GhVisTools] Parsed GUID: {guid}");
+                    Debug.WriteLine($"[GhObjTools] Parsed GUID: {guid}");
                     GHComponentUtils.SetComponentPreview(guid, previewOn);
-                    Debug.WriteLine($"[GhVisTools] Set preview to {previewOn} for GUID: {guid}");
+                    Debug.WriteLine($"[GhObjTools] Set preview to {previewOn} for GUID: {guid}");
                     updated.Add(guid.ToString());
                 }
                 else
                 {
-                    Debug.WriteLine($"[GhVisTools] Invalid GUID: {s}");
+                    Debug.WriteLine($"[GhObjTools] Invalid GUID: {s}");
+                }
+            }
+
+            return new { success = true, updated };
+        }
+        #endregion
+
+        #region Lock
+        private async Task<object> ExecuteToggleLockAsync(JObject parameters)
+        {
+            var guids = parameters["guids"]?.ToObject<List<string>>() ?? new List<string>();
+            var locked = parameters["locked"]?.ToObject<bool>() ?? false;
+            Debug.WriteLine($"[GhObjTools] ExecuteToggleLockAsync: locked={locked}, guids count={guids.Count}");
+            var updated = new List<string>();
+
+            foreach (var s in guids)
+            {
+                Debug.WriteLine($"[GhObjTools] Processing GUID string: {s}");
+                if (Guid.TryParse(s, out var guid))
+                {
+                    Debug.WriteLine($"[GhObjTools] Parsed GUID: {guid}");
+                    GHComponentUtils.SetComponentLock(guid, locked);
+                    Debug.WriteLine($"[GhObjTools] Set lock to {locked} for GUID: {guid}");
+                    updated.Add(guid.ToString());
+                }
+                else
+                {
+                    Debug.WriteLine($"[GhObjTools] Invalid GUID: {s}");
                 }
             }
 

--- a/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
@@ -51,20 +51,61 @@ namespace SmartHopper.Core.Grasshopper.Utils
                     Debug.WriteLine("[GHComponentUtils] Component is not preview capable");
                 }
             }
-            //else if (obj is IGH_DocumentObject docObj)
-            //{
-            //    Debug.WriteLine($"[GHComponentUtils] GH_DocumentObject.Hidden={docObj.Hidden}");
-            //    docObj.Hidden = !previewOn;
-            //    Debug.WriteLine($"[GHComponentUtils] New Hidden={docObj.Hidden}");
-            //    if (redraw)
-            //    {
-            //        Instances.RedrawCanvas();
-            //        Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
-            //    }
-            //}
+            else if (obj is IGH_Param param)
+            {
+                Debug.WriteLine($"[GHComponentUtils] IGH_Param.Hidden={param.Hidden}");
+                param.Hidden = !previewOn;
+                Debug.WriteLine($"[GHComponentUtils] New Hidden={param.Hidden}");
+                if (redraw)
+                {
+                    Instances.RedrawCanvas();
+                    Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
+                }
+            }
             else
             {
                 Debug.WriteLine("[GHComponentUtils] Object is not previewable (not a GH_DocumentObject)");
+            }
+        }
+
+        /// <summary>
+        /// Set lock state of a Grasshopper component by GUID.
+        /// </summary>
+        /// <param name="guid">GUID of the component</param>
+        /// <param name="locked">True to lock (disable), false to unlock (enable)</param>
+        /// <param name="redraw">True to redraw canvas immediately</param>
+        public static void SetComponentLock(Guid guid, bool locked, bool redraw = true)
+        {
+            Debug.WriteLine($"[GHComponentUtils] SetComponentLock: guid={guid}, locked={locked}");
+            var obj = GHCanvasUtils.FindInstance(guid);
+            Debug.WriteLine(obj != null
+                ? $"[GHComponentUtils] Found object of type {obj.GetType().Name}" 
+                : "[GHComponentUtils] Found null object");
+            if (obj is GH_Component component)
+            {
+                Debug.WriteLine($"[GHComponentUtils] Component.Locked={component.Locked}");
+                component.Locked = locked;
+                Debug.WriteLine($"[GHComponentUtils] New Locked={component.Locked}");
+                if (redraw)
+                {
+                    Instances.RedrawCanvas();
+                    Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
+                }
+            }
+            else if (obj is IGH_Param param)
+            {
+                Debug.WriteLine($"[GHComponentUtils] IGH_Param.Locked={param.Locked}");
+                param.Locked = locked;
+                Debug.WriteLine($"[GHComponentUtils] New Locked={param.Locked}");
+                if (redraw)
+                {
+                    Instances.RedrawCanvas();
+                    Debug.WriteLine("[GHComponentUtils] Canvas redrawn");
+                }
+            }
+            else
+            {
+                Debug.WriteLine("[GHComponentUtils] Object is neither a GH_Component nor a GH_Param");
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
@@ -51,11 +51,11 @@ namespace SmartHopper.Core.Grasshopper.Utils
                     Debug.WriteLine("[GHComponentUtils] Component is not preview capable");
                 }
             }
-            else if (obj is IGH_Param param)
+            else if (obj is IGH_PreviewObject preview)
             {
-                Debug.WriteLine($"[GHComponentUtils] IGH_Param.Hidden={param.Hidden}");
-                param.Hidden = !previewOn;
-                Debug.WriteLine($"[GHComponentUtils] New Hidden={param.Hidden}");
+                Debug.WriteLine($"[GHComponentUtils] IGH_PreviewObject.Hidden={preview.Hidden}");
+                preview.Hidden = !previewOn;
+                Debug.WriteLine($"[GHComponentUtils] New Hidden={preview.Hidden}");
                 if (redraw)
                 {
                     Instances.RedrawCanvas();


### PR DESCRIPTION
## Description

Introduces a new `ghtogglelocked` tool in `GhObjTools` allowing users to programmatically turn Grasshopper component on or off by GUID (enabling and disabling(. Utilizes `GHCanvasUtils.FindInstance` and `GHComponentUtils.SetComponentLock` with debug logging for tracing.

## Breaking Changes

None

## Testing Done

Tried in RH8.18 on windows, with the AiChat interface.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
