### PR TITLE
feat(context): add support for excluding all providers/context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renamed SmartHopper.Config to SmartHopper.Infrastructure
   - Renamed SmartHopper.Config.Tests to SmartHopper.Infrastructure.Tests
 
-
 ## [0.3.3-alpha] - 2025-06-23
 
 ### WIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added Instructions input to AI Chat Component ([#87](https://github.com/architects-toolkit/SmartHopper/issues/87)).
 - Added systemPrompt parameter to WebChatUtils.ShowWebChatDialog
+- Context manager improvements:
+  - Added support for "-*" to exclude all providers/context in one go
+  - Added support for space, tab, and newline as additional delimiters in filter strings
+  - Explicitly handle "*" wildcard to include all providers/context by default
 
 ### Changed
 
 - Several improvements to AI Chat Component:
   - Updated WebChatDialog to use provided system prompt or fall back to default
   - Improved default system prompt for AI Chat to focus on a Grasshopper assistant, including tool call examples
-- Modified manifest to reflect new context input feature
-- Code cleanup in AI Chat Component, WebChatDialog and WebChatUtils
-- Renamed SmartHopper.Config to SmartHopper.Infrastructure
-- Renamed SmartHopper.Config.Tests to SmartHopper.Infrastructure.Tests
-- Reorganized AIProvider, AIContext and AITool managers
+- Modified manifest to reflect new instructions input feature in AI Chat Component
+- Modified AITextEvaluate, AITextGenerate, AIListEvaluate and AIListFilter to exclude all context using the new "-*" filter
+- Code reorganization:
+  - Reorganized AIProvider, AIContext and AITool managers
+  - Code cleanup in AI Chat Component, WebChatDialog and WebChatUtils
+  - Renamed SmartHopper.Config to SmartHopper.Infrastructure
+  - Renamed SmartHopper.Config.Tests to SmartHopper.Infrastructure.Tests
+
 
 ## [0.3.3-alpha] - 2025-06-23
 

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>0.3.4-dev.250709</SolutionVersion>
+    <SolutionVersion>0.3.4-dev.250710</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/src/SmartHopper.Components/List/AIListEvaluate.cs
+++ b/src/SmartHopper.Components/List/AIListEvaluate.cs
@@ -169,7 +169,7 @@ namespace SmartHopper.Components.List
                     {
                         ["list"] = JArray.Parse(normalizedListTree[i].Value),
                         ["question"] = question.Value,
-                        ["contextProviderFilter"] = "-*"
+                        ["contextProviderFilter"] = "-*",
                     };
 
                     var toolResult = await parent.CallAiToolAsync(

--- a/src/SmartHopper.Components/List/AIListEvaluate.cs
+++ b/src/SmartHopper.Components/List/AIListEvaluate.cs
@@ -169,7 +169,7 @@ namespace SmartHopper.Components.List
                     {
                         ["list"] = JArray.Parse(normalizedListTree[i].Value),
                         ["question"] = question.Value,
-                        ["contextProviderFilter"] = "-environment,-time"
+                        ["contextProviderFilter"] = "-*"
                     };
 
                     var toolResult = await parent.CallAiToolAsync(

--- a/src/SmartHopper.Components/List/AIListFilter.cs
+++ b/src/SmartHopper.Components/List/AIListFilter.cs
@@ -174,7 +174,7 @@ namespace SmartHopper.Components.List
                     {
                         ["list"] = JArray.Parse(normalizedListTree[i].Value),
                         ["criteria"] = criterion.Value,
-                        ["contextProviderFilter"] = "-*"
+                        ["contextProviderFilter"] = "-*",
                     };
 
                     Debug.WriteLine($"[ProcessData] Calling AI tool 'list_filter' with parameters: {parameters}");

--- a/src/SmartHopper.Components/List/AIListFilter.cs
+++ b/src/SmartHopper.Components/List/AIListFilter.cs
@@ -174,7 +174,7 @@ namespace SmartHopper.Components.List
                     {
                         ["list"] = JArray.Parse(normalizedListTree[i].Value),
                         ["criteria"] = criterion.Value,
-                        ["contextProviderFilter"] = "-environment,-time"
+                        ["contextProviderFilter"] = "-*"
                     };
 
                     Debug.WriteLine($"[ProcessData] Calling AI tool 'list_filter' with parameters: {parameters}");

--- a/src/SmartHopper.Components/Text/AITextEvaluate.cs
+++ b/src/SmartHopper.Components/Text/AITextEvaluate.cs
@@ -160,7 +160,7 @@ namespace SmartHopper.Components.Text
                     {
                         ["text"] = textTree[i]?.Value,
                         ["question"] = questionTree[i]?.Value,
-                        ["contextProviderFilter"] = "-*"
+                        ["contextProviderFilter"] = "-*",
                     };
 
                     var toolResult = await parent.CallAiToolAsync("text_evaluate", parameters, reuseCount)

--- a/src/SmartHopper.Components/Text/AITextEvaluate.cs
+++ b/src/SmartHopper.Components/Text/AITextEvaluate.cs
@@ -160,7 +160,7 @@ namespace SmartHopper.Components.Text
                     {
                         ["text"] = textTree[i]?.Value,
                         ["question"] = questionTree[i]?.Value,
-                        ["contextProviderFilter"] = "-environment,-time"
+                        ["contextProviderFilter"] = "-*"
                     };
 
                     var toolResult = await parent.CallAiToolAsync("text_evaluate", parameters, reuseCount)

--- a/src/SmartHopper.Components/Text/AITextGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerate.cs
@@ -160,7 +160,7 @@ namespace SmartHopper.Components.Text
                     {
                         ["prompt"] = promptTree[i]?.Value,
                         ["instructions"] = instructionsTree[i]?.Value,
-                        ["contextProviderFilter"] = "-environment,-time"
+                        ["contextProviderFilter"] = "-*"
                     };
 
                     var toolResult = await parent.CallAiToolAsync(

--- a/src/SmartHopper.Components/Text/AITextGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerate.cs
@@ -160,7 +160,7 @@ namespace SmartHopper.Components.Text
                     {
                         ["prompt"] = promptTree[i]?.Value,
                         ["instructions"] = instructionsTree[i]?.Value,
-                        ["contextProviderFilter"] = "-*"
+                        ["contextProviderFilter"] = "-*",
                     };
 
                     var toolResult = await parent.CallAiToolAsync(

--- a/src/SmartHopper.Core/Messaging/AIUtils.cs
+++ b/src/SmartHopper.Core/Messaging/AIUtils.cs
@@ -83,6 +83,7 @@ namespace SmartHopper.Core.Messaging
             try
             {
                 // Add context from all registered context providers, applying filters if specified
+                Debug.WriteLine($"[AIUtils] Adding context from providers: {contextProviderFilter ?? "null"}, keys: {contextKeyFilter ?? "null"}");
                 var contextData = AIContextManager.GetCurrentContext(contextProviderFilter, contextKeyFilter);
                 if (contextData.Count > 0)
                 {

--- a/src/SmartHopper.Infrastructure/Managers/AIContext/AIContextManager.cs
+++ b/src/SmartHopper.Infrastructure/Managers/AIContext/AIContextManager.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using SmartHopper.Infrastructure.Interfaces;
 
@@ -35,6 +36,8 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
 
             // Add the new provider
             _contextProviders.Add(provider);
+
+            Debug.WriteLine($"[RegisterProvider] Registered provider: {provider.ProviderId}");
         }
 
         /// <summary>
@@ -46,6 +49,8 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
             if (string.IsNullOrEmpty(providerId)) return;
 
             _contextProviders.RemoveAll(p => p.ProviderId == providerId);
+
+            Debug.WriteLine($"[UnregisterProvider] Unregistered provider: {providerId}");
         }
 
         /// <summary>
@@ -95,11 +100,14 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
             var result = new Dictionary<string, string>();
 
             // if "-*" is specified in either filter, exclude all and return an empty dictionary
-            if ((providerFilter != null && providerFilter.Contains("-*")) ||
-                (contextFilter != null && contextFilter.Contains("-*")))
+            if ((!string.IsNullOrEmpty(providerFilter) && providerFilter.Contains("-*")) ||
+                (!string.IsNullOrEmpty(contextFilter) && contextFilter.Contains("-*")))
             {
+                Debug.WriteLine($"[GetCurrentContext] Excluding all providers and context");
                 return result;
             }
+
+            Debug.WriteLine($"[GetCurrentContext] Provider filter: '{providerFilter ?? "null"}', Context filter: '{contextFilter ?? "null"}'");
 
             // Parse provider filters
             HashSet<string> includeProviderFilters = null;
@@ -107,6 +115,7 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
 
             if (!string.IsNullOrEmpty(providerFilter))
             {
+                Debug.WriteLine($"[GetCurrentContext] Processing provider filter: {providerFilter}");
                 var filterParts = providerFilter.Split(new[] { ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(p => p.Trim())
                     .ToList();
@@ -119,12 +128,9 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
                     .ToList();
 
                 // Handle '*' wildcard: treat '*' as include-all (default behavior)
-                if (!includeFilters.Contains("*"))
+                if (!includeFilters.Contains("*") && includeFilters.Count > 0)
                 {
-                    if (includeFilters.Count > 0)
-                    {
-                        includeProviderFilters = new HashSet<string>(includeFilters);
-                    }
+                    includeProviderFilters = new HashSet<string>(includeFilters);
                 }
 
                 if (excludeFilters.Count > 0)
@@ -139,6 +145,7 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
 
             if (!string.IsNullOrEmpty(contextFilter))
             {
+                Debug.WriteLine($"[GetCurrentContext] Processing context filter: {contextFilter}");
                 var filterParts = contextFilter.Split(new[] { ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(c => c.Trim())
                     .ToList();
@@ -151,12 +158,9 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
                     .ToList();
 
                 // Handle '*' wildcard: treat '*' as include-all (default behavior)
-                if (!includeFilters.Contains("*"))
+                if (!includeFilters.Contains("*") && includeFilters.Count > 0)
                 {
-                    if (includeFilters.Count > 0)
-                    {
-                        includeContextFilters = new HashSet<string>(includeFilters);
-                    }
+                    includeContextFilters = new HashSet<string>(includeFilters);
                 }
 
                 if (excludeFilters.Count > 0)

--- a/src/SmartHopper.Infrastructure/Managers/AIContext/AIContextManager.cs
+++ b/src/SmartHopper.Infrastructure/Managers/AIContext/AIContextManager.cs
@@ -81,14 +81,25 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
         /// <summary>
         /// Gets the combined context from all registered providers, with optional filtering
         /// </summary>
-        /// <param name="providerFilter">Optional provider ID filter. If specified, only context from providers with matching IDs will be included.
-        /// Multiple providers can be specified as a comma-separated list. Prefix a provider ID with '-' to exclude it (e.g., "-time" excludes the time provider).</param>
-        /// <param name="contextFilter">Optional context key filter. If specified, only context with matching keys will be included. Multiple context keys can be specified as a comma-separated list.
-        /// Prefix a context key with '-' to exclude it (e.g., "-time_current-datetime" excludes that specific context key).</param>
+        /// <param name="providerFilter">Optional provider ID filter. If specified, only context from providers with matching IDs will be included. Multiple providers can be specified as a comma-separated or space-separated list.
+        /// Prefix a provider ID with '-' to exclude it (e.g., "-time" excludes the time provider).
+        /// Use '*' to include all providers (default behavior).
+        /// Use '-*' to exclude all providers.</param>
+        /// <param name="contextFilter">Optional context key filter. If specified, only context with matching keys will be included. Multiple context keys can be specified as a comma-separated or space-separated list.
+        /// Prefix a context key with '-' to exclude it (e.g., "-time_current-datetime" excludes that specific context key).
+        /// Use '*' to include all context keys (default behavior).
+        /// Use '-*' to exclude all context keys.</param>
         /// <returns>A dictionary of context key-value pairs</returns>
         public static Dictionary<string, string> GetCurrentContext(string providerFilter = null, string contextFilter = null)
         {
             var result = new Dictionary<string, string>();
+
+            // if "-*" is specified in either filter, exclude all and return an empty dictionary
+            if ((providerFilter != null && providerFilter.Contains("-*")) ||
+                (contextFilter != null && contextFilter.Contains("-*")))
+            {
+                return result;
+            }
 
             // Parse provider filters
             HashSet<string> includeProviderFilters = null;
@@ -96,7 +107,7 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
 
             if (!string.IsNullOrEmpty(providerFilter))
             {
-                var filterParts = providerFilter.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                var filterParts = providerFilter.Split(new[] { ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(p => p.Trim())
                     .ToList();
 
@@ -107,9 +118,13 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
                     .Where(p => !string.IsNullOrEmpty(p))
                     .ToList();
 
-                if (includeFilters.Count > 0)
+                // Handle '*' wildcard: treat '*' as include-all (default behavior)
+                if (!includeFilters.Contains("*"))
                 {
-                    includeProviderFilters = new HashSet<string>(includeFilters);
+                    if (includeFilters.Count > 0)
+                    {
+                        includeProviderFilters = new HashSet<string>(includeFilters);
+                    }
                 }
 
                 if (excludeFilters.Count > 0)
@@ -124,7 +139,7 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
 
             if (!string.IsNullOrEmpty(contextFilter))
             {
-                var filterParts = contextFilter.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                var filterParts = contextFilter.Split(new[] { ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(c => c.Trim())
                     .ToList();
 
@@ -135,9 +150,13 @@ namespace SmartHopper.Infrastructure.Managers.AIContext
                     .Where(c => !string.IsNullOrEmpty(c))
                     .ToList();
 
-                if (includeFilters.Count > 0)
+                // Handle '*' wildcard: treat '*' as include-all (default behavior)
+                if (!includeFilters.Contains("*"))
                 {
-                    includeContextFilters = new HashSet<string>(includeFilters);
+                    if (includeFilters.Count > 0)
+                    {
+                        includeContextFilters = new HashSet<string>(includeFilters);
+                    }
                 }
 
                 if (excludeFilters.Count > 0)


### PR DESCRIPTION
## Description

This PR introduces a new feature to exclude all providers or contexts in one go using the "-*" syntax. This enhancement improves the coding experience when working with multiple providers or contexts by allowing bulk exclusion without having to list each one individually.

Key changes:
- Added support for "-*" to exclude all providers/context in one go
- Added support for space, tab, and newline as additional delimiters in filter strings
- Explicitly handle "*" wildcard to include all providers/context by default
- Updated AITextEvaluate, AITextGenerate, AIListEvaluate, and AIListFilter to utilize the new exclude all functionality

## Breaking Changes

No breaking changes. This is a purely additive feature that maintains backward compatibility.

## Testing Done

- [x] Verified that "-*" correctly excludes all providers
- [x] Tested with various delimiters (comma, space, tab, newline)
- [x] Confirmed that "*" still works as before to include all providers
- [x] Tested with existing components (AITextEvaluate, AITextGenerate, AIListEvaluate, AIListFilter)

## Checklist

- [x] This PR is focused on a single feature
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.1.0/) format
- [x] PR description follows [Pull Request Description Template](https://github.com/architects-toolkit/SmartHopper/blob/main/CONTRIBUTING.md#pull-request-description-template)