### PR TITLE
feat(undo): undo support for move preview and lock setters

### DIFF
--- a/.windsurf/rules/grasshopper-undo.md
+++ b/.windsurf/rules/grasshopper-undo.md
@@ -13,11 +13,16 @@ Ensure that any code which mutates Grasshopper canvas objects (moving, adding, d
   ```csharp
   obj.RecordUndoEvent("[SH] <Action Description>");
   ```
-- For batch or multi-step operations, use the document’s undo util:
+- For batch or multi-step operations, create and commit a `GH_UndoRecord`:
   ```csharp
-  var undo = document.UndoUtil.CreateGenericObjectEvent("[SH] Batch Action");
+  using Grasshopper.Kernel.Undo;
+
+  var record = new GH_UndoRecord("[SH] Batch Action");
   // for each object change:
-  obj.RecordUndoEvent(undo);
+  obj.RecordUndoEvent(record);
+  // after all changes:
+  doc.UndoUtil.RecordEvent(record);
+  ```
 
 ## Examples
 - MoveInstance

--- a/.windsurf/rules/grasshopper-undo.md
+++ b/.windsurf/rules/grasshopper-undo.md
@@ -1,0 +1,37 @@
+---
+trigger: model_decision
+description: Registering undo events so that the user can later ctrl+z an action. Check this rule when writing code that makes changes to the canvas (adding, moving, changing, or deleting components or connections)
+---
+
+# Grasshopper Undo Rule
+
+## Purpose
+Ensure that any code which mutates Grasshopper canvas objects (moving, adding, deleting, wiring, etc.) records an undo event so users can undo with Ctrl+Z.
+
+## Rule
+- **Before** mutating any `IGH_DocumentObject` (e.g. setting `Attributes.Pivot`, adding/removing objects, changing wires), insert:
+  ```csharp
+  obj.RecordUndoEvent("[SH] <Action Description>");
+  ```
+- For batch or multi-step operations, use the document’s undo util:
+  ```csharp
+  var undo = document.UndoUtil.CreateGenericObjectEvent("[SH] Batch Action");
+  // for each object change:
+  obj.RecordUndoEvent(undo);
+
+## Examples
+- MoveInstance
+  ```diff
+  - var current = obj.Attributes.Pivot;
+  + obj.RecordUndoEvent("[SH] Move Instance");
+  + var current = obj.Attributes.Pivot;
+  ```
+- AddObjectToCanvas
+  ```diff
+  - doc.AddObject(obj, false);
+  + obj.RecordUndoEvent("[SH] Add Object");
+  + doc.AddObject(obj, false);
+  ```
+
+## Enforcement
+Code reviews or static analysis should flag any GH canvas mutations missing a preceding RecordUndoEvent or undo-util usage.

--- a/.windsurf/rules/windsurf-rules.md
+++ b/.windsurf/rules/windsurf-rules.md
@@ -1,0 +1,6 @@
+---
+trigger: model_decision
+description: When generating windsurf rules
+---
+
+Windsurf rules cannot be automatically written. Return them in the chat, wrapping content in a codeblock. Escape the ` character.

--- a/.windsurf/rules/windsurf-rules.md
+++ b/.windsurf/rules/windsurf-rules.md
@@ -1,6 +1,6 @@
 ---
 trigger: model_decision
-description: When generating windsurf rules
+description: When generating windsurf rules, stored in .windsurf/rules
 ---
 
 Windsurf rules cannot be automatically written. Return them in the chat, wrapping content in a codeblock. Escape the ` character.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added undo support to `MoveInstance`.
+
 ## [0.3.1-alpha] - 2025-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added undo support to `MoveInstance`.
+- Added undo support to `MoveInstance`, `SetComponentPreview`, and `SetComponentLock`.
 
 ## [0.3.1-alpha] - 2025-05-06
 

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>0.3.1-alpha</SolutionVersion>
+    <SolutionVersion>0.3.2-dev.250512</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
@@ -20,6 +20,7 @@ using SmartHopper.Core.Grasshopper.Utils;
 using SmartHopper.Core.Models.Document;
 using System.Linq;
 using SmartHopper.Core.Grasshopper.Graph;
+using Grasshopper.Kernel;
 
 namespace SmartHopper.Core.Grasshopper.Tools
 {
@@ -82,30 +83,32 @@ namespace SmartHopper.Core.Grasshopper.Tools
             // New tool to move component pivot position
             yield return new AITool(
                 name: "gh_move_obj",
-                description: "Move Grasshopper component pivot by GUID, with absolute or relative position.",
+                description: "Move Grasshopper components by GUID with specific targets and optional relative offset.",
                 parametersSchema: @"{
                     ""type"": ""object"",
                     ""properties"": {
-                        ""guids"": {
-                            ""type"": ""array"",
-                            ""items"": { ""type"": ""string"" },
-                            ""description"": ""List of component GUIDs to move.""
-                        },
-                        ""x"": {
-                            ""type"": ""number"",
-                            ""description"": ""X coordinate for pivot (absolute or offset).""
-                        },
-                        ""y"": {
-                            ""type"": ""number"",
-                            ""description"": ""Y coordinate for pivot (absolute or offset).""
+                        ""targets"": {
+                            ""type"": ""object"",
+                            ""patternProperties"": {
+                                ""^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"": {
+                                    ""type"": ""object"",
+                                    ""properties"": {
+                                        ""x"": { ""type"": ""number"" },
+                                        ""y"": { ""type"": ""number"" }
+                                    },
+                                    ""required"": [ ""x"", ""y"" ]
+                                }
+                            },
+                            ""additionalProperties"": false,
+                            ""description"": ""Mapping of component GUID strings to target coordinates (keys must be GUIDs).""
                         },
                         ""relative"": {
                             ""type"": ""boolean"",
-                            ""description"": ""True for relative offset; false for absolute.""
+                            ""description"": ""True to treat targets as relative offsets.""
                         }
                     },
-                    ""required"": [ ""guids"", ""x"", ""y"" ]
-                }",
+                    ""required"": [ ""targets"" ]
+                }" ,
                 execute: this.GhMoveObjAsync
             );
 
@@ -196,33 +199,18 @@ namespace SmartHopper.Core.Grasshopper.Tools
         #region MoveInstance
         private async Task<object> GhMoveObjAsync(JObject parameters)
         {
-            var guids = parameters["guids"]?.ToObject<List<string>>() ?? new List<string>();
-            var x = parameters["x"]?.ToObject<float>() ?? 0f;
-            var y = parameters["y"]?.ToObject<float>() ?? 0f;
+            var targetsObj = parameters["targets"] as JObject;
+            if (targetsObj == null)
+                return new { success = false, error = "Missing or invalid 'targets' parameter." };
             var relative = parameters["relative"]?.ToObject<bool>() ?? false;
-            Debug.WriteLine($"[GhObjTools] GhMoveObjAsync: x={x}, y={y}, relative={relative}, count={guids.Count}");
-            var updated = new List<string>();
-            foreach (var s in guids)
-            {
-                Debug.WriteLine($"[GhObjTools] Processing GUID string: {s}");
-                if (Guid.TryParse(s, out var guid))
-                {
-                    var moved = GHCanvasUtils.MoveInstance(guid, new PointF(x, y), relative);
-                    Debug.WriteLine(moved
-                        ? $"[GhObjTools] Moved GUID: {guid} to ({x},{y}) relative={relative}"
-                        : $"[GhObjTools] Instance not found for GUID: {guid}");
-                    if (moved)
-                    {
-                        updated.Add(guid.ToString());
-                    }
-                }
-                else
-                {
-                    Debug.WriteLine($"[GhObjTools] Invalid GUID: {s}");
-                }
-            }
-
-            return new { success = true, updated };
+            var dict = new Dictionary<Guid, PointF>();
+            foreach (var prop in targetsObj.Properties())
+                if (Guid.TryParse(prop.Name, out var g))
+                    dict[g] = new PointF(
+                        prop.Value["x"]?.ToObject<float>() ?? 0f,
+                        prop.Value["y"]?.ToObject<float>() ?? 0f);
+            var movedList = GHCanvasUtils.MoveInstance(dict, relative);
+            return new { success = movedList.Any(), updated = movedList.Select(g => g.ToString()).ToList() };
         }
         #endregion
 

--- a/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Tools/GhObjTools.cs
@@ -205,10 +205,21 @@ namespace SmartHopper.Core.Grasshopper.Tools
             var relative = parameters["relative"]?.ToObject<bool>() ?? false;
             var dict = new Dictionary<Guid, PointF>();
             foreach (var prop in targetsObj.Properties())
+            {
                 if (Guid.TryParse(prop.Name, out var g))
+                {
+                    var xToken = prop.Value["x"];
+                    var yToken = prop.Value["y"];
+                    if (xToken == null || yToken == null)
+                    {
+                        Debug.WriteLine($"[GhObjTools] GhMoveObjAsync: Missing 'x' or 'y' for target {prop.Name}. Skipping.");
+                        continue;
+                    }
                     dict[g] = new PointF(
-                        prop.Value["x"]?.ToObject<float>() ?? 0f,
-                        prop.Value["y"]?.ToObject<float>() ?? 0f);
+                        xToken.ToObject<float>(),
+                        yToken.ToObject<float>());
+                }
+            }
             var movedList = GHCanvasUtils.MoveInstance(dict, relative);
             return new { success = movedList.Any(), updated = movedList.Select(g => g.ToString()).ToList() };
         }

--- a/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/GHComponentUtils.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.Drawing;
 using Grasshopper;
 using Grasshopper.Kernel;
+using Grasshopper.Kernel.Undo;
 
 namespace SmartHopper.Core.Grasshopper.Utils
 {
@@ -39,6 +40,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
                 Debug.WriteLine($"[GHComponentUtils] Component.IsPreviewCapable={component.IsPreviewCapable}, Hidden={component.Hidden}");
                 if (component.IsPreviewCapable)
                 {
+                    obj.RecordUndoEvent("[SH] Set Component Preview");
                     component.Hidden = !previewOn;
                     Debug.WriteLine($"[GHComponentUtils] New Hidden={component.Hidden}");
                     if (redraw)
@@ -55,6 +57,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
             else if (obj is IGH_PreviewObject preview)
             {
                 Debug.WriteLine($"[GHComponentUtils] IGH_PreviewObject.Hidden={preview.Hidden}");
+                obj.RecordUndoEvent("[SH] Set Component Preview");
                 preview.Hidden = !previewOn;
                 Debug.WriteLine($"[GHComponentUtils] New Hidden={preview.Hidden}");
                 if (redraw)
@@ -85,6 +88,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
             if (obj is GH_Component component)
             {
                 Debug.WriteLine($"[GHComponentUtils] Component.Locked={component.Locked}");
+                obj.RecordUndoEvent("[SH] Set Component Lock");
                 component.Locked = locked;
                 Debug.WriteLine($"[GHComponentUtils] New Locked={component.Locked}");
                 if (redraw)
@@ -96,6 +100,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
             else if (obj is IGH_Param param)
             {
                 Debug.WriteLine($"[GHComponentUtils] IGH_Param.Locked={param.Locked}");
+                obj.RecordUndoEvent("[SH] Set Component Lock");
                 param.Locked = locked;
                 Debug.WriteLine($"[GHComponentUtils] New Locked={param.Locked}");
                 if (redraw)


### PR DESCRIPTION
## Description

Added undo support to `MoveInstance`, `SetComponentPreview`, and `SetComponentLock`.

## Breaking Changes

None.

## Testing Done

RH8.18 on windows

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
