### PR TITLE
fix(core): robust JSON list parsing for AI-generated outputs with arbitrary delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed issue: Output metrics not being set when using Boolean toggle.
 - Fixed issue ([#208](https://github.com/architects-toolkit/SmartHopper/issues/208)): enabled compatibility with params in `gh_toggle_preview` tool.
 - Fixed WebChatDialog not automatically closing when Rhino is closed.
+- Fixed "Parsing error when output contains { }" ([#276](https://github.com/architects-toolkit/SmartHopper/issues/276)).
 
 ## [0.4.0-alpha] - 2025-07-22
 
@@ -91,7 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `GhRetrieveComponents` to use the correct ai tool `gh_list_components` instead of `gh_get_available_components`
 - Fixes "Missing required parameter: ‘response_format.json_schema' in text-list-generate with OpenAI provider" ([#259](https://github.com/architects-toolkit/SmartHopper/issues/259)).
 - Fixes "Check structured output compatibility with models" ([#273](https://github.com/architects-toolkit/SmartHopper/issues/273)).
-- Fixed "Parsing error when output contains { }" ([#276](https://github.com/architects-toolkit/SmartHopper/issues/276)).
 
 ## [0.3.6-alpha] - 2025-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `GhRetrieveComponents` to use the correct ai tool `gh_list_components` instead of `gh_get_available_components`
 - Fixes "Missing required parameter: ‘response_format.json_schema' in text-list-generate with OpenAI provider" ([#259](https://github.com/architects-toolkit/SmartHopper/issues/259)).
 - Fixes "Check structured output compatibility with models" ([#273](https://github.com/architects-toolkit/SmartHopper/issues/273)).
+- Fixed "Parsing error when output contains { }" ([#276](https://github.com/architects-toolkit/SmartHopper/issues/276)).
 
 ## [0.3.6-alpha] - 2025-07-20
 

--- a/src/SmartHopper.Components/Img/AIImgGenerateComponent.cs
+++ b/src/SmartHopper.Components/Img/AIImgGenerateComponent.cs
@@ -188,7 +188,7 @@ namespace SmartHopper.Components.Img
 
                         // Update progress
                         processedPaths++;
-                        this._progressReporter?.Invoke($"Processing path {processedPaths}/{totalPaths}");
+                        this._progressReporter?.Invoke($"Process {processedPaths}/{totalPaths}");
 
                         var promptBranch = this._prompts.get_Branch(path);
                         var sizeBranch = this._sizes.PathExists(path) ? this._sizes.get_Branch(path) : this._sizes.get_Branch(new GH_Path(0));

--- a/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
@@ -67,7 +67,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 var messages = new List<KeyValuePair<string, string>>
                 {
-                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY the JSON array. Include no extra text or formatting. Do not wrap the output in quotes or in a code block.\n\nOUTPUT EXAMPLES: ['item1', 'item2', 'item3']"),
+                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY the JSON array. Include no extra text or formatting. Do not wrap the output in quotes or in a code block.\n\nIMPORTANT: Each item must be a quoted string in the JSON array, even if it contains commas or special characters.\n\nOUTPUT EXAMPLES: ['item1', 'item2', 'item3'] or ['{1,0,0}', '{0.707,0.707,0}', '{0,1,0}']"),
                     new("user", prompt.Value)
                 };
 

--- a/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
@@ -30,7 +30,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
     /// </summary>
     public class list_generate : IAIToolProvider
     {
-        private const string ListJsonSchema = "{\"type\":\"array\",\"items\":{\"type\":\"string\"}}";
+        private const string ListJsonSchema = "['item1', 'item2', 'item3', ...]";
 
         /// <summary>
         /// Get all tools provided by this class.
@@ -51,7 +51,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""prompt"", ""count"", ""type""]
                 }",
                 execute: this.GenerateListToolWrapper,
-                requiredCapabilities: AIModelCapability.TextInput | AIModelCapability.TextOutput | AIModelCapability.StructuredOutput
+                requiredCapabilities: AIModelCapability.TextInput | AIModelCapability.StructuredOutput
             );
         }
 
@@ -67,7 +67,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 var messages = new List<KeyValuePair<string, string>>
                 {
-                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY a valid JSON array of strings matching this schema: {ListJsonSchema}. Include no extra text or formatting."),
+                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY the JSON array. Include no extra text or formatting. Do not wrap the output in quotes or in a code block.\n\nOUTPUT EXAMPLES: ['item1', 'item2', 'item3']"),
                     new("user", prompt.Value)
                 };
 

--- a/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/list_generate.cs
@@ -67,7 +67,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 var messages = new List<KeyValuePair<string, string>>
                 {
-                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY the JSON array. Include no extra text or formatting. Do not wrap the output in quotes or in a code block.\n\nIMPORTANT: Each item must be a quoted string in the JSON array, even if it contains commas or special characters.\n\nOUTPUT EXAMPLES: ['item1', 'item2', 'item3'] or ['{1,0,0}', '{0.707,0.707,0}', '{0,1,0}']"),
+                    new("system", $"You are a list generator assistant. Generate {count} items of text based on the prompt and return ONLY the JSON array. Include no extra text or formatting. Do not wrap the output in quotes or in a code block.\n\nIMPORTANT: Each item must be a quoted string in the JSON array, even if it contains commas or special characters.\n\nOUTPUT EXAMPLES: ['item1', 'item2', 'item3'] or ['{{1,0,0}}', '{{0.707,0.707,0}}', '{{0,1,0}}']"),
                     new("user", prompt.Value)
                 };
 
@@ -84,7 +84,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 // Strip thinking tags from response before parsing
                 var cleanedResponse = AI.StripThinkTags(response.Response);
-                
+
                 // Parse JSON array of strings
                 var items = ParsingTools.ParseStringArrayFromResponse(cleanedResponse);
                 Debug.WriteLine($"[ListTools] Generated items: {string.Join(", ", items)}");

--- a/src/SmartHopper.Core.Grasshopper/Utils/ParsingTools.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/ParsingTools.cs
@@ -163,6 +163,7 @@ namespace SmartHopper.Core.Grasshopper.Utils
         /// <summary>
         /// Splits a string on commas while respecting any type of delimiters to avoid splitting structured strings.
         /// Handles: {}, (), [], and any nested combinations.
+        /// Properly handles escaped quotes within strings.
         /// </summary>
         private static List<string> SplitRespectingDelimiters(string input)
         {
@@ -179,14 +180,22 @@ namespace SmartHopper.Core.Grasshopper.Utils
                 // Handle quotes to avoid splitting quoted strings
                 if ((c == '"' || c == '\'') && !inQuotes)
                 {
-                    inQuotes = true;
-                    quoteChar = c;
+                    // Check if this quote is escaped
+                    if (!IsEscaped(input, i))
+                    {
+                        inQuotes = true;
+                        quoteChar = c;
+                    }
                     current.Append(c);
                 }
                 else if (c == quoteChar && inQuotes)
                 {
-                    inQuotes = false;
-                    quoteChar = '\0';
+                    // Check if this quote is escaped
+                    if (!IsEscaped(input, i))
+                    {
+                        inQuotes = false;
+                        quoteChar = '\0';
+                    }
                     current.Append(c);
                 }
                 // Handle opening delimiters
@@ -225,6 +234,27 @@ namespace SmartHopper.Core.Grasshopper.Utils
             }
             
             return result;
+        }
+
+        /// <summary>
+        /// Determines if a character at the given position is escaped by counting preceding backslashes.
+        /// Handles multiple consecutive backslashes correctly (e.g., \\" where \\" represents \+ escaped quote).
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <param name="position">The position of the character to check.</param>
+        /// <returns>True if the character is escaped, false otherwise.</returns>
+        private static bool IsEscaped(string input, int position)
+        {
+            if (position == 0) return false;
+            
+            int backslashCount = 0;
+            for (int i = position - 1; i >= 0 && input[i] == '\\'; i--)
+            {
+                backslashCount++;
+            }
+            
+            // If odd number of backslashes, the character is escaped
+            return backslashCount % 2 == 1;
         }
 
         /// <summary>

--- a/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
+++ b/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
@@ -199,9 +199,7 @@ namespace SmartHopper.Providers.DeepSeek
                     var systemMessage = new JObject
                     {
                         ["role"] = "system",
-                        ["content"] = "You are a helpful assistant that returns responses in JSON format. " +
-                                      "The response must be a valid JSON object that follows this schema exactly: " +
-                                      jsonSchema
+                        ["content"] = "The response must be a valid JSON object that strictly follows this schema: " + jsonSchema
                     };
                     convertedMessages.Insert(0, systemMessage);
                 }

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProvider.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProvider.cs
@@ -154,9 +154,7 @@ namespace SmartHopper.Providers.MistralAI
                 var systemMessage = new JObject
                 {
                     ["role"] = "system",
-                    ["content"] = "You are a helpful assistant that returns responses in JSON format. " +
-                                  "The response must be a valid JSON object that follows this schema exactly: " +
-                                  jsonSchema
+                    ["content"] = "The response must be a valid JSON object that strictly follows this schema: " + jsonSchema
                 };
                 convertedMessages.Insert(0, systemMessage);
             }

--- a/src/SmartHopper.Providers.OpenAI/OpenAIProvider.cs
+++ b/src/SmartHopper.Providers.OpenAI/OpenAIProvider.cs
@@ -146,10 +146,11 @@ namespace SmartHopper.Providers.OpenAI
                 ["temperature"] = this.GetSetting<double>("Temperature"),
             };
 
-            // Add reasoning effort if model starts with "(0-9)o"
-            if (Regex.IsMatch(model, @"^[0-9]o", RegexOptions.IgnoreCase))
+            // Add reasoning effort if model starts with "o-series"
+            if (Regex.IsMatch(model, @"^o[0-9]", RegexOptions.IgnoreCase))
             {
                 requestBody["reasoning_effort"] = reasoningEffort;
+                requestBody["temperature"] = 1; // Only 1 is accepted for o-series models
             }
 
             // Store wrapper info for response unwrapping


### PR DESCRIPTION
## Description

This PR resolves [#276](https://github.com/architects-toolkit/SmartHopper/issues/276) by making the parsing of AI-generated lists robust to any coordinate or value formatting, regardless of delimiters (e.g., `{}`, [()], `[]`, `;`, etc.). It ensures that lists like `{1,0,0}, (2,1,0), [3,2,0]` or quoted/semicolon-delimited values are always correctly parsed as single items.

Fixes #276

## Breaking Changes

None

## Testing Done

RH8.21 on windows

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
