### PR TITLE
feat(greeting): Add toggle for AI-generated chat greetings and force use provider default model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Greeting generation was using stored settings models instead of the provider's default model. To solve it, now if `AIUtils.GetResponse` doesn't get a model, it will use the provider's default model.
+
 ## [0.5.0-alpha] - 2025-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Settings parameter to enable/disable AI generated greeting in chat.
+
 ### Fixed
 
 - Greeting generation was using stored settings models instead of the provider's default model. To solve it, now if `AIUtils.GetResponse` doesn't get a model, it will use the provider's default model.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmartHopper - AI-Powered Grasshopper3D Plugin
 
-[![Version](https://img.shields.io/badge/version-0%2E5%2E0--alpha-orange)](https://github.com/architects-toolkit/SmartHopper/releases)
-[![Status](https://img.shields.io/badge/status-Alpha-orange)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Version](https://img.shields.io/badge/version-0%2E5%2E1--dev.250730-brown)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Status](https://img.shields.io/badge/status-Unstable%20Development-brown)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![Test results](https://img.shields.io/github/actions/workflow/status/architects-toolkit/SmartHopper/.github/workflows/ci-dotnet-tests.yml?label=.NET%20CI&logo=dotnet)](https://github.com/architects-toolkit/SmartHopper/actions/workflows/ci-dotnet-tests.yml)
 [![Grasshopper](https://img.shields.io/badge/plugin_for-Grasshopper3D-darkgreen?logo=rhinoceros)](https://www.rhino3d.com/)
 [![MistralAI](https://img.shields.io/badge/AI--powered-MistralAI-orange?logo=mistralai)](https://mistral.ai/)

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>0.5.0-alpha</SolutionVersion>
+    <SolutionVersion>0.5.1-dev.250730</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/src/SmartHopper.Core/Messaging/AIUtils.cs
+++ b/src/SmartHopper.Core/Messaging/AIUtils.cs
@@ -141,15 +141,15 @@ namespace SmartHopper.Core.Messaging
                     // If toolFilter is not null -> use FunctionCalling capability
                     if (!string.IsNullOrWhiteSpace(jsonSchema))
                     {
-                        model = selectedProvider.GetDefaultModel(AIModelCapability.JsonGenerator);
+                        model = selectedProvider.GetDefaultModel(AIModelCapability.JsonGenerator, false);
                     }
                     else if (!string.IsNullOrWhiteSpace(toolFilter))
                     {
-                        model = selectedProvider.GetDefaultModel(AIModelCapability.AdvancedChat);
+                        model = selectedProvider.GetDefaultModel(AIModelCapability.AdvancedChat, false);
                     }
                     else
                     {
-                        model = selectedProvider.GetDefaultModel(AIModelCapability.BasicChat);
+                        model = selectedProvider.GetDefaultModel(AIModelCapability.BasicChat, false);
                     }
 
                     Debug.WriteLine($"[AIUtils] No model specified, using provider's default model: {model}");

--- a/src/SmartHopper.Core/Messaging/AIUtils.cs
+++ b/src/SmartHopper.Core/Messaging/AIUtils.cs
@@ -44,6 +44,18 @@ namespace SmartHopper.Core.Messaging
             }
         }
 
+        /// <summary>
+        /// Gets an AI response using the specified provider and parameters.
+        /// </summary>
+        /// <param name="providerName">The name of the AI provider to use.</param>
+        /// <param name="model">The model to use for the request. If empty, uses provider's default model.</param>
+        /// <param name="messages">The conversation messages as key-value pairs (role, content).</param>
+        /// <param name="jsonSchema">Optional JSON schema for structured output.</param>
+        /// <param name="endpoint">Optional custom endpoint to use.</param>
+        /// <param name="toolFilter">Optional filter for available AI tools.</param>
+        /// <param name="contextProviderFilter">Optional filter for context providers.</param>
+        /// <param name="contextKeyFilter">Optional filter for context keys.</param>
+        /// <returns>An AIResponse containing the generated response and metadata.</returns>
         public static async Task<AIResponse> GetResponse(
             string providerName,
             string model,
@@ -57,6 +69,18 @@ namespace SmartHopper.Core.Messaging
             return await GetResponse(providerName, model, AIMessageBuilder.CreateMessage(messages), jsonSchema, endpoint, toolFilter, contextProviderFilter, contextKeyFilter).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Gets an AI response using the specified provider and parameters.
+        /// </summary>
+        /// <param name="providerName">The name of the AI provider to use.</param>
+        /// <param name="model">The model to use for the request. If empty, uses provider's default model.</param>
+        /// <param name="messages">The conversation messages as ChatMessageModel objects.</param>
+        /// <param name="jsonSchema">Optional JSON schema for structured output.</param>
+        /// <param name="endpoint">Optional custom endpoint to use.</param>
+        /// <param name="toolFilter">Optional filter for available AI tools.</param>
+        /// <param name="contextProviderFilter">Optional filter for context providers.</param>
+        /// <param name="contextKeyFilter">Optional filter for context keys.</param>
+        /// <returns>An AIResponse containing the generated response and metadata.</returns>
         public static async Task<AIResponse> GetResponse(
             string providerName,
             string model,
@@ -70,6 +94,18 @@ namespace SmartHopper.Core.Messaging
             return await GetResponse(providerName, model, AIMessageBuilder.CreateMessage(messages), jsonSchema, endpoint, toolFilter, contextProviderFilter, contextKeyFilter).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Internal implementation for getting AI responses with full context management.
+        /// </summary>
+        /// <param name="providerName">The name of the AI provider to use.</param>
+        /// <param name="model">The model to use for the request. If empty, uses provider's default model.</param>
+        /// <param name="messages">The conversation messages as a JArray.</param>
+        /// <param name="jsonSchema">Optional JSON schema for structured output.</param>
+        /// <param name="endpoint">Optional custom endpoint to use.</param>
+        /// <param name="toolFilter">Optional filter for available AI tools.</param>
+        /// <param name="contextProviderFilter">Optional filter for context providers.</param>
+        /// <param name="contextKeyFilter">Optional filter for context keys.</param>
+        /// <returns>An AIResponse containing the generated response and metadata.</returns>
         private static async Task<AIResponse> GetResponse(
             string providerName,
             string model,

--- a/src/SmartHopper.Core/UI/Chat/WebChatDialog.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatDialog.cs
@@ -28,6 +28,7 @@ using SmartHopper.Infrastructure.Managers.AIProviders;
 using SmartHopper.Infrastructure.Managers.AITools;
 using SmartHopper.Infrastructure.Models;
 using SmartHopper.Infrastructure.Properties;
+using SmartHopper.Infrastructure.Settings;
 
 namespace SmartHopper.Core.UI.Chat
 {
@@ -929,6 +930,19 @@ namespace SmartHopper.Core.UI.Chat
                 if (!string.IsNullOrEmpty(this._systemPrompt))
                 {
                     this.AddSystemMessage(this._systemPrompt);
+                }
+
+                // Check if AI greeting is enabled in settings
+                var settings = SmartHopperSettings.Instance;
+                if (!settings.EnableAIGreeting)
+                {
+                    // Skip greeting entirely if disabled
+                    await Application.Instance.InvokeAsync(() =>
+                    {
+                        this._statusLabel.Text = "Ready";
+                        this._progressReporter?.Invoke("Ready");
+                    });
+                    return;
                 }
 
                 // Show loading message immediately in the chat

--- a/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
@@ -63,7 +63,7 @@ namespace SmartHopper.Infrastructure.Tests
 
             public Task<AIResponse> GenerateImage(string prompt, string model = "", string size = "1024x1024", string quality = "standard", string style = "vivid") => Task.FromResult(new AIResponse { FinishReason = "error", ErrorMessage = "Test provider does not support image generation" });
 
-            public string GetDefaultModel(AIModelCapability capability) { return "dummy_test_model"; }
+            public string GetDefaultModel(AIModelCapability capability, bool useSettings = true) { return "dummy_test_model"; }
         }
 
         private class DummySettings : IAIProviderSettings

--- a/src/SmartHopper.Infrastructure/Interfaces/IAIProvider.cs
+++ b/src/SmartHopper.Infrastructure/Interfaces/IAIProvider.cs
@@ -49,7 +49,7 @@ namespace SmartHopper.Infrastructure.Interfaces
         /// <summary>
         /// Gets the default model name for the provider.
         /// </summary>
-        string GetDefaultModel(AIModelCapability requiredCapability = AIModelCapability.BasicChat);
+        string GetDefaultModel(AIModelCapability requiredCapability = AIModelCapability.BasicChat, bool useSettings = true);
 
         /// <summary>
         /// Gets a response from the AI provider.

--- a/src/SmartHopper.Infrastructure/Managers/AIProviders/AIProvider.cs
+++ b/src/SmartHopper.Infrastructure/Managers/AIProviders/AIProvider.cs
@@ -230,25 +230,28 @@ namespace SmartHopper.Infrastructure.Managers.AIProviders
             }
         }
 
-        public string GetDefaultModel(AIModelCapability requiredCapability = AIModelCapability.BasicChat)
+        public string GetDefaultModel(AIModelCapability requiredCapability = AIModelCapability.BasicChat, bool useSettings = true)
         {
             // Use settings model if matches requiredCapabilites
-            string modelFromSettings = this.GetSetting<string>("Model");
-
-            if (!string.IsNullOrWhiteSpace(modelFromSettings))
+            if (useSettings)
             {
-                if (ModelManager.ModelManager.Instance.ValidateCapabilities(this.Name, modelFromSettings, requiredCapability))
+                string modelFromSettings = this.GetSetting<string>("Model");
+
+                if (!string.IsNullOrWhiteSpace(modelFromSettings))
                 {
-                    return modelFromSettings;
+                    if (ModelManager.ModelManager.Instance.ValidateCapabilities(this.Name, modelFromSettings, requiredCapability))
+                    {
+                        return modelFromSettings;
+                    }
                 }
             }
 
             // Else, try to get default model from ModelManager that matches the required capabilities
-            string modelFromModelManager = ModelManager.ModelManager.Instance.GetDefaultModel(this.Name, requiredCapability);
+            string modelFromProviderDefault = ModelManager.ModelManager.Instance.GetDefaultModel(this.Name, requiredCapability);
 
-            if (!string.IsNullOrWhiteSpace(modelFromModelManager))
+            if (!string.IsNullOrWhiteSpace(modelFromProviderDefault))
             {
-                return modelFromModelManager;
+                return modelFromProviderDefault;
             }
 
             return null;

--- a/src/SmartHopper.Infrastructure/Settings/SmartHopperSettings.cs
+++ b/src/SmartHopper.Infrastructure/Settings/SmartHopperSettings.cs
@@ -43,6 +43,9 @@ namespace SmartHopper.Infrastructure.Settings
         [JsonProperty]
         public Dictionary<string, bool> TrustedProviders { get; set; }
 
+        [JsonProperty]
+        public bool EnableAIGreeting { get; set; }
+
         private static SmartHopperSettings _instance;
 
         public static SmartHopperSettings Instance => _instance ??= Load();
@@ -53,6 +56,7 @@ namespace SmartHopper.Infrastructure.Settings
             this.DebounceTime = 1000;
             this.DefaultAIProvider = string.Empty;
             this.TrustedProviders = new Dictionary<string, bool>();
+            this.EnableAIGreeting = true; // Default to enabled
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

This PR adds a new setting to control whether AI-generated greeting messages appear in the chat interface. Users can now enable or disable these greetings through the settings dialog.

It also forces to use the provider's default model instead of the stored in settings by user, for greetings.

## Breaking Changes

None.

## Testing Done

RH8.21 on windows.

## Checklist

- [ ] This PR is focused on a single feature or bug fix
- [ ] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [ ] CHANGELOG.md has been updated
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] PR description follows [Pull Request Description Template](#pull-request-description-template)
