### PR TITLE
chore: bump version to 1.2.4 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump to stable version
+
 ## [1.2.4-alpha] - 2026-01-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmartHopper - AI-Powered Tools and Assistant for Grasshopper3D
 
-[![Version](https://img.shields.io/badge/version-1.2.4--alpha-orange?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
-[![Status](https://img.shields.io/badge/status-Alpha-orange?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Version](https://img.shields.io/badge/version-1.2.4-brightgreen?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Status](https://img.shields.io/badge/status-Stable-brightgreen?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![.NET CI](https://img.shields.io/github/actions/workflow/status/architects-toolkit/SmartHopper/.github/workflows/ci-dotnet-tests.yml?label=tests&logo=dotnet&style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/actions/workflows/ci-dotnet-tests.yml)
 [![Ready to use](https://img.shields.io/badge/ready_to_use-YES-brightgreen?style=for-the-badge)](https://smarthopper.xyz/#installation)
 [![License](https://img.shields.io/badge/license-LGPL%20v3-white?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/blob/main/LICENSE)

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>1.2.4-alpha</SolutionVersion>
+    <SolutionVersion>1.2.4</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/yak-package/manifest.yml
+++ b/yak-package/manifest.yml
@@ -7,7 +7,7 @@ description: >
 
   ----
 
-  NOTE: This is an alpha release and you might find bugs :/ Please, report them at <https://github.com/architects-toolkit/SmartHopper/issues>
+  Please report any issues at <https://github.com/architects-toolkit/SmartHopper/issues>
 
   ----
 


### PR DESCRIPTION
## Description

- Updated version from 1.2.4-alpha to 1.2.4 in Solution.props
- Updated README badges to reflect stable status with brightgreen color
- Removed alpha warning from yak package manifest description
- Updated CHANGELOG.md with version bump note

## Breaking Changes

None.

## Testing Done

Compiled and tested.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] PR description follows [Pull Request Description Template](#pull-request-description-template)
