### PR TITLE
feat(ci): add yak package upload workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 # Critical repository files
 /.gitignore         @marc-romu
 /.gitattributes     @marc-romu
-/.windsurfrules     @marc-romu
+/.windsurf     @marc-romu
 *.ps1               @marc-romu
 
 # Critical solution files
@@ -27,3 +27,6 @@
 /Solution.props     @marc-romu
 /Directory.Build.props @marc-romu
 /Directory.Build.targets @marc-romu
+
+# Yak package
+/yak-package/**     @marc-romu

--- a/.github/workflows/release-5-upload-yak.yml
+++ b/.github/workflows/release-5-upload-yak.yml
@@ -108,8 +108,8 @@ jobs:
           Invoke-WebRequest -Uri "http://files.mcneel.com/yak/tools/latest/yak.exe" -OutFile "yak.exe"
           Write-Host "Downloaded Yak CLI"
 
-      - name: Prepare Windows Yak package
-        id: prepare_windows
+      - name: Build Windows Yak package
+        id: build_windows
         shell: pwsh
         run: |
           $version = "${{ steps.get_version.outputs.version }}"
@@ -118,25 +118,11 @@ jobs:
           New-Item -ItemType Directory -Path $pkgDir
           Expand-Archive -Path "artifacts/windows.zip" -DestinationPath $pkgDir -Force
           Copy-Item -Path "yak-package\*" -Destination $pkgDir -Recurse -Force
-          (Get-Content "$pkgDir/manifest.yml") -replace '\{\{VERSION\}\}', $version | Set-Content "$pkgDir/manifest.yml"
-          $zipName = "SmartHopper-$version-Windows-Yak.zip"
-          Compress-Archive -Path "$pkgDir/*" -DestinationPath $zipName -Force
-          echo "windows_yak_package=$zipName" >> $env:GITHUB_OUTPUT
-
-      # - name: Prepare Mac Yak package
-      #   id: prepare_mac
-      #   shell: pwsh
-      #   run: |
-      #     $version = "${{ steps.get_version.outputs.version }}"
-      #     $pkgDir = "yak-mac"
-      #     Remove-Item $pkgDir -Recurse -Force -ErrorAction SilentlyContinue
-      #     New-Item -ItemType Directory -Path $pkgDir
-      #     Expand-Archive -Path "artifacts/mac.zip" -DestinationPath $pkgDir -Force
-      #     Copy-Item -Path "yak-package\*" -Destination $pkgDir -Recurse -Force
-      #     (Get-Content "$pkgDir/manifest.yml") -replace '\{\{VERSION\}\}', $version | Set-Content "$pkgDir/manifest.yml"
-      #     $zipName = "SmartHopper-$version-Mac-Yak.zip"
-      #     Compress-Archive -Path "$pkgDir/*" -DestinationPath $zipName -Force
-      #     echo "mac_yak_package=$zipName" >> $env:GITHUB_OUTPUT
+          Push-Location $pkgDir
+          ./yak.exe build --platform win
+          $zip = Get-ChildItem -Filter "*.zip" | Select-Object -ExpandProperty FullName
+          echo "windows_yak_package=$zip" >> $env:GITHUB_OUTPUT
+          Pop-Location
 
       - name: Upload Windows Yak package to Yak
         if: inputs.upload_to_yak == 'true'
@@ -145,7 +131,7 @@ jobs:
           $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"
           $Flags = ""
           if ($PreRelease -eq "true") { $Flags = "--pre" }
-          $FilePath = "${{ steps.prepare_windows.outputs.windows_yak_package }}"
+          $FilePath = "${{ steps.build_windows.outputs.windows_yak_package }}"
           Write-Host "Uploading Windows Yak package: $FilePath"
           ./yak.exe push $FilePath $Flags
           if ($LASTEXITCODE -ne 0) {
@@ -157,21 +143,4 @@ jobs:
         env:
           YAK_TOKEN: ${{ secrets.YAK_AUTH_TOKEN }}
 
-      # - name: Upload Mac Yak package to Yak
-      #   if: inputs.upload_to_yak == 'true'
-      #   shell: pwsh
-      #   run: |
-      #     $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"
-      #     $Flags = ""
-      #     if ($PreRelease -eq "true") { $Flags = "--pre" }
-      #     $FilePath = "${{ steps.prepare_mac.outputs.mac_yak_package }}"
-      #     Write-Host "Uploading Mac Yak package: $FilePath"
-      #     ./yak.exe push $FilePath $Flags
-      #     if ($LASTEXITCODE -ne 0) {
-      #       Write-Host "::error::Failed to upload Mac Yak package"
-      #       exit 1
-      #     } else {
-      #       Write-Host "Successfully uploaded Mac Yak package"
-      #     }
-      #   env:
-      #     YAK_TOKEN: ${{ secrets.YAK_AUTH_TOKEN }}
+      # Mac pipeline is currently disabled; add mac build/upload with `yak build --platform mac` as needed

--- a/.github/workflows/release-5-upload-yak.yml
+++ b/.github/workflows/release-5-upload-yak.yml
@@ -20,10 +20,11 @@ name: 🚀 5 Upload to Yak Rhino Server
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to upload (defaults to latest release tag)'
+      upload_to_yak:
+        description: 'Confirm upload to Yak?'
         required: false
-        default: ''
+        type: boolean
+        default: false
 
 jobs:
   upload-to-yak:
@@ -138,6 +139,7 @@ jobs:
       #     echo "mac_yak_package=$zipName" >> $env:GITHUB_OUTPUT
 
       - name: Upload Windows Yak package to Yak
+        if: inputs.upload_to_yak == 'true'
         shell: pwsh
         run: |
           $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"
@@ -156,6 +158,7 @@ jobs:
           YAK_TOKEN: ${{ secrets.YAK_AUTH_TOKEN }}
 
       # - name: Upload Mac Yak package to Yak
+      #   if: inputs.upload_to_yak == 'true'
       #   shell: pwsh
       #   run: |
       #     $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"

--- a/.github/workflows/release-5-upload-yak.yml
+++ b/.github/workflows/release-5-upload-yak.yml
@@ -1,0 +1,174 @@
+name: 🚀 5 Upload to Yak Rhino Server
+
+# Description: This workflow uploads the release artifacts to the Yak Rhino Server.
+# It must be triggered manually after the release is built.
+#
+# Prerequisites:
+# - A YAK_AUTH_TOKEN secret must be configured in your repository settings
+#   To obtain a token:
+#   1. Install the Yak CLI: https://developer.rhino3d.com/guides/yak/yak-cli-reference/
+#   2. Run: yak login --ci
+#   3. Add the displayed token as a repository secret named YAK_AUTH_TOKEN
+#
+# Triggers:
+# - Manually via workflow_dispatch
+#
+# Permissions:
+# - contents:read - Required to read repository content for building
+# - contents:write - Required to upload assets to releases (only when triggered by release)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to upload (defaults to latest release tag)'
+        required: false
+        default: ''
+
+jobs:
+  upload-to-yak:
+    name: Upload to Yak
+    runs-on: windows-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: get_version
+        uses: ./.github/actions/versioning/get-version
+        with:
+          branch: main
+
+      - name: Determine pre-release flag
+        id: prerelease
+        shell: bash
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if [[ "$VERSION" =~ -(dev|alpha|beta|rc) ]]; then
+            echo "PRE_RELEASE=true" >> $GITHUB_OUTPUT
+          else
+            echo "PRE_RELEASE=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create artifacts directory
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts
+        
+      - name: Download Windows release asset
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: ${{ github.repository }}
+          tag: ${{ steps.get_version.outputs.version }}
+          fileName: "SmartHopper-${{ steps.get_version.outputs.version }}-Rhino8-Windows.zip"
+          out-file-path: "artifacts"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      # - name: Download Mac release asset
+      #   uses: robinraju/release-downloader@v1
+      #   with:
+      #     repository: ${{ github.repository }}
+      #     tag: ${{ steps.get_version.outputs.version }}
+      #     fileName: "SmartHopper-${{ steps.get_version.outputs.version }}-Rhino8-Mac-not-tested.zip"
+      #     out-file-path: "artifacts"
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Verify downloaded assets
+        shell: pwsh
+        run: |
+          $windowsFile = "artifacts/SmartHopper-${{ steps.get_version.outputs.version }}-Rhino8-Windows.zip"
+          $macFile = "artifacts/SmartHopper-${{ steps.get_version.outputs.version }}-Rhino8-Mac-not-tested.zip"
+          
+          if (-not (Test-Path $windowsFile)) {
+            Write-Host "::error::Windows asset not found after download: $windowsFile"
+            exit 1
+          }
+          
+          if (-not (Test-Path $macFile)) {
+            Write-Host "::error::Mac asset not found after download: $macFile"
+            exit 1
+          }
+          
+          Write-Host "Assets downloaded successfully"
+          
+          # Rename files to make them easier to reference in Yak commands
+          Move-Item -Path $windowsFile -Destination "artifacts/windows.zip" -Force
+          Move-Item -Path $macFile -Destination "artifacts/mac.zip" -Force
+
+      - name: Download Yak CLI
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "http://files.mcneel.com/yak/tools/latest/yak.exe" -OutFile "yak.exe"
+          Write-Host "Downloaded Yak CLI"
+
+      - name: Prepare Windows Yak package
+        id: prepare_windows
+        shell: pwsh
+        run: |
+          $version = "${{ steps.get_version.outputs.version }}"
+          $pkgDir = "yak-windows"
+          Remove-Item $pkgDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $pkgDir
+          Expand-Archive -Path "artifacts/windows.zip" -DestinationPath $pkgDir -Force
+          Copy-Item -Path "yak-package\*" -Destination $pkgDir -Recurse -Force
+          (Get-Content "$pkgDir/manifest.yml") -replace '\{\{VERSION\}\}', $version | Set-Content "$pkgDir/manifest.yml"
+          $zipName = "SmartHopper-$version-Windows-Yak.zip"
+          Compress-Archive -Path "$pkgDir/*" -DestinationPath $zipName -Force
+          echo "windows_yak_package=$zipName" >> $env:GITHUB_OUTPUT
+
+      # - name: Prepare Mac Yak package
+      #   id: prepare_mac
+      #   shell: pwsh
+      #   run: |
+      #     $version = "${{ steps.get_version.outputs.version }}"
+      #     $pkgDir = "yak-mac"
+      #     Remove-Item $pkgDir -Recurse -Force -ErrorAction SilentlyContinue
+      #     New-Item -ItemType Directory -Path $pkgDir
+      #     Expand-Archive -Path "artifacts/mac.zip" -DestinationPath $pkgDir -Force
+      #     Copy-Item -Path "yak-package\*" -Destination $pkgDir -Recurse -Force
+      #     (Get-Content "$pkgDir/manifest.yml") -replace '\{\{VERSION\}\}', $version | Set-Content "$pkgDir/manifest.yml"
+      #     $zipName = "SmartHopper-$version-Mac-Yak.zip"
+      #     Compress-Archive -Path "$pkgDir/*" -DestinationPath $zipName -Force
+      #     echo "mac_yak_package=$zipName" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Windows Yak package to Yak
+        shell: pwsh
+        run: |
+          $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"
+          $Flags = ""
+          if ($PreRelease -eq "true") { $Flags = "--pre" }
+          $FilePath = "${{ steps.prepare_windows.outputs.windows_yak_package }}"
+          Write-Host "Uploading Windows Yak package: $FilePath"
+          ./yak.exe push $FilePath $Flags
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Failed to upload Windows Yak package"
+            exit 1
+          } else {
+            Write-Host "Successfully uploaded Windows Yak package"
+          }
+        env:
+          YAK_TOKEN: ${{ secrets.YAK_AUTH_TOKEN }}
+
+      # - name: Upload Mac Yak package to Yak
+      #   shell: pwsh
+      #   run: |
+      #     $PreRelease = "${{ steps.prerelease.outputs.PRE_RELEASE }}"
+      #     $Flags = ""
+      #     if ($PreRelease -eq "true") { $Flags = "--pre" }
+      #     $FilePath = "${{ steps.prepare_mac.outputs.mac_yak_package }}"
+      #     Write-Host "Uploading Mac Yak package: $FilePath"
+      #     ./yak.exe push $FilePath $Flags
+      #     if ($LASTEXITCODE -ne 0) {
+      #       Write-Host "::error::Failed to upload Mac Yak package"
+      #       exit 1
+      #     } else {
+      #       Write-Host "Successfully uploaded Mac Yak package"
+      #     }
+      #   env:
+      #     YAK_TOKEN: ${{ secrets.YAK_AUTH_TOKEN }}

--- a/.windsurf/rules/yak-package-management.md
+++ b/.windsurf/rules/yak-package-management.md
@@ -1,0 +1,94 @@
+---
+trigger: glob
+globs: .github/workflows/release-**.yml
+---
+
+# Yak Package Management for Rhino/Grasshopper
+
+## Overview
+Yak is the package manager for Rhino and Grasshopper. It enables publishing, distribution, and installation of plugins.
+
+## Key Information
+
+### Authentication
+- Generate a non-expiring API key using `yak login --ci`
+- Store this key as a GitHub secret named `YAK_AUTH_TOKEN`
+- In GitHub Actions, set the `YAK_TOKEN` environment variable to this secret
+
+### Pre-release Versioning
+- Versions with suffixes `-alpha`, `-beta`, or `-rc` are considered pre-releases
+- Pre-releases must use the `--pre` flag when pushing to Yak
+- Regular releases have no suffix in their version
+
+### Package Structure
+
+A Yak package is a ZIP file containing your plugin files and a `manifest.yml` file. The structure should be as follows:
+
+```
+MyPlugin/
+├── manifest.yml          # Required: Package metadata
+├── MyPlugin.rhp          # Windows plugin (RHP file)
+├── MyPlugin.gha          # Grasshopper assembly (if applicable)
+├── MyPlugin.Mac.rhp      # Mac plugin (for Rhino 7+)
+└── README.md             # Optional: Documentation
+```
+
+#### Manifest File
+
+The `manifest.yml` must include:
+
+```yaml
+name: MyPlugin
+version: 1.0.0
+description: A brief description of the plugin
+authors: ["Author Name"]
+repository_url: https://github.com/username/repository
+keywords: ["rhino", "grasshopper", "category"]
+icon: icon.png  # Optional: 64x64px PNG
+
+# Platform-specific files
+platforms:
+  - name: windows
+    file: MyPlugin.rhp
+    rhino_version: "7.0"
+    platform: x64
+    runtime: net48  # or net6.0-windows
+  - name: mac
+    file: MyPlugin.Mac.rhp
+    rhino_version: "7.0"
+    platform: x64
+    runtime: net6.0-macos
+```
+
+### File Structure
+- Windows and Mac plugins must be packaged separately
+- Each platform requires its own Yak push command
+- Include all dependencies in the package
+- Follow Rhino's plugin structure guidelines for each platform
+
+### Workflow Integration
+1. Download Yak CLI executable from McNeel's server
+2. Determine if the version is a pre-release
+3. Download release assets from GitHub release
+4. Push to Yak server with appropriate flags
+5. Include proper error handling
+
+## CLI Reference
+
+```bash
+# Download Yak CLI
+curl -o yak.exe http://files.mcneel.com/yak/tools/latest/yak.exe
+
+# Push a package (non-pre-release)
+./yak.exe push path/to/package.zip
+
+# Push a pre-release package
+./yak.exe push path/to/package.zip --pre
+```
+
+## Environment Variables
+- `YAK_TOKEN`: Authentication token for pushing packages to Yak
+
+## Further Resources
+- [Yak CLI Reference](https://developer.rhino3d.com/guides/yak/yak-cli-reference/)
+- [The Anatomy of a Package](https://developer.rhino3d.com/guides/yak/the-anatomy-of-a-package)

--- a/.windsurf/rules/yak-package-management.md
+++ b/.windsurf/rules/yak-package-management.md
@@ -11,12 +11,12 @@ Yak is the package manager for Rhino and Grasshopper. It enables publishing, dis
 ## Key Information
 
 ### Authentication
-- Generate a non-expiring API key using `yak login --ci`
+- User generates a non-expiring API key using `yak login --ci`
 - Store this key as a GitHub secret named `YAK_AUTH_TOKEN`
 - In GitHub Actions, set the `YAK_TOKEN` environment variable to this secret
 
 ### Pre-release Versioning
-- Versions with suffixes `-alpha`, `-beta`, or `-rc` are considered pre-releases
+- Versions with suffixes `-dev`, `-alpha`, `-beta`, or `-rc` are considered pre-releases
 - Pre-releases must use the `--pre` flag when pushing to Yak
 - Regular releases have no suffix in their version
 
@@ -27,9 +27,8 @@ A Yak package is a ZIP file containing your plugin files and a `manifest.yml` fi
 ```
 MyPlugin/
 ├── manifest.yml          # Required: Package metadata
-├── MyPlugin.rhp          # Windows plugin (RHP file)
-├── MyPlugin.gha          # Grasshopper assembly (if applicable)
-├── MyPlugin.Mac.rhp      # Mac plugin (for Rhino 7+)
+├── icon.png              # Recommended: icon
+├── plugin-files.dll      # Plugin files in dll or gha
 └── README.md             # Optional: Documentation
 ```
 
@@ -44,26 +43,13 @@ description: A brief description of the plugin
 authors: ["Author Name"]
 repository_url: https://github.com/username/repository
 keywords: ["rhino", "grasshopper", "category"]
-icon: icon.png  # Optional: 64x64px PNG
-
-# Platform-specific files
-platforms:
-  - name: windows
-    file: MyPlugin.rhp
-    rhino_version: "7.0"
-    platform: x64
-    runtime: net48  # or net6.0-windows
-  - name: mac
-    file: MyPlugin.Mac.rhp
-    rhino_version: "7.0"
-    platform: x64
-    runtime: net6.0-macos
+icon: icon.png  # Recommended: 64x64px PNG
 ```
 
 ### File Structure
 - Windows and Mac plugins must be packaged separately
 - Each platform requires its own Yak push command
-- Include all dependencies in the package
+- Include all dependencies in the package (when build)
 - Follow Rhino's plugin structure guidelines for each platform
 
 ### Workflow Integration
@@ -76,9 +62,6 @@ platforms:
 ## CLI Reference
 
 ```bash
-# Download Yak CLI
-curl -o yak.exe http://files.mcneel.com/yak/tools/latest/yak.exe
-
 # Push a package (non-pre-release)
 ./yak.exe push path/to/package.zip
 

--- a/yak-package/manifest.yml
+++ b/yak-package/manifest.yml
@@ -3,7 +3,12 @@
 name: SmartHopper
 version: "{{VERSION}}"
 description: >
-  SmartHopper brings AI-powered components to Grasshopper. Do everything you can do with AI, directly within Grasshopper: Chat with your file, get insights, program scripting components, or learn parametric design with an integrated teaching assistant.
+  SmartHopper brings AI-powered components to Grasshopper.
+  Do everything you can do with AI, directly within Grasshopper:
+    - Get help with your file
+    - Program code directly to script components
+    - Learn parametric design with an integrated teaching assistant
+
 authors:
   - "Marc Roca Musach (@marc-romu)"
 repository_url: https://github.com/architects-toolkit/SmartHopper

--- a/yak-package/manifest.yml
+++ b/yak-package/manifest.yml
@@ -13,6 +13,6 @@ keywords:
   - "artificial intelligence"
   - "chat"
   - "scripting"
-  - "teaching assistant"
+  - "assistant"
   - "help"
 icon: smarthopper.png

--- a/yak-package/manifest.yml
+++ b/yak-package/manifest.yml
@@ -1,0 +1,18 @@
+# Package manifest for SmartHopper Yak package
+# version placeholder will be replaced by the workflow
+name: SmartHopper
+version: "{{VERSION}}"
+description: >
+  SmartHopper brings AI-powered components to Grasshopper. Do everything you can do with AI, directly within Grasshopper: Chat with your file, get insights, program scripting components, or learn parametric design with an integrated teaching assistant.
+authors:
+  - "Marc Roca Musach (@marc-romu)"
+repository_url: https://github.com/architects-toolkit/SmartHopper
+keywords:
+  - "smarthopper"
+  - "ai"
+  - "artificial intelligence"
+  - "chat"
+  - "scripting"
+  - "teaching assistant"
+  - "help"
+icon: smarthopper.png


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow (`release-5-upload-yak.yml`) to automate uploading SmartHopper releases to the Yak Rhino package server. The workflow:

- Downloads release artifacts from GitHub
- Builds Yak packages using `yak build` with proper platform tagging
- Supports pre-release versions (dev/alpha/beta/rc)
- Includes a confirmation step before uploading to production
- Follows security best practices with explicit permissions

## Breaking Changes

No breaking changes. This is an additive change that introduces a new deployment workflow.

## Testing Done

Not tested yet.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [ ] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [ ] CHANGELOG.md has been updated
- [x] PR title follows Conventional Commits format
- [x] PR description follows Pull Request Description Template