### PR TITLE
refactor(model-manager): centralize model management and provider-scoped selection

### DIFF
--- a/.windsurf/rules/documentation-and-changelog.md
+++ b/.windsurf/rules/documentation-and-changelog.md
@@ -3,7 +3,7 @@ trigger: always_on
 ---
 
 # Documentation and changelog
-- IMPORTANT! Keep /docs folder up-to-date with latest changes
+- IMPORTANT! Keep /docs folder up-to-date with latest changes. KEep files in /docs organized in meaningful folders. Create an index.md in each folder. Link files using md links.
 - Log API changes in CHANGELOG.md under **Unreleased** in one of: Added, Changed, Deprecated, Removed, Fixed, Security
 - Use PR template per .github/PULL_REQUEST_TEMPLATE.md
 - Add docstrings to all members, inheritdoc when possible

--- a/.windsurf/rules/general-guidelines.md
+++ b/.windsurf/rules/general-guidelines.md
@@ -3,9 +3,34 @@ trigger: always_on
 ---
 
 # General guidelines
+
+1. Follow established best practices (e.g. SOLID, naming conventions, error handling, tests), unless explicitly asked not to.
+2. Decision matrix (in priority order):
+   1. Meets the user’s requirements
+   2. Follows best practices
+   3. Maximizes security (see OWASP Top 10)
+   4. Maximizes performance
+   5. Eases future maintenance
+3. Conduct a brief threat review on all external inputs and secrets; reference OWASP/T12 checklist.
+4. In your post-edit summary, include:
+   - Alternative solutions considered, highlighting the rationale for the chosen approach
+   - Best practices applied
+   - Suggestions for future improvements
+5. Persist rich context into the Memory DB:
+   1. Capture key docs & code snippets (with URLs & summaries)
+   2. Document high-level architecture & module roles
+   3. Record project conventions (standards, naming, structure, configs)
+   4. Log public APIs/interfaces (signatures, purpose, usage)
+   5. Archive design decisions (alternatives, rationale, commit refs)
+   6. List 3rd‑party deps & integration patterns
+   7. Store user preferences & recurring workflows
+   8. Maintain consistency: dedupe, refresh stale entries, remove obsolete
+
+# Project specific guidelines
+
 - Use native Grasshopper types & methods when possible.
 - Refer to https://developer.rhino3d.com/ as the official documentation.
 - Check /docs folder for local documentation on existing code.
 - Use English only.
-- Prefer copy/pasting, renaming, and removing files via PowerShell commands, rather than direct edits.
+- Prefer copy/pasting, renaming, and removing files via PowerShell commands.
 - You are running on Windows - use windows commands in terminal, prefered PowerShell commands.

--- a/.windsurf/workflows/deep-refactor.md
+++ b/.windsurf/workflows/deep-refactor.md
@@ -1,0 +1,6 @@
+---
+description: Instruct the AI to fully refactor code, prioritizing best quality over minimal changes
+auto_execution_mode: 1
+---
+
+We are fully refactoring the code. Do not try to make minimal targeted edits. User wants to prioritize best code quality, clear architecture, clean, simple, and easy-to-maintain code. If changes introduce breaking changes, don't worry, we'll fix them later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified logic for `AIToolCall` and `AIRequestCall` in a `AIRequestBase`.
 - `AIRequestCall`: optional parameter to process pending tool calls natively during execution.
 - Summary documentation at `docs/` (linked in README).
+- `ModelManager.SetDefault(provider, model, caps, exclusive)` helper to manage per-capability defaults.
 
 ### Changed
 
@@ -33,13 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebChatDialog: refactored to align with new base class API and recent infrastructure changes.
 - `IAIReturn.Metrics` is writable; metrics now initialized in `AIProvider.Call()` with Provider, Model, and CompletionTime.
 Providers refactored to use `AIInteractionText.SetResult(...)` for consistent content/reasoning assignment.
-- Renamed capabilities to Text2Text, ToolChat, ReasoningChat, ToolReasoningChat Text2Json, Text2Image, Text2Speech, Speech2Text and Image2Text.
- 
- ### Removed
+- Renamed capabilities to Text2Text, ToolChat, ReasoningChat, ToolReasoningChat, Text2Json, Text2Image, Text2Speech, Speech2Text and Image2Text.
+- Simplified model selection policy in `ModelManager.SelectBestModel`: capability-first ordering using defaults for requested capability → best-of-rest; removed the separate "default-compatible" tier; selection is now fully centralized in `ModelManager` with no registry-level fallback or wildcard resolution.
+- Unified model retrieval via `IAIProviderModels.RetrieveModels()` with centralized registration in `ModelManager`. Components (e.g., `AIModelsComponent`) and tests updated to query `ModelManager` instead of calling per-provider legacy methods.
+
+### Removed
 
 - Removed the `TemplateProvider` since it will be explained in documentation.
 - Removed the `ContextKeyFilter` and `ContextProviderFilter` in favor of a single `ContextFilter` that filters the providers.
 - Removed `AIToolCall.ReplaceReuseCount()` in favor of unified metrics handling.
+- Removed legacy model retrieval methods across providers/tests/docs: `RetrieveAvailable`, `RetrieveCapabilities`, and `RetrieveDefault`. Providers must expose models exclusively via `RetrieveModels()` during async initialization.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Provider-scoped model selection:
+  - Added `IAIProvider.SelectModel(requiredCapability, requestedModel)` to encapsulate model resolution behind provider interface.
+  - `AIProvider` base now implements `SelectModel(...)` delegating to centralized `ModelManager.SelectBestModel` while honoring provider defaults/settings.
+  - `AIRequestBase.GetModelToUse()` refactored to call `provider.SelectModel(...)` instead of `ModelManager.Instance` directly.
+  - Removed remaining direct calls to `ModelManager.Instance.SelectBestModel` outside provider internals.
+- Docs updated: `docs/Providers/IAIProvider.md`, `docs/Providers/AIProvider.md`, `docs/Providers/ModelSelection.md` to reflect provider-scoped model selection guidance.
+
+###! Changed
+
 - AI Chat component default system prompt to a generic one.
 - Settings dialog now organized in tabs.
   - Added tab for SmartHopper Assistant configuration (triggered from the canvas button on the top-right).
@@ -35,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IAIReturn.Metrics` is writable; metrics now initialized in `AIProvider.Call()` with Provider, Model, and CompletionTime.
 Providers refactored to use `AIInteractionText.SetResult(...)` for consistent content/reasoning assignment.
 - Renamed capabilities to Text2Text, ToolChat, ReasoningChat, ToolReasoningChat, Text2Json, Text2Image, Text2Speech, Speech2Text and Image2Text.
-- Simplified model selection policy in `ModelManager.SelectBestModel`: capability-first ordering using defaults for requested capability → best-of-rest; removed the separate "default-compatible" tier; selection is now fully centralized in `ModelManager` with no registry-level fallback or wildcard resolution.
+- - Simplified model selection policy in `ModelManager.SelectBestModel`: capability-first ordering using defaults for requested capability → best-of-rest; removed the separate "default-compatible" tier; selection is now fully centralized in `ModelManager` with no registry-level fallback or wildcard resolution.
 - Unified model retrieval via `IAIProviderModels.RetrieveModels()` with centralized registration in `ModelManager`. Components (e.g., `AIModelsComponent`) and tests updated to query `ModelManager` instead of calling per-provider legacy methods.
 
 ### Removed

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -63,8 +63,8 @@ Data flow:
 
 - Registry: `src/SmartHopper.Infrastructure/AIModels/AIModelCapabilityRegistry.cs`
   - Stores capabilities keyed by `provider.model`
-  - Exact and wildcard support (e.g., `mistral-small*`) via provider‑scoped prefix matching
-  - Default selection prioritizes concrete models over wildcards
+  - Exact name and alias matching only; no wildcard resolution in the registry
+  - Model selection and defaults are handled by `ModelManager`; the registry is storage only
 
 ## 5. Context Providers
 

--- a/docs/Providers/AIModelCapabilities.md
+++ b/docs/Providers/AIModelCapabilities.md
@@ -1,0 +1,41 @@
+# AI Model Capabilities
+
+This document describes `AIModelCapabilities` and how SmartHopper uses it to drive model selection.
+
+Location: `src/SmartHopper.Infrastructure/AIModels/AIModelCapabilities.cs`
+
+## Fields
+
+- Provider: provider id in lower-case (e.g., "openai", "mistralai").
+- Model: concrete API-ready model name (e.g., "gpt-4o-mini", "mistral-small-latest").
+- Capabilities: `AICapability` bitmask of what the model can do (e.g., Text2Text, ToolChat, Text2Image, Text2Json, ReasoningChat, etc.).
+- Default: `AICapability` bitmask of the capabilities this model is the default for.
+  - A model can be capable of multiple things but be default only for a subset.
+  - Example: `mistral-small-latest` capable of Text2Text + ToolChat, but Default only for Text2Text.
+- Verified: boolean; model is verified to work end-to-end in SmartHopper.
+- Deprecated: boolean; avoid unless selected explicitly or no better option.
+- Rank: integer tie-breaker; higher is preferred after Verified/Deprecated filters.
+- Aliases: list of alternative names resolving to this model.
+- SupportsStreaming: bool; provider supports streaming with this model.
+- SupportsPromptCaching: bool; provider supports prompt-caching with this model.
+- CacheKeyStrategy: optional provider-defined cache key hint.
+
+## Best practices
+
+- Mark at most one default per capability per provider. Use `ModelManager.SetDefault(...)` with `exclusive=true` to enforce this.
+- Keep `Model` concrete (no wildcards). Wildcards belong to registry fallback only.
+- Use `Rank` sparingly; it only fine-tunes order after Verified and non-Deprecated.
+
+## Examples
+
+- Text-only default:
+  - Capabilities: Text2Text | ToolChat
+  - Default: Text2Text
+- Tool-call default:
+  - Capabilities: Text2Text | ToolChat
+  - Default: ToolChat
+
+## See also
+
+- Model selection policy: `ModelSelection.md`
+- Manager API: `ProviderManager.md`, `AIProviderModels.md`

--- a/docs/Providers/AIModelCapabilities.md
+++ b/docs/Providers/AIModelCapabilities.md
@@ -23,7 +23,7 @@ Location: `src/SmartHopper.Infrastructure/AIModels/AIModelCapabilities.cs`
 ## Best practices
 
 - Mark at most one default per capability per provider. Use `ModelManager.SetDefault(...)` with `exclusive=true` to enforce this.
-- Keep `Model` concrete (no wildcards). Wildcards belong to registry fallback only.
+- Keep `Model` concrete (no wildcards). Use `Aliases` for alternative names; selection uses exact/alias matching only.
 - Use `Rank` sparingly; it only fine-tunes order after Verified and non-Deprecated.
 
 ## Examples

--- a/docs/Providers/AIProvider.md
+++ b/docs/Providers/AIProvider.md
@@ -21,6 +21,9 @@ Offer a template-method style pipeline for providers: register models, load sett
   - `IEnumerable<SettingDescriptor> GetSettingDescriptors()` via `ProviderManager.GetProviderSettings(Name)`.
 - Default model resolution
   - `GetDefaultModel(requiredCapability, useSettings)` validates capability with `ModelManager`.
+- Provider-scoped model selection
+  - `SelectModel(requiredCapability, requestedModel)` resolves the concrete API-ready model.
+  - Default implementation delegates to centralized `ModelManager.SelectBestModel` to keep policy consistent while hiding the singleton behind the provider interface. Providers may override.
 - HTTP/API orchestration
   - `Call(request)` handles PreCall, validation, `CallApi`, metrics, PostCall.
   - `CallApi` supports GET, POST, DELETE, PATCH, Bearer auth, JSON content.
@@ -34,7 +37,7 @@ Offer a template-method style pipeline for providers: register models, load sett
 ## Extending
 
 Override `Encode/Decode/PreCall/PostCall` and set `DefaultServerUrl`.
-Use `Models` to implement provider-specific model retrieval/capabilities.
+Use `SelectModel(...)` for model resolution in requests/components. Use `Models` to implement provider-specific retrieval/capabilities.
 
 ## Security & reliability
 

--- a/docs/Providers/AIProvider.md
+++ b/docs/Providers/AIProvider.md
@@ -11,8 +11,8 @@ Offer a template-method style pipeline for providers: register models, load sett
 ## Highlights
 
 - Initialization (`InitializeProviderAsync`)
-  - Retrieves `Models.RetrieveCapabilities()` and `RetrieveDefault()`.
-  - Registers model capabilities and defaults with `ModelManager`.
+  - Retrieves `Models.RetrieveModels()`.
+  - Registers provider models and capabilities with `ModelManager` (single source of truth).
   - Loads default setting values from descriptors and merges with stored settings.
 - Settings helpers
   - `GetSetting<T>(key)` with type conversion and recursion guard.

--- a/docs/Providers/AIProviderModels.md
+++ b/docs/Providers/AIProviderModels.md
@@ -10,18 +10,13 @@ Expose model lists, capabilities, and defaults to the provider during initializa
 
 ## Key members
 
-- `GetModel(string requestedModel = "")` — choose requested or provider default.
-- `Task<List<string>> RetrieveAvailable()` — fetch available model names (override in concrete providers).
-- `Task<Dictionary<string, AICapability>> RetrieveCapabilities()` — build capabilities map; calls `RetrieveAvailable()` and `RetrieveCapabilities(model)`.
-- `AICapability RetrieveCapabilities(string model)` — resolves concrete names via wildcard patterns.
-- `Dictionary<string, AICapability> RetrieveDefault()` — default models per capability (override to declare defaults).
+- `Task<List<AIModelCapabilities>> RetrieveModels()` — asynchronously fetch full model metadata (name, capabilities, defaults, verification, rank) for registration in `ModelManager`.
 
 ## Relationships
 
-- Used by `AIProvider.InitializeProviderAsync()` to register capabilities/defaults with `ModelManager`.
-- Works with `AIModelCapabilities` and `AIModelCapabilityRegistry` on the central registry side.
+- Used by `AIProvider.InitializeProviderAsync()` to retrieve and register provider models with `ModelManager`.
+- Works with `AIModelCapabilities` and `ModelManager` as the single source of truth.
 
 ## Notes
 
-- The base implementation returns empty lists by default; providers should override to query their APIs.
-- Wildcard matching lets providers publish patterns like `mistral-small*` while resolving concrete names at runtime.
+- Implementations should fetch concrete models and metadata from provider APIs. Registration is handled centrally by `ModelManager`.

--- a/docs/Providers/IAIProvider.md
+++ b/docs/Providers/IAIProvider.md
@@ -28,6 +28,7 @@ Provide a stable interface so components and tools can call any provider in a pr
   - `IAIReturn PostCall(IAIReturn response)`
 - Model selection
   - `string GetDefaultModel(AICapability requiredCapability = AICapability.Text2Text, bool useSettings = true)`
+  - `string SelectModel(AICapability requiredCapability, string requestedModel)`
 - Settings
   - `void RefreshCachedSettings(Dictionary<string, object> settings)`
   - `IEnumerable<SettingDescriptor> GetSettingDescriptors()`
@@ -35,7 +36,8 @@ Provide a stable interface so components and tools can call any provider in a pr
 ## Usage
 
 - Implement providers by either implementing this interface or deriving from `AIProvider`.
-- Use `Models` to resolve the model from a user request or defaults.
+- Use `SelectModel(requiredCapability, requestedModel)` to resolve the concrete, API-ready model for a request.
+- Use `GetDefaultModel(...)` only for fallback/default display purposes.
 - Implement `Encode/Decode` to translate between SmartHopper models and the provider API schema.
 - Use `PreCall/Call/PostCall` to customize end-to-end request handling.
 

--- a/docs/Providers/ModelSelection.md
+++ b/docs/Providers/ModelSelection.md
@@ -1,0 +1,70 @@
+# Model Selection Policy
+
+Location: `src/SmartHopper.Infrastructure/AIModels/ModelManager.cs`
+
+This page describes the simplified, capability-first model selection policy and how to manage defaults using `SetDefault`.
+
+## Policy (capability-first)
+
+When selecting a model for a given `provider` and `requiredCapability`:
+
+1. __User-specified model__
+   - If known and capable → use it.
+   - If unknown → pass through (assume valid upstream).
+   - Else → fallback.
+
+2. __Preferred default__ (e.g., settings) if capable.
+
+3. __Default for the requested capability__ among registered models.
+
+   - Tie-breakers:
+     - Verified: true before false.
+     - Rank: higher first.
+     - Deprecated: false before true.
+     - Name: ascending (ordinal, case-insensitive).
+
+4. __Best of the rest__: any capable model ordered by the same tie-breakers.
+
+Notes:
+
+- Models must be concrete API-ready names. No wildcard resolution.
+- Selection is fully handled by `ModelManager.SelectBestModel()`; the registry is internal for storage only.
+- The policy intentionally excludes a separate "default-compatible" tier to reduce complexity.
+
+## Is "Last Resort" necessary?
+
+Not applicable. Registry-level fallback has been removed. `ModelManager` encapsulates selection logic entirely, and `AIModelCapabilityRegistry` is internal to `ModelManager` for thread-safe storage and retrieval.
+
+## Managing defaults with SetDefault
+
+Use `ModelManager.SetDefault(provider, model, caps, exclusive = true)` to set default models per capability.
+
+- `caps` is an `AICapability` bitmask. You can set multiple capability defaults at once.
+- `exclusive = true` clears those capability bits from other models of the same provider to ensure a single default per capability.
+
+### Examples
+
+```csharp
+// Make mistral-small-latest the default for Text2Text
+ModelManager.Instance.SetDefault("mistralai", "mistral-small-latest", AICapability.Text2Text);
+
+// Make gpt-4o-mini the default for ToolChat and Text2Json, exclusively
+ModelManager.Instance.SetDefault(
+    "openai",
+    "gpt-4o-mini",
+    AICapability.ToolChat | AICapability.Text2Json,
+    exclusive: true
+);
+```
+
+## Tie-breaker guidance
+
+- __Verified__: mark true only after end-to-end success within SmartHopper.
+- __Deprecated__: set true to steer selection away unless explicitly chosen or no alternatives exist.
+- __Rank__: use to fine-tune preference among similar verified, non-deprecated models.
+
+## Related docs
+
+- `AIModelCapabilities` model: `AIModelCapabilities.md`
+- Providers integration: `AIProviderModels.md`, `ProviderManager.md`
+- AICall module: `Providers/AICall/index.md`

--- a/docs/Providers/ModelSelection.md
+++ b/docs/Providers/ModelSelection.md
@@ -4,6 +4,11 @@ Location: `src/SmartHopper.Infrastructure/AIModels/ModelManager.cs`
 
 This page describes the simplified, capability-first model selection policy and how to manage defaults using `SetDefault`.
 
+## Callers: how to select a model
+
+- Always call `provider.SelectModel(requiredCapability, requestedModel)`.
+- Do not call `ModelManager.SelectBestModel` directly from requests/components. The provider base class delegates to it internally by default, keeping policy centralized while maintaining proper abstraction.
+
 ## Policy (capability-first)
 
 When selecting a model for a given `provider` and `requiredCapability`:
@@ -28,7 +33,7 @@ When selecting a model for a given `provider` and `requiredCapability`:
 Notes:
 
 - Models must be concrete API-ready names. No wildcard resolution.
-- Selection is fully handled by `ModelManager.SelectBestModel()`; the registry is internal for storage only.
+- Selection is fully handled by `ModelManager.SelectBestModel()`; the registry is internal for storage only. Callers should go through `IAIProvider.SelectModel(...)`.
 - The policy intentionally excludes a separate "default-compatible" tier to reduce complexity.
 
 ## Is "Last Resort" necessary?

--- a/docs/Providers/ModelSelection.md
+++ b/docs/Providers/ModelSelection.md
@@ -28,13 +28,14 @@ When selecting a model for a given `provider` and `requiredCapability`:
      - Deprecated: false before true.
      - Name: ascending (ordinal, case-insensitive).
 
-4. __Best of the rest__: any capable model ordered by the same tie-breakers.
+4. __Default-compatible__: any model marked as default for other capabilities but still compatible with the required capability, ordered by the same tie-breakers.
+
+5. __Best of the rest__: any capable model ordered by the same tie-breakers.
 
 Notes:
 
 - Models must be concrete API-ready names. No wildcard resolution.
 - Selection is fully handled by `ModelManager.SelectBestModel()`; the registry is internal for storage only. Callers should go through `IAIProvider.SelectModel(...)`.
-- The policy intentionally excludes a separate "default-compatible" tier to reduce complexity.
 
 ## Is "Last Resort" necessary?
 

--- a/docs/Providers/index.md
+++ b/docs/Providers/index.md
@@ -43,3 +43,5 @@ Providers implement API-specific logic while conforming to a common contract so 
 - [IAIProviderSettings](./IAIProviderSettings.md)
 - [AIProviderSettings](./AIProviderSettings.md)
 - [AICall](./AICall/index.md)
+- [AIModelCapabilities](./AIModelCapabilities.md)
+- [Model Selection Policy](./ModelSelection.md)

--- a/docs/Suggestions.md
+++ b/docs/Suggestions.md
@@ -1,0 +1,174 @@
+# Architecture Suggestions (SmartHopper)
+
+This document outlines an idealized refactoring to centralize concerns, reduce duplication, and improve reliability across SmartHopper. It complements existing docs under `docs/Providers/`, `docs/Components/`, `docs/Context/`, and `docs/Tools/`.
+
+Breaking changes are acceptable; this is a forward-looking plan.
+
+## Guiding principles
+
+- Single responsibility per module; move cross-cutting logic to reusable services.
+- Provider-agnostic orchestration in Infrastructure; provider specifics isolated in `SmartHopper.Providers.*`.
+- Immutable core data structures with builders for composition.
+- Explicit, composable policies for validation, security, retries, and telemetry.
+
+## Current strengths (to keep)
+
+- Template-method provider pipeline (`PreCall → FormatRequestBody → CallApi → PostCall`) in `AIProvider`.
+- Central capability registry and model resolution (`ModelManager`, `AIModelCapabilityRegistry`).
+- Context injection at request level (`AIBody`), component base classes, and secure provider loading.
+
+## Pain points to address
+
+- Multi-turn/tool orchestration repeated in components.
+- Tool result shapes normalized by convention, not centrally enforced.
+- Schema wrapping/unwrapping differs across providers.
+- Metrics/progress logic scattered between bases and components.
+- Model selection fallback logic appears in multiple places.
+- GH-specific tool code mixed with generic tool runtime concerns.
+- Validation split across tools/components without a uniform pipeline.
+
+## Suggestions (independently applicable)
+
+### Suggestion 1 — ConversationSession (central multi‑turn engine)
+
+- New service in `src/SmartHopper.Infrastructure/AICall/ConversationSession/`.
+- API: `Start(AIBody|AIBodyBuilder)`, `RunToStableResult(options)`, `Stream(observer)`, `ProcessPendingTools(policy)`.
+- Handles assistant → tool_call → tool_result → assistant loops with proper linking and retries.
+- Components call `ConversationSession.RunToStableResult()` instead of hand‑written loops.
+- Stream‑first friendly: integrates `IStreamingAdapter` to emit partials and support backpressure; components can opt‑in to incremental UI updates.
+- Cache‑aware hooks: exposes request/response fingerprints so Policies can leverage provider prompt caching (e.g., cache keys/ETags) and local memoization.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/ConversationSession/`, `src/SmartHopper.Core/ComponentBase/`, Providers under `src/SmartHopper.Providers.*`
+- Phased migration plan:
+  1. Introduce `ConversationSession` + basic Policies behind `AIRequestCall` (no component changes yet).
+  2. Add streaming adapter; expose via `ConversationSession`.
+- Remember to test... Contract tests for `ConversationSession` transcripts with fake providers/tools.
+- Remember to update documentation in... `docs/Providers/ConversationSession.md`, `docs/Providers/AICall/Policies.md`, `docs/Providers/AICall/index.md`
+
+### Suggestion 2 — Unified Model Management & Selection
+
+- Replace the current 3‑step model registration (available/capabilities/defaults) with a single declarative model descriptor per provider.
+- Introduce `AIModel` descriptor managed by `ModelManager`:
+  - `string Name`
+  - `string Provider`
+  - `AICapability Capabilities` (flags)
+  - `AIModelDefaultSelector DefaultFor` (optional) — indicates default usage, e.g. Text2Text, Text2Json, ToolChat, ImageOutput. Multiple allowed.
+  - Optional metadata: `Rank` (tie‑break), `Deprecated`, `Aliases`.
+- Providers expose a list of `AIModel` items (static or API‑fetched) instead of calling three separate registration methods. Example: `OpenAIProviderModels.List()` returns descriptors and `ModelManager` ingests them.
+- Make `AIRequestBase.GetModelToUse()` the single authority for model fallback with this algorithm:
+  1) Use user‑specified model from component if provided (verbatim).
+  2) Else, use provider default model (`DefaultFor` includes a general default like Text2Text) for the current provider.
+  3) Verify required capabilities (`AICapability` set on the request) against the chosen model.
+  4) If not compatible, select the provider’s best default capable model (prefer concrete names; fall back to most specific wildcard/alias; use `Rank` as tie‑break).
+  5) If none found, return a failure with actionable message listing compatible candidates.
+- Thread‑safety requirements:
+  - `ModelManager` and `AIModelCapabilityRegistry` use immutable snapshots for reads and a `ReaderWriterLockSlim` (or similar) for writes.
+  - Public getters return read‑only collections; updates replace the snapshot atomically.
+  - No sync‑over‑async; API discovery performed async and merged on completion.
+- Component guidance:
+  - Components should pass the user’s model input if present; otherwise pass empty and delegate selection to `GetModelToUse()`.
+  - Remove all per‑component fallback chains and capability checks; rely on centralized selection + validation.
+- Forward‑compat metadata: allow descriptors to declare `SupportsStreaming`, `SupportsPromptCaching`, and provider cache semantics (e.g., cache key strategies) to influence selection when features are requested.
+- Impacted areas: Providers under `src/SmartHopper.Providers.*`
+- Phased migration plan:
+  1. Unified model management: introduce `AIModel` descriptors, refactor providers to return descriptor lists, and make `AIRequestBase.GetModelToUse()` the sole authority. Remove all component fallbacks. Ensure `ModelManager`/`AIModelCapabilityRegistry` are thread‑safe.
+- Remember to test... Regression tests for model selection priority and capability validation.
+- Remember to update documentation in... `docs/Providers/index.md`, `docs/Architecture.md`
+
+### Suggestion 3 — Request/Response policy pipeline
+
+- Policies under `src/SmartHopper.Infrastructure/AICall/Policies/`:
+  - Request: context injection, prompt templating, capability validation, schema attach, moderation, retries/backoff, provider prompt‑cache tags/ETags when available.
+  - Response: decoding, schema validation, post‑parse validators, redaction, telemetry, local response caching with TTL and invalidation keyed by `AIBody` fingerprint and external resource hashes.
+- Middleware‑style composition for uniform cross‑cutting behavior.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/Policies/`
+- Phased migration plan:
+  1. Introduce `ConversationSession` + basic Policies behind `AIRequestCall` (no component changes yet).
+  2. Introduce `IValidator<T>` chains; move GH validations into validators.
+- Remember to test... Policy pipeline unit tests (retry, redaction, schema attach/validate).
+- Remember to update documentation in... `docs/Providers/AICall/Policies.md`, `docs/Providers/AICall/index.md`
+
+### Suggestion 4 — JsonSchemaService
+
+- Centralize schema wrapping/unwrapping and validation for all providers.
+- Helpers for common shapes: `List<T>`, `ImageResult`, `GhJsonSpec`.
+- Removes provider divergence for non‑object schemas.
+- GHJSON pipeline helpers: generation/validation utilities for GH definitions and adapters to support saving Grasshopper files in GHJSON format.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/JsonSchemaService/`, Providers under `src/SmartHopper.Providers.*`
+- Phased migration plan:
+  1. Add `JsonSchemaService`; remove provider-specific schema quirks gradually.
+- Remember to test... Policy pipeline unit tests (schema attach/validate).
+- Remember to update documentation in... `docs/Providers/JsonSchemaService.md`, `docs/Providers/AICall/index.md`
+
+### Suggestion 5 — Tool Runtime decoupling + ToolResultNormalizer
+
+- Move generic tool contracts/execution to `src/SmartHopper.Infrastructure/AITools/`.
+- Keep GH adapters in `src/SmartHopper.Core.Grasshopper/AITools/`.
+- `ToolResultNormalizer.Normalize(toolName, JObject)` guarantees consistent top‑level keys and error envelope.
+- Define AI tool(s) for GH authoring: e.g., `gh_generate_definition` producing a `GhJsonSpec`, plus adapters/utilities to save/export GH in GHJSON safely.
+- Impacted areas: `src/SmartHopper.Infrastructure/AITools/`, `src/SmartHopper.Core.Grasshopper/AITools/`
+- Phased migration plan:
+  1. Extract Tool Runtime core; add `ToolResultNormalizer`; keep GH adapters.
+- Remember to test... ToolResultNormalizer shape tests.
+- Remember to update documentation in... `docs/Tools/Runtime.md`, `docs/Components/index.md`
+
+### Suggestion 6 — AIBody immutability via builder
+
+- Replace mutable `AIBody` with immutable value + `AIBodyBuilder`.
+- Context injection handled by policies, not `Interactions` getter side‑effects.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/`, `src/SmartHopper.Core/ComponentBase/`
+- Phased migration plan:
+  1. Switch to `AIBodyBuilder` and immutable `AIBody`; provide shims for old code.
+- Remember to test... Policy pipeline unit tests (schema attach/validate).
+- Remember to update documentation in... `docs/Providers/AICall/index.md`, `docs/Providers/AICall/body-metrics-status.md`
+
+### Suggestion 7 — Metrics & progress services
+
+- `AIMetricsService` and `ProgressService` aggregate per‑call and session metrics.
+- Debounce/progress UX unified; components subscribe for updates.
+- Streaming/caching metrics: time‑to‑first‑token, partial throughput, cache hit/miss rates, and provider cache usage diagnostics.
+- Impacted areas: `src/SmartHopper.Core/ComponentBase/`
+- Phased migration plan:
+  1. Centralize metrics/progress; eliminate bespoke component logic.
+- Remember to test... Policy pipeline unit tests.
+- Remember to update documentation in... `docs/Providers/AICall/body-metrics-status.md`, `docs/Components/index.md`
+
+### Suggestion 8 — Validation pipeline with typed validators
+
+- `IValidator<T>` chains for request, response, and tools.
+- GH‑specific validators (e.g., GhJSON) live in `SmartHopper.Core.Grasshopper` and plug into the pipeline.
+- Impacted areas: `src/SmartHopper.Core.Grasshopper/AITools/`, `src/SmartHopper.Infrastructure/AICall/Policies/`
+- Phased migration plan:
+  1. Introduce `IValidator<T>` chains; move GH validations into validators.
+- Remember to test... Policy pipeline unit tests (validate).
+- Remember to update documentation in... `docs/Providers/AICall/Policies.md`, `docs/Components/index.md`
+
+### Suggestion 9 — Streaming adapter
+
+- `IStreamingAdapter` unifies stream events (partials, tool proposals, final) across providers.
+- Exposed via `ConversationSession.Stream()`.
+- Support backpressure and cancellation propagation; optional buffering policies for UI friendliness.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/ConversationSession/`, Providers under `src/SmartHopper.Providers.*`
+- Phased migration plan:
+  1. Add streaming adapter; expose via `ConversationSession`.
+- Remember to test... Contract tests for `ConversationSession` transcripts with fake providers/tools.
+- Remember to update documentation in... `docs/Providers/ConversationSession.md`
+
+### Suggestion 10 — Security & data egress controls
+
+- Redaction policies for requests/responses; tool egress allowlists.
+- Schema whitelisting/catalog for `JsonOutputSchema`.
+- Per‑tool quotas, timeouts, and cancellation.
+- Impacted areas: `src/SmartHopper.Infrastructure/AICall/Policies/`, Providers under `src/SmartHopper.Providers.*`
+- Phased migration plan:
+  1. Enable default security policies (least privilege), opt‑in broader access.
+- Remember to test... Policy pipeline unit tests (redaction).
+- Remember to update documentation in... `docs/Providers/AICall/Policies.md`, `docs/Architecture.md`
+
+## Future thoughts (suggestions should consider future conditions and try to be flexible to accept them in the future)
+
+- [ ] Provider streaming of responses
+- [ ] Provider-side prompt caching
+- [ ] Local caching of responses to avoid recomputation
+- [ ] AI tool to generate Grasshopper definitions in GHJSON format
+- [ ] New way to save Grasshopper files in GHJSON format
+- [ ] Improve WebChat UI with full html environment, including dynamic loading messages supporting streaming

--- a/src/SmartHopper.Components/AI/AIChatComponent.cs
+++ b/src/SmartHopper.Components/AI/AIChatComponent.cs
@@ -163,7 +163,7 @@ namespace SmartHopper.Components.AI
         /// <summary>
         /// Worker class for the AI Chat component.
         /// </summary>
-        private class AIChatWorker : AsyncWorkerBase
+        private sealed class AIChatWorker : AsyncWorkerBase
         {
             private readonly AIChatComponent component;
             private readonly Action<string> progressReporter;

--- a/src/SmartHopper.Components/AI/AIModelsComponent.cs
+++ b/src/SmartHopper.Components/AI/AIModelsComponent.cs
@@ -137,11 +137,11 @@ namespace SmartHopper.Components.AI
                         return;
                     }
 
-                    // Ensure provider is initialized so models get registered into ModelManager (idempotent)
+                    // Initialize provider (ensures settings and provider state are ready)
                     await provider.InitializeProviderAsync().ConfigureAwait(false);
 
-                    // Retrieve registered models from ModelManager
-                    var caps = ModelManager.Instance.GetProviderModels(provider.Name) ?? new List<AIModelCapabilities>();
+                    // Retrieve models directly from the provider (no global singleton)
+                    var caps = await provider.Models.RetrieveModels().ConfigureAwait(false) ?? new List<AIModelCapabilities>();
                     if (caps == null || caps.Count == 0)
                     {
                         this._result["Success"] = false;

--- a/src/SmartHopper.Components/AI/AIModelsComponent.cs
+++ b/src/SmartHopper.Components/AI/AIModelsComponent.cs
@@ -19,6 +19,7 @@ using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using SmartHopper.Components.Properties;
 using SmartHopper.Core.ComponentBase;
+using SmartHopper.Infrastructure.AIModels;
 
 namespace SmartHopper.Components.AI
 {
@@ -136,9 +137,12 @@ namespace SmartHopper.Components.AI
                         return;
                     }
 
-                    // Retrieve available models
-                    var models = await provider.Models.RetrieveAvailable().ConfigureAwait(false);
-                    if (models == null || !models.Any())
+                    // Ensure provider is initialized so models get registered into ModelManager (idempotent)
+                    await provider.InitializeProviderAsync().ConfigureAwait(false);
+
+                    // Retrieve registered models from ModelManager
+                    var caps = ModelManager.Instance.GetProviderModels(provider.Name) ?? new List<AIModelCapabilities>();
+                    if (caps == null || caps.Count == 0)
                     {
                         this._result["Success"] = false;
                         this._result["Error"] = "No models available from the selected provider";
@@ -148,7 +152,12 @@ namespace SmartHopper.Components.AI
                     // Convert to GH_Structure for output
                     var tree = new GH_Structure<GH_String>();
                     var path = new GH_Path(0);
-                    foreach (var model in models)
+                    foreach (var model in caps
+                        .OrderByDescending(m => m.Verified)
+                        .ThenByDescending(m => m.Rank)
+                        .ThenBy(m => m.Deprecated)
+                        .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                        .Select(m => m.Model))
                     {
                         tree.Append(new GH_String(model), path);
                     }

--- a/src/SmartHopper.Components/Grasshopper/GhGetComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhGetComponents.cs
@@ -68,21 +68,21 @@ namespace SmartHopper.Components.Grasshopper
 
             if (!(runObject is GH_Boolean run))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Run must be a boolean");
+                this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Run must be a boolean");
                 return;
             }
 
             if (!run.Value)
             {
-                if (lastComponentNames.Count > 0)
+                if (this.lastComponentNames.Count > 0)
                 {
-                    DA.SetDataList(0, lastComponentNames);
-                    DA.SetDataList(1, lastComponentGuids);
-                    DA.SetData(2, lastJsonOutput);
+                    DA.SetDataList(0, this.lastComponentNames);
+                    DA.SetDataList(1, this.lastComponentGuids);
+                    DA.SetData(2, this.lastJsonOutput);
                 }
                 else
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Set Run to True to execute the component");
+                    this.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Set Run to True to execute the component");
                 }
 
                 return;
@@ -124,15 +124,15 @@ namespace SmartHopper.Components.Grasshopper
                 var toolResult = toolResultInteraction?.Result;
                 if (toolResult == null)
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Tool 'gh_get' did not return a valid result");
+                    this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Tool 'gh_get' did not return a valid result");
                     return;
                 }
                 var componentNames = toolResult["names"]?.ToObject<List<string>>() ?? new List<string>();
                 var componentGuids = toolResult["guids"]?.ToObject<List<string>>() ?? new List<string>();
                 var json = toolResult["json"]?.ToString() ?? string.Empty;
-                lastComponentNames = componentNames;
-                lastComponentGuids = componentGuids;
-                lastJsonOutput = json;
+                this.lastComponentNames = componentNames;
+                this.lastComponentGuids = componentGuids;
+                this.lastJsonOutput = json;
                 DA.SetDataList(0, componentNames);
                 DA.SetDataList(1, componentGuids);
                 DA.SetData(2, json);
@@ -140,7 +140,7 @@ namespace SmartHopper.Components.Grasshopper
             }
             catch (Exception ex)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+                this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
             }
         }
     }

--- a/src/SmartHopper.Components/Grasshopper/GhPutComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhPutComponents.cs
@@ -136,10 +136,11 @@ namespace SmartHopper.Components.Grasshopper
                         }
                         else if (trimmed.StartsWith("- "))
                         {
-                            AddRuntimeMessage(currentLevel, trimmed.Substring(2));
+                            this.AddRuntimeMessage(currentLevel, trimmed.Substring(2));
                         }
                     }
                 }
+
                 if (!success) return;
 
                 // 5. Extract and output component names

--- a/src/SmartHopper.Components/Grasshopper/GhRetrieveComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhRetrieveComponents.cs
@@ -67,17 +67,17 @@ namespace SmartHopper.Components.Grasshopper
 
             if (!run)
             {
-                if (lastNames.Count > 0)
+                if (this.lastNames.Count > 0)
                 {
-                    DA.SetDataList(0, lastNames);
-                    DA.SetDataList(1, lastGuids);
-                    DA.SetData(2, lastJson);
+                    DA.SetDataList(0, this.lastNames);
+                    DA.SetDataList(1, this.lastGuids);
+                    DA.SetData(2, this.lastJson);
                 }
                 else
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark,
-                        "Set Run to True to execute the component");
+                    this.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Set Run to True to execute the component");
                 }
+
                 return;
             }
 
@@ -106,7 +106,7 @@ namespace SmartHopper.Components.Grasshopper
                 var toolResult = toolResultInteraction?.Result;
                 if (toolResult == null)
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error,
+                    this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error,
                         "Tool 'gh_list_components' did not return a valid result");
                     return;
                 }
@@ -115,9 +115,9 @@ namespace SmartHopper.Components.Grasshopper
                 var guids = toolResult["guids"]?.ToObject<List<string>>() ?? new List<string>();
                 var json = toolResult["json"]?.ToString() ?? string.Empty;
 
-                lastNames = names;
-                lastGuids = guids;
-                lastJson = json;
+                this.lastNames = names;
+                this.lastGuids = guids;
+                this.lastJson = json;
 
                 DA.SetDataList(0, names);
                 DA.SetDataList(1, guids);
@@ -125,7 +125,7 @@ namespace SmartHopper.Components.Grasshopper
             }
             catch (Exception ex)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+                this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
             }
         }
     }

--- a/src/SmartHopper.Components/Grasshopper/GhTidyUpComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhTidyUpComponents.cs
@@ -102,21 +102,21 @@ namespace SmartHopper.Components.Grasshopper
 
             if (!(runObj is GH_Boolean run))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Run must be a boolean");
+                this.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Run must be a boolean");
                 return;
             }
 
             if (!run.Value)
             {
-                if (LastErrors.Count > 0)
-                    DA.SetDataList(0, LastErrors);
+                if (this.LastErrors.Count > 0)
+                    DA.SetDataList(0, this.LastErrors);
                 else
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Set Run to True to execute tidy up");
+                    this.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Set Run to True to execute tidy up");
                 return;
             }
 
-            LastErrors.Clear();
-            var guids = SelectedObjects.Select(o => o.InstanceGuid.ToString()).ToList();
+            this.LastErrors.Clear();
+            var guids = this.SelectedObjects.Select(o => o.InstanceGuid.ToString()).ToList();
             if (!guids.Any())
             {
                 this.LastErrors.Add("No components selected");
@@ -162,9 +162,9 @@ namespace SmartHopper.Components.Grasshopper
             }
             catch (Exception ex)
             {
-                LastErrors.Add(ex.Message);
+                this.LastErrors.Add(ex.Message);
             }
-            DA.SetDataList(0, LastErrors);
+            DA.SetDataList(0, this.LastErrors);
         }
     }
 }

--- a/src/SmartHopper.Components/Img/AIImgGenerateComponent.cs
+++ b/src/SmartHopper.Components/Img/AIImgGenerateComponent.cs
@@ -238,17 +238,17 @@ namespace SmartHopper.Components.Img
                                 {
                                     // Get the image result (could be URL or base64 data)
                                     string imageResult = toolResult["result"]?.ToString() ?? string.Empty;
-                                    
+
                                     // Get revised prompt - now returned directly from new schema
                                     string revisedPrompt = toolResult["revisedPrompt"]?.ToString() ?? prompt;
-                                    
+
                                     // Process the image result (URL or base64)
                                     if (!string.IsNullOrEmpty(imageResult))
                                     {
                                         try
                                         {
                                             Bitmap bitmap;
-                                            
+
                                             // Check if it's a URL or base64 data
                                             if (imageResult.StartsWith("http://") || imageResult.StartsWith("https://"))
                                             {
@@ -268,7 +268,7 @@ namespace SmartHopper.Components.Img
                                                 using var stream = new MemoryStream(imageBytes);
                                                 bitmap = new Bitmap(stream);
                                             }
-                                            
+
                                             // Wrap the bitmap in a Grasshopper-compatible image object
                                             branchResults.Add(new GH_ObjectWrapper(bitmap));
                                             branchRevisedPrompts.Add(new GH_String(revisedPrompt));

--- a/src/SmartHopper.Components/List/AIListEvaluate.cs
+++ b/src/SmartHopper.Components/List/AIListEvaluate.cs
@@ -57,7 +57,7 @@ namespace SmartHopper.Components.List
             return new AIListEvaluateWorker(this, this.AddRuntimeMessage);
         }
 
-        private class AIListEvaluateWorker : AsyncWorkerBase
+        private sealed class AIListEvaluateWorker : AsyncWorkerBase
         {
             private Dictionary<string, GH_Structure<GH_String>> inputTree;
             private Dictionary<string, GH_Structure<GH_Boolean>> result;

--- a/src/SmartHopper.Components/List/AIListFilter.cs
+++ b/src/SmartHopper.Components/List/AIListFilter.cs
@@ -57,7 +57,7 @@ namespace SmartHopper.Components.List
             return new AIListFilterWorker(this, this.AddRuntimeMessage);
         }
 
-        private class AIListFilterWorker : AsyncWorkerBase
+        private sealed class AIListFilterWorker : AsyncWorkerBase
         {
             private Dictionary<string, GH_Structure<GH_String>> inputTree;
             private Dictionary<string, GH_Structure<GH_String>> result;

--- a/src/SmartHopper.Components/Text/AITextEvaluate.cs
+++ b/src/SmartHopper.Components/Text/AITextEvaluate.cs
@@ -56,7 +56,7 @@ namespace SmartHopper.Components.Text
             return new AITextEvaluateWorker(this, this.AddRuntimeMessage);
         }
 
-        private class AITextEvaluateWorker : AsyncWorkerBase
+        private sealed class AITextEvaluateWorker : AsyncWorkerBase
         {
             private readonly AITextEvaluate parent;
             private Dictionary<string, GH_Structure<GH_String>> inputTree;

--- a/src/SmartHopper.Components/Text/AITextGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextGenerate.cs
@@ -56,7 +56,7 @@ namespace SmartHopper.Components.Text
             return new AITextGenerateWorker(this, this.AddRuntimeMessage);
         }
 
-        private class AITextGenerateWorker : AsyncWorkerBase
+        private sealed class AITextGenerateWorker : AsyncWorkerBase
         {
             private Dictionary<string, GH_Structure<GH_String>> inputTree;
             private Dictionary<string, GH_Structure<GH_String>> result;

--- a/src/SmartHopper.Components/Text/AITextListGenerate.cs
+++ b/src/SmartHopper.Components/Text/AITextListGenerate.cs
@@ -57,7 +57,7 @@ namespace SmartHopper.Components.Text
             return new AITextListGenerateWorker(this, this.AddRuntimeMessage);
         }
 
-        private class AITextListGenerateWorker : AsyncWorkerBase
+        private sealed class AITextListGenerateWorker : AsyncWorkerBase
         {
             private Dictionary<string, GH_Structure<GH_String>> inputTree;
             private Dictionary<string, GH_Structure<GH_String>> result;

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
@@ -26,6 +26,7 @@ using Grasshopper.Kernel.Types;
 using Newtonsoft.Json.Linq;
 using SmartHopper.Infrastructure.AICall;
 using SmartHopper.Infrastructure.AITools;
+using SmartHopper.Infrastructure.AIModels;
 
 namespace SmartHopper.Core.ComponentBase
 {
@@ -144,9 +145,16 @@ namespace SmartHopper.Core.ComponentBase
                 return string.Empty;
             }
 
-            string actualModel = provider.Models.GetModel(model);
+            // If user specified a model, pass it through
+            if (!string.IsNullOrWhiteSpace(model))
+            {
+                return model;
+            }
 
-            return actualModel;
+            // Otherwise use centralized default selection via ModelManager
+            var providerName = provider.Name;
+            var selected = ModelManager.Instance.GetDefaultModel(providerName, AICapability.Text2Text);
+            return selected ?? string.Empty;
         }
 
         #endregion

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
@@ -25,8 +25,8 @@ using Grasshopper.Kernel.Data;
 using Grasshopper.Kernel.Types;
 using Newtonsoft.Json.Linq;
 using SmartHopper.Infrastructure.AICall;
-using SmartHopper.Infrastructure.AITools;
 using SmartHopper.Infrastructure.AIModels;
+using SmartHopper.Infrastructure.AITools;
 
 namespace SmartHopper.Core.ComponentBase
 {

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.cs
@@ -151,9 +151,8 @@ namespace SmartHopper.Core.ComponentBase
                 return model;
             }
 
-            // Otherwise use centralized default selection via ModelManager
-            var providerName = provider.Name;
-            var selected = ModelManager.Instance.GetDefaultModel(providerName, AICapability.Text2Text);
+            // Otherwise, use provider-level default resolution (respects settings and capabilities)
+            var selected = provider.GetDefaultModel(AICapability.Text2Text, useSettings: true);
             return selected ?? string.Empty;
         }
 

--- a/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
@@ -72,6 +72,14 @@ namespace SmartHopper.Infrastructure.Tests
 
             public string GetDefaultModel(AICapability requiredCapability = AICapability.Text2Text, bool useSettings = true) => "dummy_test_model";
 
+            public string SelectModel(AICapability requiredCapability, string requestedModel)
+            {
+                // For tests, prefer requested model when provided; otherwise fall back to default.
+                return string.IsNullOrEmpty(requestedModel)
+                    ? this.GetDefaultModel(requiredCapability, useSettings: true)
+                    : requestedModel;
+            }
+
             public void RefreshCachedSettings(Dictionary<string, object> settings)
             {
             }

--- a/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs
@@ -35,7 +35,12 @@ namespace SmartHopper.Infrastructure.Tests
 
             public async Task InitializeProviderAsync()
             {
-                await Task.CompletedTask;
+                // Register dummy models into ModelManager following the new unified flow
+                var models = await this.Models.RetrieveModels().ConfigureAwait(false);
+                foreach (var m in models)
+                {
+                    ModelManager.Instance.SetCapabilities(m);
+                }
             }
 
             public DummyProvider()
@@ -76,41 +81,29 @@ namespace SmartHopper.Infrastructure.Tests
 
         private class DummyProviderModels : IAIProviderModels
         {
-            public string GetModel(string requestedModel = "")
+            public async Task<List<AIModelCapabilities>> RetrieveModels()
             {
-                return string.IsNullOrEmpty(requestedModel) ? "dummy_model_1" : requestedModel;
-            }
-
-            public async Task<List<string>> RetrieveAvailable()
-            {
-                return await Task.FromResult(new List<string> { "dummy_model_1", "dummy_model_2" });
-            }
-
-            public async Task<Dictionary<string, AICapability>> RetrieveCapabilities()
-            {
-                return await Task.FromResult(new Dictionary<string, AICapability>
+                var list = new List<AIModelCapabilities>
                 {
-                    ["dummy_model_1"] = AICapability.Text2Text,
-                    ["dummy_model_2"] = AICapability.TextInput | AICapability.TextOutput
-                });
-            }
-
-            public AICapability RetrieveCapabilities(string model)
-            {
-                var capabilities = new Dictionary<string, AICapability>
-                {
-                    ["dummy_model_1"] = AICapability.Text2Text,
-                    ["dummy_model_2"] = AICapability.TextInput | AICapability.TextOutput
+                    new AIModelCapabilities
+                    {
+                        Provider = "dummyprovider",
+                        Model = "dummy_model_1",
+                        Capabilities = AICapability.Text2Text,
+                        Default = AICapability.Text2Text,
+                        Verified = true,
+                        Rank = 10,
+                    },
+                    new AIModelCapabilities
+                    {
+                        Provider = "dummyprovider",
+                        Model = "dummy_model_2",
+                        Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                        Verified = false,
+                        Rank = 0,
+                    }
                 };
-                return capabilities.TryGetValue(model, out var capability) ? capability : AICapability.None;
-            }
-
-            public Dictionary<string, AICapability> RetrieveDefault()
-            {
-                return new Dictionary<string, AICapability>
-                {
-                    ["dummy_model_1"] = AICapability.Text2Text
-                };
+                return await Task.FromResult(list);
             }
         }
 

--- a/src/SmartHopper.Infrastructure.Tests/ModelManagerTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/ModelManagerTests.cs
@@ -53,7 +53,7 @@ namespace SmartHopper.Infrastructure.Tests
 
             // Assert
             Assert.Same(instance1, instance2);
-            Assert.NotNull(instance1.Registry);
+            Assert.NotNull(instance1);
         }
 
         /// <summary>

--- a/src/SmartHopper.Infrastructure/AICall/AIRequestBase.cs
+++ b/src/SmartHopper.Infrastructure/AICall/AIRequestBase.cs
@@ -117,11 +117,8 @@ namespace SmartHopper.Infrastructure.AICall
                 return string.Empty;
             }
 
-            // Use provider settings default as preferred fallback
-            var preferredDefault = provider.GetDefaultModel(this.Capability, useSettings: true);
-
-            // Centralized selection & fallback in ModelManager
-            var selected = ModelManager.Instance.SelectBestModel(provider.Name, this.model, this.Capability, preferredDefault);
+            // Delegate selection to provider to hide singleton and centralize policy
+            var selected = provider.SelectModel(this.Capability, this.model);
             return selected;
         }
     }

--- a/src/SmartHopper.Infrastructure/AICall/AIRequestBase.cs
+++ b/src/SmartHopper.Infrastructure/AICall/AIRequestBase.cs
@@ -103,7 +103,10 @@ namespace SmartHopper.Infrastructure.AICall
         {
             if (this.Capability == AICapability.None)
             {
-                return string.Empty;
+                // No capability context has been set yet (e.g., intermediary tool calls reading Model).
+                // In this case, do NOT override: return the user-requested model verbatim.
+                // Model selection (validation/fallback) must happen only when a capability is known.
+                return this.model ?? string.Empty;
             }
             
             if (string.IsNullOrEmpty(this.Provider))

--- a/src/SmartHopper.Infrastructure/AIModels/AICapability.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/AICapability.cs
@@ -10,12 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using SmartHopper.Infrastructure.AIProviders;
 
 namespace SmartHopper.Infrastructure.AIModels
 {
@@ -26,23 +20,23 @@ namespace SmartHopper.Infrastructure.AIModels
     public enum AICapability
     {
         None = 0,
-        
+
         // Input capabilities
         TextInput = 1 << 0,
         ImageInput = 1 << 1,
         AudioInput = 1 << 2,
         JsonInput = 1 << 3,
-        
+
         // Output capabilities
         TextOutput = 1 << 4,
         ImageOutput = 1 << 5,
         AudioOutput = 1 << 6,
         JsonOutput = 1 << 7,
-        
+
         // Advanced capabilities
         FunctionCalling = 1 << 8,
         Reasoning = 1 << 9,
-        
+
         // Composite capabilities for default definition
         Text2Text = TextInput | TextOutput,
         ToolChat = Text2Text | FunctionCalling,
@@ -53,6 +47,7 @@ namespace SmartHopper.Infrastructure.AIModels
         Text2Speech = TextInput | AudioOutput,
         Speech2Text = AudioInput | TextOutput,
         Image2Text = ImageInput | TextOutput,
+        Image2Image = ImageInput | ImageInput | ImageOutput,
     }
 
     /// <summary>
@@ -73,44 +68,53 @@ namespace SmartHopper.Infrastructure.AIModels
             }
 
             var flags = new List<string>();
-            
+
             // Check each individual flag
             if ((capabilities & AICapability.TextInput) == AICapability.TextInput)
             {
                 flags.Add("TextInput");
             }
+
             if ((capabilities & AICapability.TextOutput) == AICapability.TextOutput)
             {
                 flags.Add("TextOutput");
             }
+
             if ((capabilities & AICapability.ImageInput) == AICapability.ImageInput)
             {
                 flags.Add("ImageInput");
             }
+
             if ((capabilities & AICapability.ImageOutput) == AICapability.ImageOutput)
             {
                 flags.Add("ImageOutput");
             }
+
             if ((capabilities & AICapability.AudioInput) == AICapability.AudioInput)
             {
                 flags.Add("AudioInput");
             }
+
             if ((capabilities & AICapability.AudioOutput) == AICapability.AudioOutput)
             {
                 flags.Add("AudioOutput");
             }
+
             if ((capabilities & AICapability.JsonInput) == AICapability.JsonInput)
             {
                 flags.Add("JsonInput");
             }
+
             if ((capabilities & AICapability.JsonOutput) == AICapability.JsonOutput)
             {
                 flags.Add("JsonOutput");
             }
+
             if ((capabilities & AICapability.FunctionCalling) == AICapability.FunctionCalling)
             {
                 flags.Add("FunctionCalling");
             }
+
             if ((capabilities & AICapability.Reasoning) == AICapability.Reasoning)
             {
                 flags.Add("Reasoning");

--- a/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilities.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilities.cs
@@ -47,6 +47,41 @@ namespace SmartHopper.Infrastructure.AIModels
         public AICapability Default { get; set; } = AICapability.None;
 
         /// <summary>
+        /// Indicates the model has been verified to work end-to-end in SmartHopper.
+        /// </summary>
+        public bool Verified { get; set; } = false;
+
+        /// <summary>
+        /// Whether the provider supports streaming with this model.
+        /// </summary>
+        public bool SupportsStreaming { get; set; } = false;
+
+        /// <summary>
+        /// Whether the provider supports prompt caching with this model.
+        /// </summary>
+        public bool SupportsPromptCaching { get; set; } = false;
+
+        /// <summary>
+        /// Optional ranking to break ties when multiple models match; higher is preferred.
+        /// </summary>
+        public int Rank { get; set; } = 0;
+
+        /// <summary>
+        /// Indicates whether this model is deprecated.
+        /// </summary>
+        public bool Deprecated { get; set; } = false;
+
+        /// <summary>
+        /// Alternative names that should resolve to this model.
+        /// </summary>
+        public List<string> Aliases { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Provider-defined cache key strategy name or hint (optional).
+        /// </summary>
+        public string CacheKeyStrategy { get; set; } = string.Empty;
+
+        /// <summary>
         /// Checks if this model supports a specific capability.
         /// </summary>
         /// <param name="capability">The capability to check for.</param>

--- a/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilityRegistry.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilityRegistry.cs
@@ -19,7 +19,7 @@ namespace SmartHopper.Infrastructure.AIModels
     /// Registry containing capability information for all known models.
     /// Thread-safe: uses ConcurrentDictionary for reads/writes.
     /// </summary>
-    public class AIModelCapabilityRegistry
+    protected class AIModelCapabilityRegistry
     {
         /// <summary>
         /// Dictionary of model capabilities keyed by "provider.model".

--- a/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilityRegistry.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/AIModelCapabilityRegistry.cs
@@ -19,7 +19,7 @@ namespace SmartHopper.Infrastructure.AIModels
     /// Registry containing capability information for all known models.
     /// Thread-safe: uses ConcurrentDictionary for reads/writes.
     /// </summary>
-    protected class AIModelCapabilityRegistry
+    public sealed class AIModelCapabilityRegistry
     {
         /// <summary>
         /// Dictionary of model capabilities keyed by "provider.model".

--- a/src/SmartHopper.Infrastructure/AIModels/IAIProviderModels.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/IAIProviderModels.cs
@@ -14,40 +14,15 @@ using System.Threading.Tasks;
 namespace SmartHopper.Infrastructure.AIModels
 {
     /// <summary>
-    /// Interface for AI provider model management operations.
+    /// Interface for AI provider model metadata retrieval.
+    /// Providers must return concrete models (no wildcards) with full metadata.
     /// </summary>
     public interface IAIProviderModels
     {
         /// <summary>
-        /// Gets the model to use for AI processing.
+        /// Retrieves all models with full metadata for this provider.
         /// </summary>
-        /// <param name="requestedModel">The requested model, or empty for default.</param>
-        /// <returns>The model to use.</returns>
-        string GetModel(string requestedModel = "");
-
-        /// <summary>
-        /// Retrieves the list of available model names for this provider.
-        /// </summary>
-        /// <returns>A list of available model names.</returns>
-        Task<List<string>> RetrieveAvailable();
-
-        /// <summary>
-        /// Gets all models and their capabilities supported by this provider.
-        /// </summary>
-        /// <returns>Dictionary of model names and their capabilities.</returns>
-        Task<Dictionary<string, AICapability>> RetrieveCapabilities();
-
-        /// <summary>
-        /// Gets the capability information for a specific model.
-        /// </summary>
-        /// <param name="model">The model name.</param>
-        /// <returns>Model capabilities or null if not found.</returns>
-        AICapability RetrieveCapabilities(string model);
-
-        /// <summary>
-        /// Gets all default models supported by this provider.
-        /// </summary>
-        /// <returns>Dictionary of model names and their capabilities.</returns>
-        Dictionary<string, AICapability> RetrieveDefault();
+        /// <returns>List of model capability records (concrete names only).</returns>
+        Task<List<AIModelCapabilities>> RetrieveModels();
     }
 }

--- a/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
@@ -246,8 +246,11 @@ namespace SmartHopper.Infrastructure.AIModels
         {
             if (string.IsNullOrWhiteSpace(provider) || requiredCapability == AICapability.None)
             {
+                Debug.WriteLine($"[ModelManager.SelectBestModel] Invalid args -> provider='{provider}', requiredCapability='{requiredCapability.ToDetailedString()}'");
                 return string.Empty;
             }
+
+            Debug.WriteLine($"[ModelManager.SelectBestModel] provider='{provider}', userModel='{userModel}', required='{requiredCapability.ToDetailedString()}', preferredDefault='{preferredDefault}'");
 
             // If user specified a model, validate capability if known; allow unknown to pass
             if (!string.IsNullOrWhiteSpace(userModel))
@@ -256,15 +259,18 @@ namespace SmartHopper.Infrastructure.AIModels
                 if (known == null)
                 {
                     // Unknown model -> pass through
+                    Debug.WriteLine($"[ModelManager.SelectBestModel] User model '{userModel}' is unknown for provider '{provider}'. Passing through without override.");
                     return userModel;
                 }
 
                 if (known.HasCapability(requiredCapability))
                 {
                     // Known and capable
+                    Debug.WriteLine($"[ModelManager.SelectBestModel] Using user model '{userModel}' (known and capable: {known.Capabilities.ToDetailedString()})");
                     return userModel;
                 }
                 // else: fall through to fallback selection
+                Debug.WriteLine($"[ModelManager.SelectBestModel] User model '{userModel}' is known but NOT capable of {requiredCapability.ToDetailedString()} (has {known.Capabilities.ToDetailedString()}). Falling back.");
             }
 
             // Build candidate list of models that support the capability
@@ -278,12 +284,18 @@ namespace SmartHopper.Infrastructure.AIModels
                 var preferredCaps = this.GetCapabilities(provider, preferredDefault);
                 if (preferredCaps != null && preferredCaps.HasCapability(requiredCapability))
                 {
+                    Debug.WriteLine($"[ModelManager.SelectBestModel] Using preferredDefault '{preferredDefault}' (capable: {preferredCaps.Capabilities.ToDetailedString()})");
                     return preferredDefault;
+                }
+                else
+                {
+                    Debug.WriteLine($"[ModelManager.SelectBestModel] preferredDefault '{preferredDefault}' is not capable or unknown. Continuing selection.");
                 }
             }
 
             if (candidates.Count == 0)
             {
+                Debug.WriteLine($"[ModelManager.SelectBestModel] No candidates found for provider '{provider}' with capability {requiredCapability.ToDetailedString()}.");
                 return string.Empty;
             }
 
@@ -297,6 +309,7 @@ namespace SmartHopper.Infrastructure.AIModels
                 .FirstOrDefault();
             if (defaultExact != null)
             {
+                Debug.WriteLine($"[ModelManager.SelectBestModel] Selecting provider default (exact) '{defaultExact.Model}'.");
                 return defaultExact.Model;
             }
 
@@ -310,6 +323,7 @@ namespace SmartHopper.Infrastructure.AIModels
                 .FirstOrDefault();
             if (defaultCompatible != null)
             {
+                Debug.WriteLine($"[ModelManager.SelectBestModel] Selecting provider default (compatible) '{defaultCompatible.Model}'.");
                 return defaultCompatible.Model;
             }
 
@@ -322,9 +336,11 @@ namespace SmartHopper.Infrastructure.AIModels
                 .FirstOrDefault();
             if (best != null)
             {
+                Debug.WriteLine($"[ModelManager.SelectBestModel] Selecting best available '{best.Model}'.");
                 return best.Model;
             }
 
+            Debug.WriteLine($"[ModelManager.SelectBestModel] Failed to select a model; returning empty.");
             return string.Empty;
         }
 

--- a/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
@@ -24,6 +24,7 @@ namespace SmartHopper.Infrastructure.AIModels
     {
         private static readonly Lazy<ModelManager> _instance = new Lazy<ModelManager>(() => new ModelManager());
         private AIModelCapabilityRegistry _registry;
+        private readonly object _syncRoot = new object();
 
         /// <summary>
         /// Gets the singleton instance of the ModelManager.
@@ -38,11 +39,6 @@ namespace SmartHopper.Infrastructure.AIModels
             this._registry = new AIModelCapabilityRegistry();
             Debug.WriteLine("[ModelManager] Initialized with new capability registry");
         }
-
-        /// <summary>
-        /// Gets the current capability registry.
-        /// </summary>
-        public AIModelCapabilityRegistry Registry => _registry;
 
         #region Capability Management
 
@@ -85,8 +81,68 @@ namespace SmartHopper.Infrastructure.AIModels
         {
             if (AIModelCapabilities == null) return;
 
-            this._registry.SetCapabilities(AIModelCapabilities);
+            lock (_syncRoot)
+            {
+                this._registry.SetCapabilities(AIModelCapabilities);
+            }
             Debug.WriteLine($"[ModelManager] Registered capabilities for {AIModelCapabilities.Provider}.{AIModelCapabilities.Model}");
+        }
+
+        /// <summary>
+        /// Marks a model as the default for the given capabilities. When exclusive is true (default),
+        /// clears those capabilities from Default on other models of the same provider to ensure
+        /// at most one default per capability.
+        /// </summary>
+        /// <param name="provider">Provider name.</param>
+        /// <param name="model">Model name.</param>
+        /// <param name="caps">Capabilities to set as default for this model.</param>
+        /// <param name="exclusive">If true, unsets these defaults from other models of the provider.</param>
+        public void SetDefault(string provider, string model, AICapability caps, bool exclusive = true)
+        {
+            if (string.IsNullOrWhiteSpace(provider) || string.IsNullOrWhiteSpace(model) || caps == AICapability.None)
+            {
+                return;
+            }
+
+            var normalizedProvider = provider.ToLower();
+
+            lock (_syncRoot)
+            {
+                // Optionally clear the bits from other models in the same provider
+                if (exclusive)
+                {
+                    var all = this.GetProviderModels(normalizedProvider);
+                    foreach (var m in all)
+                    {
+                        if (!string.Equals(m.Model, model, StringComparison.Ordinal))
+                        {
+                            var before = m.Default;
+                            m.Default &= ~caps; // clear the specified capability bits
+                            if (m.Default != before)
+                            {
+                                this._registry.SetCapabilities(m);
+                            }
+                        }
+                    }
+                }
+
+                // Ensure the target model exists (create or update)
+                var target = this.GetCapabilities(normalizedProvider, model);
+                if (target == null)
+                {
+                    target = new AIModelCapabilities
+                    {
+                        Provider = normalizedProvider,
+                        Model = model,
+                        Capabilities = AICapability.None,
+                        Default = AICapability.None,
+                    };
+                }
+
+                target.Default |= caps;
+                this._registry.SetCapabilities(target);
+            }
+            Debug.WriteLine($"[ModelManager] Set default for {normalizedProvider}.{model} -> {caps}");
         }
 
         /// <summary>
@@ -108,7 +164,33 @@ namespace SmartHopper.Infrastructure.AIModels
         /// <returns>The default model name or null if none found.</returns>
         public string GetDefaultModel(string provider, AICapability requiredCapability)
         {
-            return this._registry.GetDefaultModel(provider, requiredCapability);
+            if (string.IsNullOrWhiteSpace(provider)) return string.Empty;
+
+            // Snapshot of provider models
+            var providerModels = this.GetProviderModels(provider);
+            if (providerModels.Count == 0) return string.Empty;
+
+            // Exact defaults for the capability
+            var exact = providerModels
+                .Where(m => (m.Default & requiredCapability) == requiredCapability)
+                .OrderByDescending(m => m.Verified)
+                .ThenByDescending(m => m.Rank)
+                .ThenBy(m => m.Deprecated)
+                .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (exact != null) return exact.Model;
+
+            // Any default that is compatible
+            var compatible = providerModels
+                .Where(m => m.Default != AICapability.None && m.HasCapability(requiredCapability))
+                .OrderByDescending(m => m.Verified)
+                .ThenByDescending(m => m.Rank)
+                .ThenBy(m => m.Deprecated)
+                .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (compatible != null) return compatible.Model;
+
+            return string.Empty;
         }
 
         /// <summary>
@@ -122,6 +204,127 @@ namespace SmartHopper.Infrastructure.AIModels
                 return false;
 
             return this._registry.Models.Keys.Any(key => key.StartsWith($"{provider}.", StringComparison.OrdinalIgnoreCase));
+        }
+
+        #endregion
+
+        #region Model Listing and Selection
+
+        /// <summary>
+        /// Returns all registered models for a provider.
+        /// </summary>
+        public List<AIModelCapabilities> GetProviderModels(string provider)
+        {
+            if (string.IsNullOrWhiteSpace(provider)) return new List<AIModelCapabilities>();
+
+            var models = this._registry.Models.Values
+                .Where(m => m != null && string.Equals(m.Provider, provider, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            return models;
+        }
+
+        /// <summary>
+        /// Centralized model selection and fallback.
+        /// - If user specified a model:
+        ///   * If known and capable -> use it.
+        ///   * If unknown -> allow it to pass through.
+        ///   * If known but not capable -> fallback.
+        /// - If no user model or fallback needed:
+        ///   * Prefer preferredDefault when capable.
+        ///   * Then provider defaults with exact capability.
+        ///   * Then other defaults compatible with capability.
+        ///   * Then other registered models ordered by Verified, Rank, and not Deprecated.
+        /// </summary>
+        /// <param name="provider">Provider name.</param>
+        /// <param name="userModel">User-specified model (optional).</param>
+        /// <param name="requiredCapability">Required capability flags.</param>
+        /// <param name="preferredDefault">A preferred default (e.g., settings default) to try first when falling back.</param>
+        /// <returns>Selected model name or empty when none.</returns>
+        public string SelectBestModel(string provider, string userModel, AICapability requiredCapability, string preferredDefault = null)
+        {
+            if (string.IsNullOrWhiteSpace(provider) || requiredCapability == AICapability.None)
+            {
+                return string.Empty;
+            }
+
+            // If user specified a model, validate capability if known; allow unknown to pass
+            if (!string.IsNullOrWhiteSpace(userModel))
+            {
+                var known = this.GetCapabilities(provider, userModel);
+                if (known == null)
+                {
+                    // Unknown model -> pass through
+                    return userModel;
+                }
+
+                if (known.HasCapability(requiredCapability))
+                {
+                    // Known and capable
+                    return userModel;
+                }
+                // else: fall through to fallback selection
+            }
+
+            // Build candidate list of models that support the capability
+            var candidates = this.GetProviderModels(provider)
+                .Where(m => m.HasCapability(requiredCapability))
+                .ToList();
+
+            // Try preferred default first if it is capable
+            if (!string.IsNullOrWhiteSpace(preferredDefault))
+            {
+                var preferredCaps = this.GetCapabilities(provider, preferredDefault);
+                if (preferredCaps != null && preferredCaps.HasCapability(requiredCapability))
+                {
+                    return preferredDefault;
+                }
+            }
+
+            if (candidates.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            // 1) Defaults with exact capability
+            var defaultExact = candidates
+                .Where(m => (m.Default & requiredCapability) == requiredCapability)
+                .OrderByDescending(m => m.Verified)
+                .ThenByDescending(m => m.Rank)
+                .ThenBy(m => m.Deprecated)
+                .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (defaultExact != null)
+            {
+                return defaultExact.Model;
+            }
+
+            // 2) Other defaults that are compatible
+            var defaultCompatible = candidates
+                .Where(m => m.Default != AICapability.None)
+                .OrderByDescending(m => m.Verified)
+                .ThenByDescending(m => m.Rank)
+                .ThenBy(m => m.Deprecated)
+                .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (defaultCompatible != null)
+            {
+                return defaultCompatible.Model;
+            }
+
+            // 3) Any other registered model, ordered by quality
+            var best = candidates
+                .OrderByDescending(m => m.Verified)
+                .ThenByDescending(m => m.Rank)
+                .ThenBy(m => m.Deprecated)
+                .ThenBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+            if (best != null)
+            {
+                return best.Model;
+            }
+
+            return string.Empty;
         }
 
         #endregion

--- a/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
+++ b/src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
@@ -225,6 +225,7 @@ namespace SmartHopper.Infrastructure.AIModels
         }
 
         /// <summary>
+        /// DO NOT CALL THIS DIRECTLY. USE AIProvider.SelectModel() INSTEAD.
         /// Centralized model selection and fallback.
         /// - If user specified a model:
         ///   * If known and capable -> use it.

--- a/src/SmartHopper.Infrastructure/AIProviders/AIProvider.cs
+++ b/src/SmartHopper.Infrastructure/AIProviders/AIProvider.cs
@@ -384,6 +384,17 @@ namespace SmartHopper.Infrastructure.AIProviders
             return null;
         }
 
+        /// <inheritdoc/>
+        public virtual string SelectModel(AICapability requiredCapability, string requestedModel)
+        {
+            // Prefer provider-configured default from settings when compatible
+            var preferredDefault = this.GetDefaultModel(requiredCapability, useSettings: true);
+
+            // Delegate to centralized selection policy to avoid duplication
+            var selected = ModelManager.Instance.SelectBestModel(this.Name, requestedModel, requiredCapability, preferredDefault);
+            return selected ?? string.Empty;
+        }
+
         /// <summary>
         /// Sets a setting value for this provider with automatic provider scoping and persistence.
         /// </summary>

--- a/src/SmartHopper.Infrastructure/AIProviders/IAIProvider.cs
+++ b/src/SmartHopper.Infrastructure/AIProviders/IAIProvider.cs
@@ -91,6 +91,15 @@ namespace SmartHopper.Infrastructure.AIProviders
         string GetDefaultModel(AICapability requiredCapability = AICapability.Text2Text, bool useSettings = true);
 
         /// <summary>
+        /// Selects the most appropriate model given a requested model (optional) and a required capability.
+        /// Implementations should respect provider settings and capability compatibility.
+        /// </summary>
+        /// <param name="requiredCapability">The capability required by the request/tool.</param>
+        /// <param name="requestedModel">An optional user/request-specified model name.</param>
+        /// <returns>The selected model name (concrete, API-ready), or empty string when none.</returns>
+        string SelectModel(AICapability requiredCapability, string requestedModel);
+
+        /// <summary>
         /// Refreshes the provider's cached settings by merging the input settings with existing cached settings.
         /// </summary>
         /// <param name="settings">The new settings to merge with existing cached settings.</param>

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
@@ -10,12 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using SmartHopper.Infrastructure.AICall;
 using SmartHopper.Infrastructure.AIModels;
 using SmartHopper.Infrastructure.AIProviders;
 
@@ -39,239 +34,65 @@ namespace SmartHopper.Providers.MistralAI
         }
 
         /// <summary>
-        /// Retrieves the list of available model names for MistralAI.
+        /// Retrieves all models with full metadata (concrete names only) for MistralAI.
         /// </summary>
-        /// <returns>A list of available model names.</returns>
-        public override async Task<List<string>> RetrieveAvailable()
+        /// <returns>List of AIModelCapabilities.</returns>
+        public override Task<List<AIModelCapabilities>> RetrieveModels()
         {
-            try
+            var provider = this.mistralProvider.Name.ToLower();
+
+            var models = new List<AIModelCapabilities>
             {
-                Debug.WriteLine("[MistralAI] Retrieving available models");
-
-                // Use AIRequestCall to perform the request
-                var request = new AIRequestCall();
-                request.Initialize(this.mistralProvider.Name, string.Empty, string.Empty, "/models", AICapability.TextInput);
-                request.HttpMethod = "GET";
-                request.ContentType = "application/json";
-                request.Authentication = "bearer";
-
-                var aiReturn = await request.Exec().ConfigureAwait(false);
-                if (!aiReturn.Success)
+                new AIModelCapabilities
                 {
-                    throw new Exception($"API request failed: {aiReturn.ErrorMessage}");
-                }
-
-                var response = aiReturn.Body.GetLastInteraction() as AIInteractionText;
-                var content = response?.Content ?? string.Empty;
-                var json = JObject.Parse(content);
-                var data = json["data"] as JArray;
-                var modelNames = new List<string>();
-                if (data != null)
+                    Provider = provider,
+                    Model = "mistral-small-latest",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput,
+                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.Text2Json,
+                    SupportsStreaming = true,
+                    Verified = true,
+                    Rank = 90,
+                },
+                new AIModelCapabilities
                 {
-                    foreach (var item in data.OfType<JObject>())
-                    {
-                        var name = item["id"]?.ToString();
-                        if (!string.IsNullOrEmpty(name))
-                        {
-                            modelNames.Add(name);
-                        }
-                    }
-                }
-
-                // Fallback when API returns an empty list
-                if (modelNames.Count == 0)
+                    Provider = provider,
+                    Model = "mistral-medium-latest",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 80,
+                },
+                new AIModelCapabilities
                 {
-                    Debug.WriteLine("[MistralAI] API returned 0 models, using fallback list");
-                    return GetFallbackAvailableModels();
-                }
-
-                return modelNames;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[MistralAI] Error retrieving available models: {ex.Message}");
-                // Fallback to a sensible offline list when API is unavailable (e.g., missing API key)
-                return GetFallbackAvailableModels();
-            }
-        }
-
-        /// <summary>
-        /// Gets all models and their capabilities supported by MistralAI, fetching fresh data from API.
-        /// </summary>
-        /// <returns>Dictionary of model names and their capabilities.</returns>
-        public override async Task<Dictionary<string, AICapability>> RetrieveCapabilities()
-        {
-            var result = new Dictionary<string, AICapability>();
-
-            try
-            {
-                Debug.WriteLine("[MistralAI] Fetching models and capabilities via API");
-
-                // Get list of available models
-                var models = await this.RetrieveAvailable().ConfigureAwait(false);
-
-                // If no models were retrieved (likely due to API key issue), return default capabilities
-                if (models == null || models.Count == 0)
+                    Provider = provider,
+                    Model = "mistral-large-latest",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 70,
+                },
+                new AIModelCapabilities
                 {
-                    Debug.WriteLine("[MistralAI] No models retrieved, returning default capabilities");
-                    return GetDefaultCapabilities();
-                }
-
-                var processedCount = 0;
-
-                foreach (var modelName in models)
+                    Provider = provider,
+                    Model = "magistral-small-latest",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.ToolReasoningChat,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 85,
+                },
+                new AIModelCapabilities
                 {
-                    // Use AIRequestCall to get model details
-                    var request = new AIRequestCall();
-                    request.Initialize(this.mistralProvider.Name, string.Empty, string.Empty, $"/models/{modelName}", AICapability.TextInput);
-                    request.HttpMethod = "GET";
-                    request.ContentType = "application/json";
-                    request.Authentication = "bearer";
-
-                    var aiReturn = await request.Exec().ConfigureAwait(false);
-                    if (!aiReturn.Success)
-                    {
-                        Debug.WriteLine($"[MistralAI] Failed to get model details for {modelName}: {aiReturn.ErrorMessage}");
-                        continue;
-                    }
-
-                    var response = aiReturn.Body.GetLastInteraction() as AIInteractionText;
-                    var content = response?.Content ?? string.Empty;
-                    var modelInfo = JsonConvert.DeserializeObject<dynamic>(content);
-
-                    var capabilities = AICapability.None;
-
-                    // Map Mistral capabilities to our enum
-                    if (modelInfo?.capabilities?.completion_chat == true)
-                    {
-                        capabilities |= AICapability.Text2Text;
-                    }
-
-                    if (modelInfo?.capabilities?.function_calling == true)
-                    {
-                        capabilities |= AICapability.FunctionCalling;
-                    }
-
-                    if (modelInfo?.capabilities?.vision == true)
-                    {
-                        capabilities |= AICapability.ImageInput;
-                    }
-
-                    // Currently Mistral offers json_mode for all models
-                    capabilities |= AICapability.JsonOutput;
-
-                    result[modelName] = capabilities;
-                    processedCount++;
-                    Debug.WriteLine($"[MistralAI] Processed capabilities for {modelName}: {capabilities}");
-                }
-
-                Debug.WriteLine($"[MistralAI] Processed {processedCount} models with capabilities");
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[MistralAI] Error in RetrieveCapabilities: {ex.Message}");
-
-                Debug.WriteLine("[MistralAI] Falling back to static/default model capabilities");
-
-                // Fallback to static capabilities when API is unavailable (e.g., missing API key)
-                result = GetFallbackCapabilities();
-            }
-
-            // If we still have no results, use fallback
-            if (result.Count == 0)
-            {
-                Debug.WriteLine("[MistralAI] No models found, using fallback capabilities");
-                result = GetFallbackCapabilities();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Fallback list of available model IDs when API is unavailable.
-        /// </summary>
-        private List<string> GetFallbackAvailableModels()
-        {
-            return new List<string>
-            {
-                // Concrete, commonly used names
-                "mistral-small-latest",
-                "mistral-medium-latest",
-                "mistral-large-latest",
-                "magistral-small-latest",
-                "magistral-medium-latest",
+                    Provider = provider,
+                    Model = "magistral-medium-latest",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 75,
+                },
             };
-        }
 
-        /// <summary>
-        /// Gets fallback model capabilities when API is unavailable.
-        /// </summary>
-        /// <returns>Dictionary of model names and their capabilities.</returns>
-        private Dictionary<string, AICapability> GetFallbackCapabilities()
-        {
-            var result = new Dictionary<string, AICapability>();
-
-            // Mistral Small models - text input/output, structured output, function calling
-            result["mistral-small*"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling;
-
-            // Ensure concrete default ID exists alongside wildcard to allow default registration
-            result["mistral-small-latest"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling;
-
-            // Mistral Medium models - text input/output, structured output, function calling
-            result["mistral-medium*"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling;
-
-            // Mistral Large models - text input/output, structured output, function calling
-            result["mistral-large*"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling;
-
-            // Magistral Small models - text input/output, structured output, function calling
-            result["magistral-small*"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning;
-
-            // Ensure concrete default ID exists alongside wildcard to allow default registration
-            result["magistral-small-latest"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning;
-
-            // Magistral Medium models - text input/output, structured output, function calling
-            result["magistral-medium*"] = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning;
-
-            Debug.WriteLine($"[MistralAI] Registered {result.Count} fallback model patterns");
-            return result;
-        }
-
-        /// <summary>
-        /// Gets all default models supported by MistralAI.
-        /// </summary>
-        /// <returns>Dictionary of model names and their capabilities.</returns>
-        public override Dictionary<string, AICapability> RetrieveDefault()
-        {
-            var result = new Dictionary<string, AICapability>();
-
-            result["mistral-small-latest"] = AICapability.ToolChat | AICapability.Text2Json;
-            result["magistral-small-latest"] = AICapability.ToolReasoningChat;
-
-            return result;
-        }
-
-        /// <summary>
-        /// Gets default capabilities for common MistralAI models.
-        /// Used when API is not available (e.g., during initialization without API key).
-        /// </summary>
-        /// <returns>Dictionary of default model capabilities.</returns>
-        private static Dictionary<string, AICapability> GetDefaultCapabilities()
-        {
-            var result = new Dictionary<string, AICapability>();
-
-            // Ministral models
-            result["ministral-8b*"] = AICapability.ToolChat | AICapability.Text2Json;
-            result["ministral-3b*"] = AICapability.ToolChat | AICapability.Text2Json;
-
-            // Add wildcard patterns for future versions
-            result["mistral-small*"] = AICapability.ToolChat | AICapability.Text2Json | AICapability.ImageInput;
-            result["mistral-medium*"] = AICapability.ToolChat | AICapability.Text2Json | AICapability.ImageInput;
-            result["mistral-large*"] = AICapability.ToolChat | AICapability.Text2Json;
-            result["pixtral*"] = AICapability.ToolChat | AICapability.ImageInput | AICapability.Text2Json;
-            result["codestral*"] = AICapability.ToolChat | AICapability.Text2Json;
-            result["magistral*"] = AICapability.ToolReasoningChat | AICapability.Text2Json;
-
-            return result;
+            return Task.FromResult(models);
         }
     }
 }


### PR DESCRIPTION
## Description

Implements the unified model management & selection architecture (formerly Suggestion 2) with a full refactor of model registration, capability storage, and selection flow.
Key changes:
- Centralized model management in ModelManager:
  - ModelManager.SelectBestModel(...) is the single authority for selection.
  - Capability data stored via AIModelCapabilityRegistry as storage-only.
  - Exact name and alias matching only in the registry (no wildcard resolution).
- Provider-scoped selection:
  - New IAIProvider.SelectModel(requiredCapability, requestedModel) encapsulates selection.
  - AIProvider.SelectModel(...) delegates to ModelManager.SelectBestModel(...) while honoring provider defaults/settings.
  - AIRequestBase.GetModelToUse() now calls provider.SelectModel(...).
- Simplified selection policy (capability-first):
  1. User-specified model (pass-through if unknown; use if known and capable)
  2. Provider-preferred default (settings), if capable
  3. Default for the requested capability
  4. Best of the remaining capable models (verified, rank, non-deprecated, name)
  - Note: removed the separate “default-compatible” tier to reduce complexity.
- Documentation aligned with the new architecture:
  - docs/Providers/ModelSelection.md — updated selection policy.
  - docs/Architecture.md — clarified registry is exact/alias only and storage-only.
  - docs/Providers/AIModelCapabilities.md — best practices updated (no wildcards; use Aliases).
  - docs/Providers/index.md, `docs/Providers/AIProvider*.md` — guidance for provider-scoped selection.
  - docs/Suggestions.md — Suggestion 2 removed (fully implemented).
- Tests and fixes:
  - `ModelManagerTests` and `AdvancedConfigTests` updated.
  - Fix: missing `Image2Image` capability.
  - Fix: incorrect fallback to default model when component defines a specific model.
Touched areas (non-exhaustive):
- src/SmartHopper.Infrastructure/AIModels/ModelManager.cs
- src/SmartHopper.Infrastructure/AIProviders/AIProvider.cs
- src/SmartHopper.Infrastructure/AICall/AIRequestBase.cs
- `src/SmartHopper.Infrastructure/AIModels/{AIModelCapabilities.cs, AIModelCapabilityRegistry.cs, IAIProviderModels.cs}`
- Providers: OpenAIProviderModels.cs, MistralAIProviderModels.cs, DeepSeekProviderModels.cs
- Components and tests updated accordingly
## Breaking Changes
- Provider model retrieval must be centralized:
  - Removed legacy per-provider model retrieval/selection paths. Providers must expose models via RetrieveModels() and rely on ModelManager for selection.
  - No wildcard entries in registry; use concrete model names and `Aliases` for alternative names.
- External API remains the same for end users/components; changes primarily affect provider implementations.
## Testing Done
- Updated unit tests:
  - `src/SmartHopper.Infrastructure.Tests/ModelManagerTests.cs`
  - `src/SmartHopper.Infrastructure.Tests/AdvancedConfigTests.cs`
- Manual verification:
  - Selection respects user-specified models, provider defaults, capability validation, and tie-breakers (Verified, Rank, Deprecated, Name).
  - Components using provider “Default” and explicit models behave as expected.
## Checklist
- [x] Focused on a single, scoped refactor (model manager and selection)
- [x] CHANGELOG.md updated under [Unreleased]
- [x] PR title follows Conventional Commits
- [x] Docs updated under `docs/` to reflect the new behavior
## Motivation
Completes the unified model management & selection design by:
- Making ModelManager the single source of truth for capabilities and selection
- Delegating selection to providers for proper scoping and settings awareness
- Simplifying policy (removed default-compatible tier; no wildcards) for predictability and maintainability
