### PR TITLE
feat(deepseek): release 1.4.4 with DeepSeek settings, model catalog updates, and tool-call fixes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,10 +68,8 @@ ci:
 documentation:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/*.md'
           - 'docs/**'
           - '.github/ISSUE_TEMPLATE/**'
-      - all-globs-to-all-file: '!CHANGELOG*'
 
 # --- Component labels ---
 "component: AI Chat":

--- a/.github/workflows/HOTFIX_WORKFLOW.md
+++ b/.github/workflows/HOTFIX_WORKFLOW.md
@@ -61,11 +61,7 @@ This workflow will:
 ### Step 4: Review and Merge PR
 
 1. Review the PR created by the workflow
-2. Ensure all validations pass:
-   - ✅ Version Check
-   - ✅ Code Style Check
-   - ✅ Changelog Check
-   - ✅ .NET CI Tests
+2. Ensure all validations pass
 3. Merge the PR to `main`
 
 
@@ -139,7 +135,6 @@ The workflow automatically handles version conflicts:
 - **release-4-build.yml** - Builds and uploads artifacts (existing)
 - **release-5-upload-yak.yml** - Publishes to Yak (existing)
 
-
 ## Validations
 
 All PRs to `main` (including hotfixes) run:
@@ -148,7 +143,6 @@ All PRs to `main` (including hotfixes) run:
 - Code style checks
 - Changelog update verification
 - .NET build and tests
-
 
 ## Comparison with Regular Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to SmartHopper will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.4] - 2026-07-14
+
+### Added
+
+- **DeepSeek provider**: Added `ReasoningEffort` and `TopP` settings. `ReasoningEffort` is a single dropdown that controls thinking mode and reasoning depth (`none` disables thinking; `high` or `max` enables it). `TopP` exposes nucleus sampling. `TopP` is included in every chat completion request; `ReasoningEffort` is mapped to DeepSeek's `thinking` and `reasoning_effort` parameters for DeepSeek-V4 and `deepseek-reasoner` models.
+- **DeepSeek provider**: Removed the artificial `MaxTokens` cap of `8192`; the setting now supports values up to the API output limit.
+
+### Fixed
+
+- **DeepSeek provider**: Fixed multi-step tool call requests that failed with `invalid_request_error` because consecutive tool results were merged into a single message, breaking DeepSeek's requirement that each assistant `tool_calls` message is followed by one `tool` message per `tool_call_id`. Assistant tool calls and reasoning are now coalesced into one message while tool result messages remain separate; `reasoning_content` is emitted on assistant messages with `tool_calls` (with an empty string fallback) and stripped from text-only assistant messages to save bandwidth; and tool result content is now sent as a compact JSON string instead of a stripped/quoted string, matching the behavior of OpenAI and MistralAI.
+- **DeepSeek and OpenRouter providers**: Removed the optional `name` field from `role=tool` result messages. While OpenAI's function-calling guide examples include `name` on tool results, DeepSeek's strict OpenAI-compatible validator appears to reject these messages, causing intermittent `insufficient tool messages` errors in long tool-call sequences. OpenRouter's documented tool-calling schema also omits `name` on tool result messages, so it was removed there for consistency. MistralAI's official examples include `name` on tool results, so it is preserved for that provider.
 
 ## [1.4.3] - 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SmartHopper - AI-Powered Tools and Assistant for Grasshopper3D
 
-[![Version](https://img.shields.io/badge/version-1.4.3-brightgreen?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Version](https://img.shields.io/badge/version-1.4.4-brightgreen?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![Status](https://img.shields.io/badge/status-Stable-brightgreen?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![.NET CI](https://img.shields.io/github/actions/workflow/status/architects-toolkit/SmartHopper/.github/workflows/ci-dotnet-tests.yml?label=tests&logo=dotnet&style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/actions/workflows/ci-dotnet-tests.yml)
 [![Ready to use](https://img.shields.io/badge/ready_to_use-YES-brightgreen?style=for-the-badge)](https://smarthopper.xyz/#installation)

--- a/Solution.props
+++ b/Solution.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <SolutionVersion>1.4.3</SolutionVersion>
+    <SolutionVersion>1.4.4</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/src/SmartHopper.Providers.Anthropic/AnthropicProviderModels.cs
+++ b/src/SmartHopper.Providers.Anthropic/AnthropicProviderModels.cs
@@ -48,28 +48,16 @@ namespace SmartHopper.Providers.Anthropic
 
             var models = new List<AIModelCapabilities>
             {
-                // Released between February 2026 and May 2026
+                // Released between April 2026 and July 2026
 
                 new AIModelCapabilities
                 {
                     Provider = providerName,
-                    Model = "claude-sonnet-4-6",
+                    Model = "claude-sonnet-5",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Default = AICapability.Text2Json,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 10000,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = providerName,
-                    Model = "claude-opus-4-6",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9995,
                     ContextLimit = 1000000,
                 },
 
@@ -80,29 +68,62 @@ namespace SmartHopper.Providers.Anthropic
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 9995,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = providerName,
+                    Model = "claude-opus-4-8",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 9990,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = providerName,
+                    Model = "claude-fable-5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9985,
                     ContextLimit = 1000000,
                 },
 
 
 
-                // Released between November 2025 and February 2026
+                // Released between January 2026 and April 2026
 
                 new AIModelCapabilities
                 {
                     Provider = providerName,
-                    Model = "claude-opus-4-5-20251101",
+                    Model = "claude-sonnet-4-6",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Default = AICapability.Text2Json,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9980,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = providerName,
+                    Model = "claude-opus-4-6",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9985,
-                    ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-opus-4-5", "claude-opus-4-5-latest" },
+                    Rank = 9975,
+                    ContextLimit = 1000000,
                 },
 
 
 
-                // Released between August 2025 and November 2025
+                // Released between October 2025 and January 2026
 
                 new AIModelCapabilities
                 {
@@ -112,11 +133,27 @@ namespace SmartHopper.Providers.Anthropic
                     Default = AICapability.Text2Text | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.ToolChat | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = true,
-                    Rank = 9980,
+                    Rank = 9970,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-haiku-4-5", "claude-haiku-4-5-latest" },
+                    Aliases = new List<string> { "claude-haiku-4-5", "claude-haiku-4-5-latest", "claude-haiku-4.5", "claude-haiku-4.5-latest" },
                     DiscouragedForTools = new List<string> { "script_generate", "script_edit" },
                 },
+
+                new AIModelCapabilities
+                {
+                    Provider = providerName,
+                    Model = "claude-opus-4-5-20251101",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9965,
+                    ContextLimit = 200000,
+                    Aliases = new List<string> { "claude-opus-4-5", "claude-opus-4-5-latest", "claude-opus-4.5", "claude-opus-4.5-latest" },
+                },
+
+
+
+                // Released between July 2025 and October 2025
 
                 new AIModelCapabilities
                 {
@@ -125,9 +162,9 @@ namespace SmartHopper.Providers.Anthropic
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = true,
-                    Rank = 9975,
+                    Rank = 9960,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-sonnet-4-5", "claude-sonnet-4-5-latest" },
+                    Aliases = new List<string> { "claude-sonnet-4-5", "claude-sonnet-4-5-latest", "claude-sonnet-4.5", "claude-sonnet-4.5-latest" },
                 },
 
 
@@ -144,7 +181,7 @@ namespace SmartHopper.Providers.Anthropic
                     Deprecated = true,
                     Rank = 0,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-opus-4-1", "claude-opus-4-1-latest" },
+                    Aliases = new List<string> { "claude-opus-4-1", "claude-opus-4-1-latest", "claude-opus-4.1", "claude-opus-4.1-latest" },
                 },
 
                 new AIModelCapabilities
@@ -176,14 +213,15 @@ namespace SmartHopper.Providers.Anthropic
                 new AIModelCapabilities
                 {
                     Provider = providerName,
-                    Model = "claude-3-7-sonnet-20250219",
+                    Model = "claude-3-haiku-20240307",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -15,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-3-7-sonnet", "claude-3-7-sonnet-latest" },
+                    Aliases = new List<string> { "claude-3-haiku", "claude-3-haiku-latest" },
+                    DiscouragedForTools = new List<string> { "script_generate", "script_edit" },
                 },
 
                 new AIModelCapabilities
@@ -203,15 +241,14 @@ namespace SmartHopper.Providers.Anthropic
                 new AIModelCapabilities
                 {
                     Provider = providerName,
-                    Model = "claude-3-haiku-20240307",
+                    Model = "claude-3-7-sonnet-20250219",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.ImageInput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -25,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "claude-3-haiku", "claude-3-haiku-latest" },
-                    DiscouragedForTools = new List<string> { "script_generate", "script_edit" },
+                    Aliases = new List<string> { "claude-3-7-sonnet", "claude-3-7-sonnet-latest" },
                 }
             };
 

--- a/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
+++ b/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
@@ -49,12 +49,6 @@ namespace SmartHopper.Providers.DeepSeek
         #region Compiled Regex Patterns
 
         /// <summary>
-        /// Regex pattern for normalizing whitespace to single spaces.
-        /// </summary>
-        [GeneratedRegex(@"\s+")]
-        private static partial Regex WhitespaceRegex();
-
-        /// <summary>
         /// Regex pattern for extracting enum arrays from malformed JSON.
         /// </summary>
         [GeneratedRegex(@"enum[""']?:\s*\[([^\]]+)\]")]
@@ -153,9 +147,12 @@ namespace SmartHopper.Providers.DeepSeek
 
             int maxTokens = this.GetSetting<int>("MaxTokens");
             double temperature = this.GetSetting<double>("Temperature");
+            double topP = this.GetSetting<double>("TopP");
+            string reasoningEffort = this.GetSetting<string>("ReasoningEffort") ?? "high";
+            bool thinking = !string.Equals(reasoningEffort, "none", StringComparison.OrdinalIgnoreCase);
             string? toolFilter = request.Body.ToolFilter;
 
-            Debug.WriteLine($"[DeepSeek] Encode - Model: {request.Model}, MaxTokens: {maxTokens}");
+            Debug.WriteLine($"[DeepSeek] Encode - Model: {request.Model}, MaxTokens: {maxTokens}, ReasoningEffort: {reasoningEffort}");
 
 #if DEBUG
             // Log interaction sequence for debugging
@@ -177,6 +174,8 @@ namespace SmartHopper.Providers.DeepSeek
             JObject currentMessage = null;
             var currentToolCalls = new JArray();
 
+            bool IsAssistant(string? r) => string.Equals(r, "assistant", StringComparison.OrdinalIgnoreCase);
+
             // Merge System and Summary interactions before encoding
             var mergedInteractions = this.MergeSystemAndSummary(request.Body.Interactions);
 
@@ -196,8 +195,8 @@ namespace SmartHopper.Providers.DeepSeek
                         continue;
                     }
 
-                    // Check if role changed
-                    if (currentRole != role)
+                    // Check if role changed or if we should not merge this role
+                    if (currentRole != role || !IsAssistant(currentRole))
                     {
                         // Finalize previous message if exists
                         if (currentMessage != null)
@@ -208,12 +207,21 @@ namespace SmartHopper.Providers.DeepSeek
                                 currentMessage["tool_calls"] = currentToolCalls;
                             }
 
-                            // Remove reasoning_content from assistant messages without tool_calls
-                            // per DeepSeek's recommendation to save bandwidth
-                            if (string.Equals(currentMessage["role"]?.ToString(), "assistant", StringComparison.OrdinalIgnoreCase)
-                                && (currentMessage["tool_calls"] == null || (currentMessage["tool_calls"] is JArray tcArray && tcArray.Count == 0)))
+                            // Preserve reasoning_content on assistant messages with tool_calls (required by DeepSeek
+                            // thinking mode) and strip it from text-only assistant messages to save bandwidth.
+                            if (IsAssistant(currentRole))
                             {
-                                currentMessage.Remove("reasoning_content");
+                                if (currentToolCalls.Count > 0)
+                                {
+                                    if (currentMessage["reasoning_content"] == null)
+                                    {
+                                        currentMessage["reasoning_content"] = string.Empty;
+                                    }
+                                }
+                                else
+                                {
+                                    currentMessage.Remove("reasoning_content");
+                                }
                             }
 
                             convertedMessages.Add(currentMessage);
@@ -243,20 +251,15 @@ namespace SmartHopper.Providers.DeepSeek
                             }
                         }
 
-                        // Copy tool_call_id and name for tool results
+                        // Copy tool_call_id for tool results (name is not a valid field on role=tool messages).
                         if (token["tool_call_id"] != null)
                         {
                             currentMessage["tool_call_id"] = token["tool_call_id"];
                         }
-
-                        if (token["name"] != null)
-                        {
-                            currentMessage["name"] = token["name"];
-                        }
                     }
                     else
                     {
-                        // Same role: merge content and tool_calls
+                        // Same assistant role: merge content, reasoning and tool_calls
                         var existingContent = currentMessage["content"]?.ToString() ?? string.Empty;
                         var newContent = token["content"]?.ToString() ?? string.Empty;
                         if (!string.IsNullOrEmpty(newContent))
@@ -296,12 +299,21 @@ namespace SmartHopper.Providers.DeepSeek
                     currentMessage["tool_calls"] = currentToolCalls;
                 }
 
-                // Remove reasoning_content from assistant messages without tool_calls
-                // per DeepSeek's recommendation to save bandwidth
-                if (string.Equals(currentMessage["role"]?.ToString(), "assistant", StringComparison.OrdinalIgnoreCase)
-                    && (currentMessage["tool_calls"] == null || (currentMessage["tool_calls"] is JArray tcArray && tcArray.Count == 0)))
+                // Preserve reasoning_content on assistant messages with tool_calls (required by DeepSeek
+                // thinking mode) and strip it from text-only assistant messages to save bandwidth.
+                if (IsAssistant(currentRole))
                 {
-                    currentMessage.Remove("reasoning_content");
+                    if (currentToolCalls.Count > 0)
+                    {
+                        if (currentMessage["reasoning_content"] == null)
+                        {
+                            currentMessage["reasoning_content"] = string.Empty;
+                        }
+                    }
+                    else
+                    {
+                        currentMessage.Remove("reasoning_content");
+                    }
                 }
 
                 convertedMessages.Add(currentMessage);
@@ -348,7 +360,20 @@ namespace SmartHopper.Providers.DeepSeek
                 ["messages"] = convertedMessages,
                 ["max_tokens"] = maxTokens,
                 ["temperature"] = temperature,
+                ["top_p"] = topP,
             };
+
+            // Add thinking/reasoning controls for models that support thinking mode
+            bool isThinkingModel = request.Model.Contains("v4", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(request.Model, "deepseek-reasoner", StringComparison.OrdinalIgnoreCase);
+            if (isThinkingModel)
+            {
+                requestBody["thinking"] = new JObject { ["type"] = thinking ? "enabled" : "disabled" };
+                if (thinking)
+                {
+                    requestBody["reasoning_effort"] = reasoningEffort;
+                }
+            }
 
             // Add JSON response format if schema is provided (centralized wrapping)
             if (!string.IsNullOrWhiteSpace(request.Body.JsonOutputSchema))
@@ -482,23 +507,12 @@ namespace SmartHopper.Providers.DeepSeek
             }
             else if (interaction is AIInteractionToolResult toolResultInteraction)
             {
-                // DeepSeek requires cleaned/simplified tool result content
-                var jsonString = JsonConvert.SerializeObject(toolResultInteraction.Result, Formatting.None);
-                jsonString = jsonString.Replace("\"", string.Empty, StringComparison.OrdinalIgnoreCase);
-                jsonString = jsonString.Replace("\\r\\n", string.Empty, StringComparison.OrdinalIgnoreCase);
-                jsonString = jsonString.Replace("\\", string.Empty, StringComparison.OrdinalIgnoreCase);
-                jsonString = WhitespaceRegex().Replace(jsonString, " ");
-
-                messageObj["content"] = jsonString;
+                // Keep the tool result as a compact JSON string, consistent with OpenAI/MistralAI.
+                messageObj["content"] = toolResultInteraction.Result?.ToString(Formatting.None) ?? string.Empty;
 
                 if (!string.IsNullOrWhiteSpace(toolResultInteraction.Id))
                 {
                     messageObj["tool_call_id"] = toolResultInteraction.Id;
-                }
-
-                if (!string.IsNullOrWhiteSpace(toolResultInteraction.Name))
-                {
-                    messageObj["name"] = toolResultInteraction.Name;
                 }
             }
             else if (interaction is AIInteractionToolCall toolCallInteraction)

--- a/src/SmartHopper.Providers.DeepSeek/DeepSeekProviderModels.cs
+++ b/src/SmartHopper.Providers.DeepSeek/DeepSeekProviderModels.cs
@@ -47,7 +47,7 @@ namespace SmartHopper.Providers.DeepSeek
 
             var models = new List<AIModelCapabilities>
             {
-                // Released between February 2026 and May 2026
+                // Released between April 2026 and July 2026
 
                 new AIModelCapabilities
                 {

--- a/src/SmartHopper.Providers.DeepSeek/DeepSeekProviderSettings.cs
+++ b/src/SmartHopper.Providers.DeepSeek/DeepSeekProviderSettings.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using SmartHopper.Infrastructure.AIProviders;
 using SmartHopper.Infrastructure.Dialogs;
 using SmartHopper.Infrastructure.Settings;
@@ -75,6 +76,15 @@ namespace SmartHopper.Providers.DeepSeek
                 },
                 new SettingDescriptor
                 {
+                    Name = "ReasoningEffort",
+                    Type = typeof(string),
+                    DefaultValue = "high",
+                    DisplayName = "Reasoning Effort",
+                    Description = "Controls DeepSeek thinking mode and reasoning depth. Use 'none' to disable thinking, or 'high'/'max' to enable it. Only applies to deepseek-v4 models and deepseek-reasoner.",
+                    AllowedValues = new[] { "none", "high", "max" },
+                },
+                new SettingDescriptor
+                {
                     Name = "MaxTokens",
                     DisplayName = "Max Tokens",
                     Description = "Maximum number of tokens to generate",
@@ -84,7 +94,7 @@ namespace SmartHopper.Providers.DeepSeek
                     {
                         UseSlider = false, // keep the NumericStepper
                         Min = 1,
-                        Max = 8192,
+                        Max = 400000,
                         Step = 1,
                     },
                 },
@@ -94,7 +104,15 @@ namespace SmartHopper.Providers.DeepSeek
                     Type = typeof(string),
                     DefaultValue = "0.5",
                     DisplayName = "Temperature",
-                    Description = "Controls randomness (0.0–2.0). Higher values like 1.5 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. Check https://api-docs.deepseek.com/quick_start/parameter_settings/ for more information.",
+                    Description = "Controls randomness (0.0–2.0). Higher values like 1.5 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. Has no effect in thinking mode. Check https://api-docs.deepseek.com/quick_start/parameter_settings/ for more information.",
+                },
+                new SettingDescriptor
+                {
+                    Name = "TopP",
+                    Type = typeof(string),
+                    DefaultValue = "1",
+                    DisplayName = "Top P",
+                    Description = "Controls nucleus sampling (0.0–1.0). Only adjust this or Temperature, not both. Has no effect in thinking mode.",
                 },
             };
         }
@@ -119,8 +137,10 @@ namespace SmartHopper.Providers.DeepSeek
             // Extract values from settings dictionary
             string? apiKey = null;
             string? model = null;
+            string? reasoningEffort = null;
             int? maxTokens = null;
             double? temperature = null;
+            double? topP = null;
 
             // Get API key if present
             if (settings.TryGetValue("ApiKey", out var apiKeyObj) && apiKeyObj != null)
@@ -175,6 +195,42 @@ namespace SmartHopper.Providers.DeepSeek
                     if (showErrorDialogs)
                     {
                         StyledMessageDialog.ShowError("Temperature must be between 0.0 and 2.0.", "Validation Error");
+                    }
+
+                    return false;
+                }
+            }
+
+            if (settings.TryGetValue("TopP", out var topPObj) && topPObj != null)
+            {
+                // Try to parse as double
+                if (double.TryParse(topPObj.ToString(), out double parsedTopP))
+                {
+                    topP = parsedTopP;
+                }
+
+                // Ensure top_p is between 0.0 and 1.0 (both included)
+                if (topP < 0.0 || topP > 1.0)
+                {
+                    if (showErrorDialogs)
+                    {
+                        StyledMessageDialog.ShowError("Top P must be between 0.0 and 1.0.", "Validation Error");
+                    }
+
+                    return false;
+                }
+            }
+
+            if (settings.TryGetValue("ReasoningEffort", out var reasoningEffortObj) && reasoningEffortObj != null)
+            {
+                reasoningEffort = reasoningEffortObj.ToString();
+
+                // Ensure reasoning effort is one of the supported values
+                if (string.IsNullOrWhiteSpace(reasoningEffort) || !new[] { "none", "high", "max" }.Contains(reasoningEffort, StringComparer.OrdinalIgnoreCase))
+                {
+                    if (showErrorDialogs)
+                    {
+                        StyledMessageDialog.ShowError("Reasoning Effort must be 'none', 'high', or 'max'.", "Validation Error");
                     }
 
                     return false;

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *
@@ -58,26 +58,14 @@ namespace SmartHopper.Providers.MistralAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistral-medium-3.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.Reasoning | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "mistral-medium-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Default = AICapability.ReasoningChat | AICapability.ToolReasoningChat,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 10000,
-                    ContextLimit = 256000,
-                    Aliases = new List<string> { "mistral-medium-3", "mistral-medium-2604", "mistral-medium-c21211-r0-75", "mistral-vibe-cli-latest", "mistral-medium-3-5" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistral-medium-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9995,
                     ContextLimit = 262144,
-                    Aliases = new List<string> { "mistral-medium", "mistral-medium-3-5", "mistral-medium-3.5", "mistral-medium-3", "mistral-medium-2604", "mistral-vibe-cli-latest", "mistral-vibe-cli-with-tools" },
+                    Aliases = new List<string> { "mistral-medium-3-5-0", "mistral-medium", "mistral-medium-3-5", "mistral-medium-3.5", "mistral-medium-3", "mistral-medium-2604", "mistral-vibe-cli-latest", "mistral-vibe-cli-with-tools" },
                 },
 
 
@@ -88,11 +76,11 @@ namespace SmartHopper.Providers.MistralAI
                 {
                     Provider = provider,
                     Model = "mistral-small-2603",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.Text2Json | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = true,
-                    Rank = 9990,
+                    Rank = 9995,
                     ContextLimit = 131072,
                     Aliases = new List<string> { "mistral-small", "mistral-small-latest", "magistral-small-latest", "mistral-vibe-cli-fast" },
                     DiscouragedForTools = new List<string> { "script_generate", "script_edit" },
@@ -109,9 +97,9 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9985,
+                    Rank = 9990,
                     ContextLimit = 131072,
-                    Aliases = new List<string> { "ministral-3b-latest" },
+                                        Aliases = new List<string> { "ministral-3b-latest" },
                 },
 
                 new AIModelCapabilities
@@ -121,9 +109,9 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9980,
+                    Rank = 9985,
                     ContextLimit = 131072,
-                    Aliases = new List<string> { "ministral-8b-latest" },
+                                        Aliases = new List<string> { "ministral-8b-latest" },
                 },
 
                 new AIModelCapabilities
@@ -133,9 +121,9 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9975,
+                    Rank = 9980,
                     ContextLimit = 262144,
-                    Aliases = new List<string> { "ministral-14b-latest" },
+                                        Aliases = new List<string> { "ministral-14b-latest" },
                 },
 
                 new AIModelCapabilities
@@ -145,9 +133,9 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9970,
+                    Rank = 9975,
                     ContextLimit = 131072,
-                    Aliases = new List<string> { "mistral-large", "mistral-large-latest" },
+                                        Aliases = new List<string> { "mistral-large", "mistral-large-latest", "mistral-large-veteran-2512" },
                 },
 
 
@@ -161,9 +149,9 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9965,
+                    Rank = 9970,
                     ContextLimit = 256000,
-                    Aliases = new List<string> { "codestral-latest", "mistral-code-latest", "mistral-code-fim-latest" },
+                                        Aliases = new List<string> { "codestral-latest", "mistral-code-latest", "mistral-code-fim-latest" },
                 },
 
 
@@ -177,7 +165,7 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9960,
+                    Rank = 9965,
                     Aliases = new List<string> { "codestral-embed-2505" },
                 },
 
@@ -185,10 +173,10 @@ namespace SmartHopper.Providers.MistralAI
                 {
                     Provider = provider,
                     Model = "labs-leanstral-1-5-1",
-                    Capabilities = AICapability.None, // TODO: retrieve capabilities
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9955,
+                    Rank = 9960,
                     Aliases = new List<string> { "labs-leanstral-1-5" },
                 },
 
@@ -199,15 +187,28 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9950,
+                    Rank = 9955,
                     Aliases = new List<string> { "mistral-embed" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "mistral-ocr-2512",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.ImageOutput,
+                    Default = AICapability.Text2Image | AICapability.Image2Image,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Rank = 9950,
+                    Aliases = new List<string> { "mistral-ocr-3-0", "mistral-ocr-3" },
+                    DiscouragedForTools = new List<string> { "*" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "mistral-ocr-latest",
-                    Capabilities = AICapability.None, // TODO: retrieve capabilities
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.ImageOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9945,
@@ -224,7 +225,7 @@ namespace SmartHopper.Providers.MistralAI
                     Verified = false,
                     Rank = 9940,
                     ContextLimit = 32000,
-                    Aliases = new List<string> { "voxtral-mini-latest" },
+                    Aliases = new List<string> { "voxtral-mini-transcribe-2602", "voxtral-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -265,7 +266,7 @@ namespace SmartHopper.Providers.MistralAI
                     Deprecated = true,
                     Rank = 0,
                     ContextLimit = 262144,
-                    Aliases = new List<string> { "devstral-medium-latest", "devstral-latest", "mistral-code-agent-latest" },
+                                        Aliases = new List<string> { "devstral-medium-latest", "devstral-latest", "devstral-medium-251121", "mistral-code-agent-latest" },
                 },
 
                 new AIModelCapabilities
@@ -348,7 +349,7 @@ namespace SmartHopper.Providers.MistralAI
                     Deprecated = true,
                     Rank = -35,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -401,25 +402,12 @@ namespace SmartHopper.Providers.MistralAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistral-ocr-2512",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.ImageOutput,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -60,
-                    Aliases = new List<string> { "mistral-ocr-3-0", "mistral-ocr-3" },
-                    DiscouragedForTools = new List<string> { "*" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
                     Model = "mistral-small-2506",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -65,
+                    Rank = -60,
                 },
 
                 new AIModelCapabilities
@@ -430,7 +418,7 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -70,
+                    Rank = -65,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "open-mistral-nemo-2407", "mistral-tiny-2407", "mistral-tiny-latest" },
                 },
@@ -443,9 +431,21 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -75,
+                    Rank = -70,
                     ContextLimit = 131072,
-                    Aliases = new List<string> { "pixtral-large-latest", "mistral-large-pixtral-2411" },
+                                        Aliases = new List<string> { "pixtral-large-latest", "mistral-large-pixtral-2411" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "voxtral-mini-2507",
+                    Capabilities = AICapability.AudioInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -75,
+                    Aliases = new List<string> { "voxtral-mini-latest" },
                 },
 
                 new AIModelCapabilities

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProviderModels.cs
@@ -53,7 +53,36 @@ namespace SmartHopper.Providers.MistralAI
 
             var models = new List<AIModelCapabilities>
             {
-                // Released between February 2026 and May 2026
+                // Released between April 2026 and July 2026
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistral-medium-3.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.Reasoning | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Default = AICapability.ReasoningChat | AICapability.ToolReasoningChat,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 10000,
+                    ContextLimit = 256000,
+                    Aliases = new List<string> { "mistral-medium-3", "mistral-medium-2604", "mistral-medium-c21211-r0-75", "mistral-vibe-cli-latest", "mistral-medium-3-5" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistral-medium-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9995,
+                    ContextLimit = 262144,
+                    Aliases = new List<string> { "mistral-medium", "mistral-medium-3-5", "mistral-medium-3.5", "mistral-medium-3", "mistral-medium-2604", "mistral-vibe-cli-latest", "mistral-vibe-cli-with-tools" },
+                },
+
+
+
+                // Released between January 2026 and April 2026
 
                 new AIModelCapabilities
                 {
@@ -63,28 +92,15 @@ namespace SmartHopper.Providers.MistralAI
                     Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.Text2Json | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = true,
-                    Rank = 10000,
+                    Rank = 9990,
                     ContextLimit = 131072,
                     Aliases = new List<string> { "mistral-small", "mistral-small-latest", "magistral-small-latest", "mistral-vibe-cli-fast" },
                     DiscouragedForTools = new List<string> { "script_generate", "script_edit" },
                 },
 
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistral-medium-3-5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.Reasoning | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    Default = AICapability.ReasoningChat | AICapability.ToolReasoningChat,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9995,
-                    ContextLimit = 256000,
-                    Aliases = new List<string> { "mistral-medium-3.5", "mistral-medium-3", "mistral-medium-2604", "mistral-medium-c21211-r0-75", "mistral-vibe-cli-latest" },
-                },
 
 
-
-                // Released between November 2025 and February 2026
+                // Released between October 2025 and January 2026
 
                 new AIModelCapabilities
                 {
@@ -93,7 +109,7 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9990,
+                    Rank = 9985,
                     ContextLimit = 131072,
                     Aliases = new List<string> { "ministral-3b-latest" },
                 },
@@ -105,7 +121,7 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9985,
+                    Rank = 9980,
                     ContextLimit = 131072,
                     Aliases = new List<string> { "ministral-8b-latest" },
                 },
@@ -117,7 +133,7 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9980,
+                    Rank = 9975,
                     ContextLimit = 262144,
                     Aliases = new List<string> { "ministral-14b-latest" },
                 },
@@ -129,26 +145,14 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9975,
+                    Rank = 9970,
                     ContextLimit = 131072,
                     Aliases = new List<string> { "mistral-large", "mistral-large-latest" },
                 },
 
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "devstral-2512",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9970,
-                    ContextLimit = 262144,
-                    Aliases = new List<string> { "devstral-medium-latest", "devstral-latest" },
-                },
 
 
-
-                // Released between May 2025 and August 2025
+                // Released between July 2025 and October 2025
 
                 new AIModelCapabilities
                 {
@@ -159,24 +163,12 @@ namespace SmartHopper.Providers.MistralAI
                     Verified = false,
                     Rank = 9965,
                     ContextLimit = 256000,
-                    Aliases = new List<string> { "codestral-latest" },
+                    Aliases = new List<string> { "codestral-latest", "mistral-code-latest", "mistral-code-fim-latest" },
                 },
 
 
 
-                // Released before May 2024 or unknown release date
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistral-medium-2508",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = true,
-                    Rank = 9960,
-                    ContextLimit = 131072,
-                    Aliases = new List<string> { "mistral-medium", "mistral-medium-latest", "mistral-vibe-cli-with-tools" },
-                },
+                // Released before July 2024 or unknown release date
 
                 new AIModelCapabilities
                 {
@@ -185,31 +177,19 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9955,
+                    Rank = 9960,
                     Aliases = new List<string> { "codestral-embed-2505" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "labs-leanstral-2603",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "labs-leanstral-1-5-1",
+                    Capabilities = AICapability.None, // TODO: retrieve capabilities
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9950,
-                    ContextLimit = 256000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "magistral-medium-2509",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9945,
-                    ContextLimit = 40000,
-                    Aliases = new List<string> { "magistral-medium-latest" },
+                    Rank = 9955,
+                    Aliases = new List<string> { "labs-leanstral-1-5" },
                 },
 
                 new AIModelCapabilities
@@ -219,43 +199,19 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9940,
+                    Rank = 9950,
                     Aliases = new List<string> { "mistral-embed" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistral-medium-2505",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "mistral-ocr-latest",
+                    Capabilities = AICapability.None, // TODO: retrieve capabilities
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9935,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistral-ocr-2512",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.ImageOutput,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9930,
-                    Aliases = new List<string> { "mistral-ocr-latest" },
-                    DiscouragedForTools = new List<string> { "*" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "open-mistral-nemo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9925,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "open-mistral-nemo-2407", "mistral-tiny-2407", "mistral-tiny-latest" },
+                    Rank = 9945,
+                    Aliases = new List<string> { "mistral-ocr-4-0", "mistral-ocr-4" },
                 },
 
                 new AIModelCapabilities
@@ -266,7 +222,7 @@ namespace SmartHopper.Providers.MistralAI
                     Default = AICapability.Speech2Text,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9920,
+                    Rank = 9940,
                     ContextLimit = 32000,
                     Aliases = new List<string> { "voxtral-mini-latest" },
                 },
@@ -279,7 +235,7 @@ namespace SmartHopper.Providers.MistralAI
                     Default = AICapability.Text2Speech,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9910,
+                    Rank = 9935,
                     Aliases = new List<string> { "voxtral-mini-tts-latest" },
                 },
 
@@ -290,7 +246,7 @@ namespace SmartHopper.Providers.MistralAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9905,
+                    Rank = 9930,
                     ContextLimit = 32000,
                     Aliases = new List<string> { "voxtral-small-latest" },
                 },
@@ -302,26 +258,26 @@ namespace SmartHopper.Providers.MistralAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistral-large-2411",
+                    Model = "devstral-2512",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = 0,
-                    ContextLimit = 131072,
+                    ContextLimit = 262144,
+                    Aliases = new List<string> { "devstral-medium-latest", "devstral-latest", "mistral-code-agent-latest" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "pixtral-large-2411",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = false,
-                    Verified = false,
+                    Model = "mistral-medium-2508",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = true,
                     Deprecated = true,
                     Rank = -5,
                     ContextLimit = 131072,
-                    Aliases = new List<string> { "pixtral-large-latest", "mistral-large-pixtral-2411" },
                 },
 
                 new AIModelCapabilities
@@ -349,12 +305,61 @@ namespace SmartHopper.Providers.MistralAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "labs-leanstral-2603",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -20,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "magistral-medium-2509",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -25,
+                    ContextLimit = 40000,
+                    Aliases = new List<string> { "magistral-medium-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "magistral-small-2509",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -20,
+                    Rank = -30,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistral-large-2411",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -35,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistral-medium-2505",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -40,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -365,7 +370,7 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -25,
+                    Rank = -45,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "mistral-moderation-latest" },
                 },
@@ -378,7 +383,7 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -30,
+                    Rank = -50,
                 },
 
                 new AIModelCapabilities
@@ -389,7 +394,20 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -35,
+                    Rank = -55,
+                    DiscouragedForTools = new List<string> { "*" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistral-ocr-2512",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.ImageOutput,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -60,
+                    Aliases = new List<string> { "mistral-ocr-3-0", "mistral-ocr-3" },
                     DiscouragedForTools = new List<string> { "*" },
                 },
 
@@ -401,7 +419,33 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -40,
+                    Rank = -65,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "open-mistral-nemo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -70,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "open-mistral-nemo-2407", "mistral-tiny-2407", "mistral-tiny-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "pixtral-large-2411",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -75,
+                    ContextLimit = 131072,
+                    Aliases = new List<string> { "pixtral-large-latest", "mistral-large-pixtral-2411" },
                 },
 
                 new AIModelCapabilities
@@ -412,7 +456,7 @@ namespace SmartHopper.Providers.MistralAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -45,
+                    Rank = -80,
                     Aliases = new List<string> { "voxtral-mini-2507" },
                 }
             };

--- a/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *

--- a/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *
@@ -63,7 +63,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 10000,
                     ContextLimit = 1050000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -74,19 +74,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9995,
                     ContextLimit = 1050000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5.5-2026-04-23",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9990,
-                    ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.5", "gpt-5.5-latest" },
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -95,8 +83,20 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 9990,
+                    ContextLimit = 1050000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.5-2026-04-23",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 9985,
                     ContextLimit = 1050000,
+                                        Aliases = new List<string> { "gpt-5.5", "gpt-5.5-latest" },
                 },
 
                 new AIModelCapabilities
@@ -108,7 +108,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9980,
                     ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.5-pro", "gpt-5.5-pro-latest" },
+                                        Aliases = new List<string> { "gpt-5.5-pro", "gpt-5.5-pro-latest" },
                 },
 
 
@@ -124,20 +124,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9975,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.4-nano", "gpt-5.4-nano-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5.4-mini-2026-03-17",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9970,
-                    ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.4-mini", "gpt-5.4-mini-latest" },
+                                        Aliases = new List<string> { "gpt-5.4-nano", "gpt-5.4-nano-latest" },
                 },
 
                 new AIModelCapabilities
@@ -148,20 +135,22 @@ namespace SmartHopper.Providers.OpenAI
                     Default = AICapability.Text2Speech | AICapability.Speech2Text,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9965,
+                    Rank = 9970,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-audio-mini", "gpt-audio-mini-latest" },
+                                        Aliases = new List<string> { "gpt-audio-mini", "gpt-audio-mini-latest" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-5.2-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "gpt-5.4-mini-2026-03-17",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9960,
+                    Rank = 9965,
                     ContextLimit = 400000,
+                                        Aliases = new List<string> { "gpt-5.4-mini", "gpt-5.4-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -171,9 +160,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9955,
+                    Rank = 9960,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.3-chat" },
+                                        Aliases = new List<string> { "gpt-5.3-chat" },
                 },
 
                 new AIModelCapabilities
@@ -183,9 +172,20 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 9955,
+                    ContextLimit = 400000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.2-codex",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 9950,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -196,7 +196,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9945,
                     ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.4", "gpt-5.4-latest" },
+                                        Aliases = new List<string> { "gpt-5.4", "gpt-5.4-latest" },
                 },
 
                 new AIModelCapabilities
@@ -208,7 +208,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9940,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-audio", "gpt-audio-latest" },
+                                        Aliases = new List<string> { "gpt-audio", "gpt-audio-latest" },
                 },
 
                 new AIModelCapabilities
@@ -220,7 +220,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9935,
                     ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.4-pro", "gpt-5.4-pro-latest" },
+                                        Aliases = new List<string> { "gpt-5.4-pro", "gpt-5.4-pro-latest" },
                 },
 
 
@@ -236,7 +236,18 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9930,
                     ContextLimit = 400000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.1-codex-max",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9925,
+                    ContextLimit = 400000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -245,9 +256,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9925,
+                    Rank = 9920,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.1", "gpt-5.1-latest" },
+                                        Aliases = new List<string> { "gpt-5.1", "gpt-5.1-latest" },
                 },
 
                 new AIModelCapabilities
@@ -257,9 +268,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9920,
+                    Rank = 9915,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-5.1-chat" },
+                                        Aliases = new List<string> { "gpt-5.1-chat" },
                 },
 
                 new AIModelCapabilities
@@ -269,19 +280,20 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9915,
+                    Rank = 9910,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-5.1-codex-max",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "gpt-5.2-chat-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9910,
-                    ContextLimit = 400000,
+                    Rank = 9905,
+                    ContextLimit = 128000,
+                                        Aliases = new List<string> { "gpt-5.2-chat" },
                 },
 
                 new AIModelCapabilities
@@ -291,21 +303,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9905,
-                    ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.2", "gpt-5.2-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5.2-chat-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 9900,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-5.2-chat" },
+                    ContextLimit = 400000,
+                                        Aliases = new List<string> { "gpt-5.2", "gpt-5.2-latest" },
                 },
 
                 new AIModelCapabilities
@@ -317,7 +317,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9895,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5.2-pro", "gpt-5.2-pro-latest" },
+                                        Aliases = new List<string> { "gpt-5.2-pro", "gpt-5.2-pro-latest" },
                 },
 
 
@@ -334,7 +334,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = true,
                     Rank = 9890,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5-mini", "gpt-5-mini-latest" },
+                                        Aliases = new List<string> { "gpt-5-mini", "gpt-5-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -346,7 +346,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9885,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5-nano", "gpt-5-nano-latest" },
+                                        Aliases = new List<string> { "gpt-5-nano", "gpt-5-nano-latest" },
                 },
 
                 new AIModelCapabilities
@@ -358,20 +358,19 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9880,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o4-mini-deep-research", "o4-mini-deep-research-latest" },
+                                        Aliases = new List<string> { "o4-mini-deep-research", "o4-mini-deep-research-latest" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-5-2025-08-07",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "gpt-5-codex",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9875,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5", "gpt-5-latest" },
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -382,18 +381,19 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9870,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-5-chat" },
+                                        Aliases = new List<string> { "gpt-5-chat" },
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-5-codex",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "gpt-5-2025-08-07",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9865,
                     ContextLimit = 400000,
+                                        Aliases = new List<string> { "gpt-5", "gpt-5-latest" },
                 },
 
                 new AIModelCapabilities
@@ -405,7 +405,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9860,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o3-deep-research", "o3-deep-research-latest" },
+                                        Aliases = new List<string> { "o3-deep-research", "o3-deep-research-latest" },
                 },
 
                 new AIModelCapabilities
@@ -417,7 +417,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9855,
                     ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5-pro", "gpt-5-pro-latest" },
+                                        Aliases = new List<string> { "gpt-5-pro", "gpt-5-pro-latest" },
                 },
 
 
@@ -433,7 +433,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9850,
                     ContextLimit = 1047576,
-                    Aliases = new List<string> { "gpt-4.1-nano", "gpt-4.1-nano-latest" },
+                                        Aliases = new List<string> { "gpt-4.1-nano", "gpt-4.1-nano-latest" },
                 },
 
                 new AIModelCapabilities
@@ -445,7 +445,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9845,
                     ContextLimit = 1047576,
-                    Aliases = new List<string> { "gpt-4.1-mini", "gpt-4.1-mini-latest" },
+                                        Aliases = new List<string> { "gpt-4.1-mini", "gpt-4.1-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -457,19 +457,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9840,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o4-mini", "o4-mini-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4.1-2025-04-14",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9835,
-                    ContextLimit = 1047576,
-                    Aliases = new List<string> { "gpt-4.1", "gpt-4.1-latest" },
+                                        Aliases = new List<string> { "o4-mini", "o4-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -479,9 +467,21 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9830,
+                    Rank = 9835,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o3", "o3-latest" },
+                                        Aliases = new List<string> { "o3", "o3-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-4.1-2025-04-14",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9830,
+                    ContextLimit = 1047576,
+                                        Aliases = new List<string> { "gpt-4.1", "gpt-4.1-latest" },
                 },
 
                 new AIModelCapabilities
@@ -493,7 +493,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9825,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o3-pro", "o3-pro-latest" },
+                                        Aliases = new List<string> { "o3-pro", "o3-pro-latest" },
                 },
 
 
@@ -509,7 +509,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9820,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-mini-search-preview", "gpt-4o-mini-search-preview-latest" },
+                                        Aliases = new List<string> { "gpt-4o-mini-search-preview", "gpt-4o-mini-search-preview-latest" },
                 },
 
                 new AIModelCapabilities
@@ -521,7 +521,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9815,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o3-mini", "o3-mini-latest" },
+                                        Aliases = new List<string> { "o3-mini", "o3-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -533,7 +533,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9810,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-search-preview", "gpt-4o-search-preview-latest" },
+                                        Aliases = new List<string> { "gpt-4o-search-preview", "gpt-4o-search-preview-latest" },
                 },
 
                 new AIModelCapabilities
@@ -545,7 +545,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9805,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o1-pro", "o1-pro-latest" },
+                                        Aliases = new List<string> { "o1-pro", "o1-pro-latest" },
                 },
 
 
@@ -561,7 +561,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9800,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o1", "o1-latest" },
+                                        Aliases = new List<string> { "o1", "o1-latest" },
                 },
 
 
@@ -577,7 +577,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9795,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-mini", "gpt-4o-mini-latest" },
+                                        Aliases = new List<string> { "gpt-4o-mini", "gpt-4o-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -589,7 +589,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9790,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-latest", "gpt-4o" },
+                                        Aliases = new List<string> { "gpt-4o-latest", "gpt-4o" },
                 },
 
 
@@ -605,7 +605,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9785,
                     ContextLimit = 4095,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -616,7 +616,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9780,
                     ContextLimit = 16385,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -627,7 +627,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9775,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -759,6 +759,7 @@ namespace SmartHopper.Providers.OpenAI
                     Provider = provider,
                     Model = "gpt-image-1",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.ImageOutput,
+                    Default = AICapability.Text2Image,
                     SupportsStreaming = false,
                     Verified = false,
                     Rank = 9715,
@@ -805,6 +806,7 @@ namespace SmartHopper.Providers.OpenAI
                     Verified = false,
                     Rank = 9695,
                     Aliases = new List<string> { "omni-moderation-latest", "omni-moderation" },
+                    DiscouragedForTools = new List<string> { "*" },
                 },
 
                 new AIModelCapabilities
@@ -895,7 +897,8 @@ namespace SmartHopper.Providers.OpenAI
                 {
                     Provider = provider,
                     Model = "whisper-1",
-                    Capabilities = AICapability.AudioInput | AICapability.TextOutput,
+                    Capabilities = AICapability.SpeechInput | AICapability.TextOutput,
+                    Default = AICapability.Speech2Text,
                     SupportsStreaming = false,
                     Verified = false,
                     Rank = 9650,
@@ -915,7 +918,7 @@ namespace SmartHopper.Providers.OpenAI
                     Deprecated = true,
                     Rank = 0,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -939,7 +942,7 @@ namespace SmartHopper.Providers.OpenAI
                     Deprecated = true,
                     Rank = -10,
                     ContextLimit = 16385,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -951,7 +954,7 @@ namespace SmartHopper.Providers.OpenAI
                     Deprecated = true,
                     Rank = -15,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4-turbo", "gpt-4-turbo-latest" },
+                                        Aliases = new List<string> { "gpt-4-turbo", "gpt-4-turbo-latest" },
                 },
 
                 new AIModelCapabilities
@@ -964,7 +967,7 @@ namespace SmartHopper.Providers.OpenAI
                     Deprecated = true,
                     Rank = -20,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1092,7 +1095,7 @@ namespace SmartHopper.Providers.OpenAI
                     Deprecated = true,
                     Rank = -75,
                     ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-audio-preview", "gpt-4o-audio-preview-latest" },
+                                        Aliases = new List<string> { "gpt-4o-audio-preview", "gpt-4o-audio-preview-latest" },
                 },
 
                 new AIModelCapabilities

--- a/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenAI/OpenAIProviderModels.cs
@@ -52,7 +52,68 @@ namespace SmartHopper.Providers.OpenAI
 
             var models = new List<AIModelCapabilities>
             {
-                // Released between February 2026 and May 2026
+                // Released between April 2026 and July 2026
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.6-luna",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 10000,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.6-terra",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9995,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.5-2026-04-23",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9990,
+                    ContextLimit = 1050000,
+                    Aliases = new List<string> { "gpt-5.5", "gpt-5.5-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.6-sol",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9985,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.5-pro-2026-04-23",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9980,
+                    ContextLimit = 1050000,
+                    Aliases = new List<string> { "gpt-5.5-pro", "gpt-5.5-pro-latest" },
+                },
+
+
+
+                // Released between January 2026 and April 2026
 
                 new AIModelCapabilities
                 {
@@ -61,7 +122,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 10000,
+                    Rank = 9975,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.4-nano", "gpt-5.4-nano-latest" },
                 },
@@ -71,12 +132,36 @@ namespace SmartHopper.Providers.OpenAI
                     Provider = provider,
                     Model = "gpt-5.4-mini-2026-03-17",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = false,
-                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
-                    Rank = 9995,
+                    Rank = 9970,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.4-mini", "gpt-5.4-mini-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-audio-mini-2025-12-15",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
+                    Default = AICapability.Text2Speech | AICapability.Speech2Text,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Rank = 9965,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-audio-mini", "gpt-audio-mini-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5.2-codex",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9960,
+                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
@@ -86,7 +171,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9990,
+                    Rank = 9955,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.3-chat" },
                 },
@@ -98,7 +183,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9985,
+                    Rank = 9950,
                     ContextLimit = 400000,
                 },
 
@@ -109,7 +194,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9980,
+                    Rank = 9945,
                     ContextLimit = 1050000,
                     Aliases = new List<string> { "gpt-5.4", "gpt-5.4-latest" },
                 },
@@ -117,13 +202,13 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-5.5-2026-04-23",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "gpt-audio-2025-08-28",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9975,
-                    ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.5", "gpt-5.5-latest" },
+                    Rank = 9940,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-audio", "gpt-audio-latest" },
                 },
 
                 new AIModelCapabilities
@@ -133,26 +218,14 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9970,
+                    Rank = 9935,
                     ContextLimit = 1050000,
                     Aliases = new List<string> { "gpt-5.4-pro", "gpt-5.4-pro-latest" },
                 },
 
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5.5-pro-2026-04-23",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9965,
-                    ContextLimit = 1050000,
-                    Aliases = new List<string> { "gpt-5.5-pro", "gpt-5.5-pro-latest" },
-                },
 
 
-
-                // Released between November 2025 and February 2026
+                // Released between October 2025 and January 2026
 
                 new AIModelCapabilities
                 {
@@ -161,21 +234,8 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9960,
+                    Rank = 9930,
                     ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-audio-mini-2025-12-15",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
-                    Default = AICapability.Text2Speech | AICapability.Speech2Text,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9955,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-audio-mini", "gpt-audio-mini-latest" },
                 },
 
                 new AIModelCapabilities
@@ -185,7 +245,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9950,
+                    Rank = 9925,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.1", "gpt-5.1-latest" },
                 },
@@ -197,7 +257,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9945,
+                    Rank = 9920,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-5.1-chat" },
                 },
@@ -209,7 +269,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9940,
+                    Rank = 9915,
                     ContextLimit = 400000,
                 },
 
@@ -220,7 +280,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9935,
+                    Rank = 9910,
                     ContextLimit = 400000,
                 },
 
@@ -231,7 +291,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9930,
+                    Rank = 9905,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.2", "gpt-5.2-latest" },
                 },
@@ -243,32 +303,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9925,
+                    Rank = 9900,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-5.2-chat" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5.2-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9920,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-audio-2025-08-28",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9915,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-audio", "gpt-audio-latest" },
                 },
 
                 new AIModelCapabilities
@@ -278,87 +315,24 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9910,
+                    Rank = 9895,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5.2-pro", "gpt-5.2-pro-latest" },
                 },
 
 
 
-                // Released between August 2025 and November 2025
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "o4-mini-deep-research-2025-06-26",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9905,
-                    ContextLimit = 200000,
-                    Aliases = new List<string> { "o4-mini-deep-research", "o4-mini-deep-research-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5-codex",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9900,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "o3-deep-research-2025-06-26",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9895,
-                    ContextLimit = 200000,
-                    Aliases = new List<string> { "o3-deep-research", "o3-deep-research-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4o-audio-preview-2025-06-03",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9890,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-audio-preview", "gpt-4o-audio-preview-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-5-pro-2025-10-06",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9885,
-                    ContextLimit = 400000,
-                    Aliases = new List<string> { "gpt-5-pro", "gpt-5-pro-latest" },
-                },
-
-
-
-                // Released between May 2025 and August 2025
+                // Released between July 2025 and October 2025
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "gpt-5-mini-2025-08-07",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
                     SupportsStreaming = true,
                     Verified = true,
-                    Default = AICapability.Text2Text | AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat | AICapability.Text2Json | AICapability.Image2Text,
-                    Rank = 9880,
+                    Rank = 9890,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5-mini", "gpt-5-mini-latest" },
                 },
@@ -370,9 +344,21 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9875,
+                    Rank = 9885,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5-nano", "gpt-5-nano-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "o4-mini-deep-research-2025-06-26",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9880,
+                    ContextLimit = 200000,
+                    Aliases = new List<string> { "o4-mini-deep-research", "o4-mini-deep-research-latest" },
                 },
 
                 new AIModelCapabilities
@@ -382,7 +368,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9870,
+                    Rank = 9875,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5", "gpt-5-latest" },
                 },
@@ -394,7 +380,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9865,
+                    Rank = 9870,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-5-chat" },
                 },
@@ -402,18 +388,41 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "o3-pro-2025-06-10",
+                    Model = "gpt-5-codex",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9865,
+                    ContextLimit = 400000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "o3-deep-research-2025-06-26",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9860,
                     ContextLimit = 200000,
-                    Aliases = new List<string> { "o3-pro", "o3-pro-latest" },
+                    Aliases = new List<string> { "o3-deep-research", "o3-deep-research-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-5-pro-2025-10-06",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9855,
+                    ContextLimit = 400000,
+                    Aliases = new List<string> { "gpt-5-pro", "gpt-5-pro-latest" },
                 },
 
 
 
-                // Released between February 2025 and May 2025
+                // Released between April 2025 and July 2025
 
                 new AIModelCapabilities
                 {
@@ -422,21 +431,9 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9855,
+                    Rank = 9850,
                     ContextLimit = 1047576,
                     Aliases = new List<string> { "gpt-4.1-nano", "gpt-4.1-nano-latest" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4o-mini-search-preview-2025-03-11",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9850,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-mini-search-preview", "gpt-4o-mini-search-preview-latest" },
                 },
 
                 new AIModelCapabilities
@@ -490,30 +487,30 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "gpt-4o-search-preview-2025-03-11",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    Model = "o3-pro-2025-06-10",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9825,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-search-preview", "gpt-4o-search-preview-latest" },
+                    ContextLimit = 200000,
+                    Aliases = new List<string> { "o3-pro", "o3-pro-latest" },
                 },
+
+
+
+                // Released between January 2025 and April 2025
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "o1-pro-2025-03-19",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "gpt-4o-mini-search-preview-2025-03-11",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9820,
-                    ContextLimit = 200000,
-                    Aliases = new List<string> { "o1-pro", "o1-pro-latest" },
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-4o-mini-search-preview", "gpt-4o-mini-search-preview-latest" },
                 },
-
-
-
-                // Released between November 2024 and February 2025
 
                 new AIModelCapabilities
                 {
@@ -530,18 +527,46 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "gpt-4o-search-preview-2025-03-11",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9810,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-4o-search-preview", "gpt-4o-search-preview-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "o1-pro-2025-03-19",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9805,
+                    ContextLimit = 200000,
+                    Aliases = new List<string> { "o1-pro", "o1-pro-latest" },
+                },
+
+
+
+                // Released between October 2024 and January 2025
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "o1-2024-12-17",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9810,
+                    Rank = 9800,
                     ContextLimit = 200000,
                     Aliases = new List<string> { "o1", "o1-latest" },
                 },
 
 
 
-                // Released between May 2024 and August 2024
+                // Released between July 2024 and October 2024
 
                 new AIModelCapabilities
                 {
@@ -550,7 +575,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.ImageInput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9805,
+                    Rank = 9795,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-4o-mini", "gpt-4o-mini-latest" },
                 },
@@ -562,36 +587,14 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9800,
+                    Rank = 9790,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-4o-latest", "gpt-4o" },
                 },
 
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4o-2024-05-13",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9795,
-                    ContextLimit = 128000,
-                },
 
 
-
-                // Released before May 2024 or unknown release date
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "dall-e-3",
-                    Capabilities = AICapability.TextInput | AICapability.ImageOutput,
-                    Default = AICapability.Text2Image,
-                    SupportsStreaming = false,
-                    Verified = true,
-                    Rank = 9790,
-                },
+                // Released before July 2024 or unknown release date
 
                 new AIModelCapabilities
                 {
@@ -618,11 +621,22 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "gpt-4o-2024-05-13",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9775,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "chat-latest",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9775,
+                    Rank = 9770,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "chat" },
                 },
@@ -633,32 +647,9 @@ namespace SmartHopper.Providers.OpenAI
                     Model = "chatgpt-image-latest",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
                     Verified = false,
-                    Rank = 9770,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "chatgpt-image" },
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4o-audio-preview-2024-12-17",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = false,
-                    Verified = false,
                     Rank = 9765,
                     ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "gpt-4o-mini-audio-preview-2024-12-17",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = false,
-                    Verified = false,
-                    Rank = 9760,
-                    ContextLimit = 128000,
-                    Aliases = new List<string> { "gpt-4o-mini-audio-preview", "gpt-4o-mini-audio-preview-latest" },
+                    Aliases = new List<string> { "chatgpt-image" },
                 },
 
                 new AIModelCapabilities
@@ -668,7 +659,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9750,
+                    Rank = 9760,
                     ContextLimit = 16000,
                 },
 
@@ -679,7 +670,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9745,
+                    Rank = 9755,
                     ContextLimit = 16000,
                     Aliases = new List<string> { "gpt-4o-mini-transcribe", "gpt-4o-mini-transcribe-latest" },
                 },
@@ -691,7 +682,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9740,
+                    Rank = 9750,
                     ContextLimit = 2000,
                 },
 
@@ -702,7 +693,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9735,
+                    Rank = 9745,
                     ContextLimit = 2000,
                     Aliases = new List<string> { "gpt-4o-mini-tts", "gpt-4o-mini-tts-latest" },
                 },
@@ -714,7 +705,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9720,
+                    Rank = 9740,
                     ContextLimit = 16000,
                 },
 
@@ -725,7 +716,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9715,
+                    Rank = 9735,
                     ContextLimit = 16000,
                 },
 
@@ -736,7 +727,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9710,
+                    Rank = 9730,
                     ContextLimit = 400000,
                     Aliases = new List<string> { "gpt-5-search-api", "gpt-5-search-api-latest" },
                 },
@@ -748,7 +739,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9705,
+                    Rank = 9725,
                     ContextLimit = 128000,
                 },
 
@@ -759,7 +750,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9700,
+                    Rank = 9720,
                     ContextLimit = 128000,
                 },
 
@@ -770,7 +761,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.ImageOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9695,
+                    Rank = 9715,
                 },
 
                 new AIModelCapabilities
@@ -780,7 +771,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.ImageOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9690,
+                    Rank = 9710,
                 },
 
                 new AIModelCapabilities
@@ -790,7 +781,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.ImageOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9685,
+                    Rank = 9705,
                 },
 
                 new AIModelCapabilities
@@ -801,7 +792,7 @@ namespace SmartHopper.Providers.OpenAI
                     Default = AICapability.Image2Image,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9680,
+                    Rank = 9700,
                     Aliases = new List<string> { "gpt-image-2", "gpt-image-2-latest" },
                 },
 
@@ -812,7 +803,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.ImageInput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9640,
+                    Rank = 9695,
                     Aliases = new List<string> { "omni-moderation-latest", "omni-moderation" },
                 },
 
@@ -823,7 +814,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.VideoOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9635,
+                    Rank = 9690,
                 },
 
                 new AIModelCapabilities
@@ -833,7 +824,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.VideoOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9630,
+                    Rank = 9685,
                 },
 
                 new AIModelCapabilities
@@ -843,7 +834,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9625,
+                    Rank = 9680,
                 },
 
                 new AIModelCapabilities
@@ -853,7 +844,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.EmbedOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9620,
+                    Rank = 9675,
                 },
 
                 new AIModelCapabilities
@@ -863,7 +854,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9615,
+                    Rank = 9670,
                     ContextLimit = 2000,
                 },
 
@@ -874,7 +865,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9610,
+                    Rank = 9665,
                     ContextLimit = 2000,
                 },
 
@@ -885,7 +876,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9605,
+                    Rank = 9660,
                     ContextLimit = 2000,
                 },
 
@@ -896,7 +887,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.TextInput | AICapability.AudioOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9600,
+                    Rank = 9655,
                     ContextLimit = 2000,
                 },
 
@@ -907,7 +898,7 @@ namespace SmartHopper.Providers.OpenAI
                     Capabilities = AICapability.AudioInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
-                    Rank = 9595,
+                    Rank = 9650,
                 },
 
 
@@ -929,12 +920,24 @@ namespace SmartHopper.Providers.OpenAI
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "dall-e-3",
+                    Capabilities = AICapability.TextInput | AICapability.ImageOutput,
+                    Default = AICapability.Text2Image,
+                    SupportsStreaming = false,
+                    Verified = true,
+                    Deprecated = true,
+                    Rank = -5,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "gpt-3.5-turbo",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -5,
+                    Rank = -10,
                     ContextLimit = 16385,
                 },
 
@@ -946,7 +949,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -10,
+                    Rank = -15,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "gpt-4-turbo", "gpt-4-turbo-latest" },
                 },
@@ -959,7 +962,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -15,
+                    Rank = -20,
                     ContextLimit = 8192,
                 },
 
@@ -971,7 +974,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -20,
+                    Rank = -25,
                 },
 
                 new AIModelCapabilities
@@ -982,7 +985,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -25,
+                    Rank = -30,
                     ContextLimit = 128000,
                     Aliases = new List<string> { "chatgpt-4o" },
                 },
@@ -995,7 +998,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -30,
+                    Rank = -35,
                     ContextLimit = 200000,
                     Aliases = new List<string> { "codex-mini" },
                 },
@@ -1008,7 +1011,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -35,
+                    Rank = -40,
                 },
 
                 new AIModelCapabilities
@@ -1019,7 +1022,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -40,
+                    Rank = -45,
                 },
 
                 new AIModelCapabilities
@@ -1030,7 +1033,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -45,
+                    Rank = -50,
                 },
 
                 new AIModelCapabilities
@@ -1041,7 +1044,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -50,
+                    Rank = -55,
                 },
 
                 new AIModelCapabilities
@@ -1052,7 +1055,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -55,
+                    Rank = -60,
                 },
 
                 new AIModelCapabilities
@@ -1063,8 +1066,46 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -60,
+                    Rank = -65,
                     ContextLimit = 8192,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-4o-audio-preview-2024-12-17",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -70,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-4o-audio-preview-2025-06-03",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -75,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-4o-audio-preview", "gpt-4o-audio-preview-latest" },
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "gpt-4o-mini-audio-preview-2024-12-17",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = false,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -80,
+                    ContextLimit = 128000,
+                    Aliases = new List<string> { "gpt-4o-mini-audio-preview", "gpt-4o-mini-audio-preview-latest" },
                 },
 
                 new AIModelCapabilities
@@ -1075,7 +1116,7 @@ namespace SmartHopper.Providers.OpenAI
                     SupportsStreaming = false,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -65,
+                    Rank = -85,
                 }
             };
 

--- a/src/SmartHopper.Providers.OpenRouter/OpenRouterProvider.cs
+++ b/src/SmartHopper.Providers.OpenRouter/OpenRouterProvider.cs
@@ -346,13 +346,8 @@ namespace SmartHopper.Providers.OpenRouter
             }
             else if (interaction is AIInteractionToolResult toolResultInteraction)
             {
-                // Format for tool results
+                // Format for tool results (OpenRouter docs only document role, tool_call_id and content).
                 obj["tool_call_id"] = toolResultInteraction.Id;
-                if (!string.IsNullOrWhiteSpace(toolResultInteraction.Name))
-                {
-                    obj["name"] = toolResultInteraction.Name;
-                }
-
                 obj["content"] = toolResultInteraction.Result?.ToString() ?? string.Empty;
             }
             else if (interaction is AIInteractionToolCall toolCallInteraction)

--- a/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *

--- a/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
@@ -51,7 +51,17 @@ namespace SmartHopper.Providers.OpenRouter
             // Sample curated models exposed via OpenRouter
             var models = new List<AIModelCapabilities>
             {
-                // Released between February 2026 and May 2026
+                // Released between April 2026 and July 2026
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openrouter/fusion",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Verified = false,
+                    Rank = 10000,
+                    ContextLimit = 1000000,
+                },
 
                 new AIModelCapabilities
                 {
@@ -60,94 +70,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 10000,
+                    Rank = 9995,
                     ContextLimit = 2000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "baidu/cobuddy:free",
+                    Model = "cohere/north-mini-code:free",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9995,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "baidu/qianfan-ocr-fast:free",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
                     Rank = 9990,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-4-26b-a4b-it:free",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9985,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-4-31b-it:free",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9980,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/lyria-3-clip-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9975,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/lyria-3-pro-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9970,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "inclusionai/ring-2.6-1t:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9965,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "minimax/minimax-m2.5:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9960,
-                    ContextLimit = 196608,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -157,30 +91,28 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9955,
+                    Rank = 9985,
                     ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-3-super-120b-a12b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "nvidia/nemotron-3-ultra-550b-a55b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9950,
-                    ContextLimit = 262144,
+                    Rank = 9980,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openrouter/owl-alpha",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
+                    Model = "nvidia/nemotron-3.5-content-safety:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9945,
-                    ContextLimit = 1048756,
+                    Rank = 9975,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -190,62 +122,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9940,
-                    ContextLimit = 131072,
+                    Rank = 9970,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "poolside/laguna-xs.2:free",
+                    Model = "poolside/laguna-xs-2.1:free",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9935,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "ibm-granite/granite-4.1-8b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9930,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "rekaai/reka-edge",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9925,
-                    ContextLimit = 16384,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "liquid/lfm-2-24b-a2b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9920,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.5-9b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9915,
+                    Rank = 9965,
                     ContextLimit = 262144,
                 },
 
@@ -256,28 +143,38 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9910,
+                    Rank = 9960,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3.5-flash-02-23",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "ibm-granite/granite-4.1-8b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9905,
-                    ContextLimit = 1000000,
+                    Rank = 9955,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "tencent/hy3-preview",
+                    Model = "nex-agi/nex-n2-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9950,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "poolside/laguna-xs-2.1",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9900,
+                    Rank = 9945,
                     ContextLimit = 262144,
                 },
 
@@ -288,249 +185,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9895,
+                    Rank = 9940,
                     ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemma-4-26b-a4b-it",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "tencent/hy3-preview",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9890,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-4-31b-it",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9885,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "bytedance-seed/seed-2.0-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9880,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/nemotron-3-super-120b-a12b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9875,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-small-2603",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9870,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "inception/mercury-2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9865,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "arcee-ai/trinity-large-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9860,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-v4-pro",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9855,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.5-35b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9850,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.6-35b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9845,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "minimax/minimax-m2.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9840,
-                    ContextLimit = 196608,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "kwaipilot/kat-coder-pro-v2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9835,
-                    ContextLimit = 256000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "minimax/minimax-m2.7",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9830,
-                    ContextLimit = 196608,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.4-nano",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9825,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.6-flash",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9820,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.5-27b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9815,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.5-plus-02-15",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9810,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "aion-labs/aion-2.0",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9805,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9800,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.6-plus",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9795,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "bytedance-seed/seed-2.0-lite",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9790,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "xiaomi/mimo-v2-omni",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9785,
+                    Rank = 9935,
                     ContextLimit = 262144,
                 },
 
@@ -541,62 +206,38 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9780,
+                    Rank = 9930,
                     ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3.5-122b-a10b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "poolside/laguna-m.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9775,
+                    Rank = 9925,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-3.1-flash-lite",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "tencent/hy3",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9770,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-flash-lite-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9765,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3.5-397b-a17b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9760,
+                    Rank = 9920,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3.5-plus-20260420",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "kwaipilot/kat-coder-air-v2.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     Verified = false,
-                    Rank = 9755,
-                    ContextLimit = 1000000,
+                    Rank = 9915,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -605,51 +246,28 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "inclusionai/ling-2.6-1t",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     Verified = false,
-                    Rank = 9750,
+                    Rank = 9910,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4.20",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "inclusionai/ring-2.6-1t",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9745,
-                    ContextLimit = 2000000,
+                    Rank = 9905,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4.3",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9740,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-flash-image-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9735,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "xiaomi/mimo-v2-pro",
+                    Model = "deepseek/deepseek-v4-pro",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9730,
+                    Rank = 9900,
                     ContextLimit = 1048576,
                 },
 
@@ -660,7 +278,130 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9725,
+                    Rank = 9895,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nex-agi/nex-n2-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9890,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.6-35b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9885,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.6-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9880,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "stepfun/step-3.7-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9875,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "minimax/minimax-m3",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9870,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.7-plus",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9865,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-3.0-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9860,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "perceptron/perceptron-mk1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9855,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.5-plus-20260420",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9850,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-build-0.1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9845,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/nemotron-3-ultra-550b-a55b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9840,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-lite",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9835,
                     ContextLimit = 1048576,
                 },
 
@@ -671,8 +412,39 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9720,
+                    Rank = 9830,
                     ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4.3",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9825,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5.2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9820,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "kwaipilot/kat-coder-pro-v2.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Verified = false,
+                    Rank = 9815,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -682,7 +454,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9715,
+                    Rank = 9810,
                     ContextLimit = 262144,
                 },
 
@@ -693,52 +465,28 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9710,
+                    Rank = 9805,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "z-ai/glm-5.1",
+                    Model = "moonshotai/kimi-k2.7-code",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9800,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.7-max",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9705,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9700,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5v-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9695,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "~google/gemini-flash-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9690,
-                    ContextLimit = 1048576,
+                    Rank = 9795,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -748,18 +496,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9685,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.4-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9680,
+                    Rank = 9790,
                     ContextLimit = 400000,
                 },
 
@@ -770,19 +507,58 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9675,
+                    Rank = 9785,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4.20-multi-agent",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "~x-ai/grok-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9670,
-                    ContextLimit = 2000000,
+                    Rank = 9780,
+                    ContextLimit = 500000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-3.0",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9775,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-luna",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9770,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-luna-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9765,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4.5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9760,
+                    ContextLimit = 500000,
                 },
 
                 new AIModelCapabilities
@@ -792,7 +568,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9665,
+                    Rank = 9755,
                     ContextLimit = 262144,
                 },
 
@@ -802,30 +578,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "mistralai/mistral-medium-3-5",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9660,
+                    Rank = 9750,
                     ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.3-chat",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9655,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.3-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9650,
-                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
@@ -835,41 +589,59 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9645,
+                    Rank = 9745,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-sonnet-4.6",
+                    Model = "anthropic/claude-sonnet-5",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9640,
+                    Rank = 9740,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.4",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "~google/gemini-flash-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9635,
+                    Rank = 9735,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.5-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9730,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-terra",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9725,
                     ContextLimit = 1050000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.4-image-2",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "openai/gpt-5.6-terra-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9630,
-                    ContextLimit = 272000,
+                    Rank = 9720,
+                    ContextLimit = 1050000,
                 },
 
                 new AIModelCapabilities
@@ -879,29 +651,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9625,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-pro-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9620,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-pro-preview-customtools",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9615,
+                    Rank = 9715,
                     ContextLimit = 1048576,
                 },
 
@@ -912,7 +662,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9610,
+                    Rank = 9710,
                     ContextLimit = 1000000,
                 },
 
@@ -923,7 +673,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9605,
+                    Rank = 9705,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-opus-4.8",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9700,
                     ContextLimit = 1000000,
                 },
 
@@ -934,7 +694,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9600,
+                    Rank = 9695,
                     ContextLimit = 1050000,
                 },
 
@@ -945,7 +705,27 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9595,
+                    Rank = 9690,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-sol",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9685,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-sol-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9680,
                     ContextLimit = 1050000,
                 },
 
@@ -955,30 +735,99 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "openai/gpt-chat-latest",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     Verified = false,
-                    Rank = 9590,
+                    Rank = 9675,
                     ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-opus-4.6-fast",
+                    Model = "sakana/fugu-ultra",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9585,
+                    Rank = 9670,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.4-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "google/gemini-3.1-flash-lite-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9665,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.4-image-2",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9580,
-                    ContextLimit = 1050000,
+                    Rank = 9660,
+                    ContextLimit = 272000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "~anthropic/claude-fable-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9655,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-fable-5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9650,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-opus-4.8-fast",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9645,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9640,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3-pro-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9635,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-opus-4.7-fast",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9630,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -988,56 +837,67 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9575,
+                    Rank = 9625,
                     ContextLimit = 1050000,
                 },
 
 
 
-                // Released between November 2025 and February 2026
+                // Released between January 2026 and April 2026
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openrouter/bodybuilder",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "google/gemma-4-26b-a4b-it:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9570,
-                    ContextLimit = 128000,
+                    Rank = 9620,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "liquid/lfm-2.5-1.2b-instruct:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "google/gemma-4-31b-it:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9565,
-                    ContextLimit = 32768,
+                    Rank = 9615,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "liquid/lfm-2.5-1.2b-thinking:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "google/lyria-3-clip-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9560,
-                    ContextLimit = 32768,
+                    Rank = 9610,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-3-nano-30b-a3b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "google/lyria-3-pro-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9555,
-                    ContextLimit = 256000,
+                    Rank = 9605,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/nemotron-3-super-120b-a12b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9600,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -1047,118 +907,85 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9550,
+                    Rank = 9595,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/ministral-3b-2512",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "rekaai/reka-edge",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9545,
-                    ContextLimit = 131072,
+                    Rank = 9590,
+                    ContextLimit = 16384,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "arcee-ai/trinity-mini",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9540,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "essentialai/rnj-1-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9535,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/ministral-8b-2512",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9530,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/ministral-14b-2512",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9525,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/nemotron-3-nano-30b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9520,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "bytedance-seed/seed-1.6-flash",
+                    Model = "qwen/qwen3.5-9b",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9515,
+                    Rank = 9585,
                     ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.5-flash-02-23",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9580,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "stepfun/step-3.5-flash",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9510,
+                    Rank = 9575,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "xiaomi/mimo-v2-flash",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "google/gemma-4-26b-a4b-it",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9505,
+                    Rank = 9570,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepseek/deepseek-v3.2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "google/gemma-4-31b-it",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9500,
-                    ContextLimit = 131072,
+                    Rank = 9565,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "bytedance-seed/seed-2.0-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9560,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -1168,52 +995,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9495,
+                    Rank = 9555,
                     ContextLimit = 202752,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepseek/deepseek-v3.2-speciale",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "nvidia/nemotron-3-super-120b-a12b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9490,
-                    ContextLimit = 163840,
+                    Rank = 9550,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "arcee-ai/trinity-large-preview",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "mistralai/mistral-small-2603",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9485,
-                    ContextLimit = 131000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "allenai/olmo-3-32b-think",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9480,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nex-agi/deepseek-v3.1-nex-n1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9475,
-                    ContextLimit = 131072,
+                    Rank = 9545,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -1223,8 +1028,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9470,
+                    Rank = 9540,
                     ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "inception/mercury-2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9535,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/trinity-large-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9530,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -1234,41 +1061,52 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9465,
+                    Rank = 9525,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "z-ai/glm-4.6v",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "minimax/minimax-m2.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9460,
-                    ContextLimit = 131072,
+                    Rank = 9520,
+                    ContextLimit = 204800,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "minimax/minimax-m2.1",
+                    Model = "minimax/minimax-m2.7",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9455,
-                    ContextLimit = 196608,
+                    Rank = 9515,
+                    ContextLimit = 204800,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "prime-intellect/intellect-3",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "qwen/qwen3.5-35b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9450,
-                    ContextLimit = 131072,
+                    Rank = 9510,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "kwaipilot/kat-coder-pro-v2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9505,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -1278,62 +1116,84 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9445,
+                    Rank = 9500,
                     ContextLimit = 65536,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepcogito/cogito-v2.1-671b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5.4-nano",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9440,
-                    ContextLimit = 128000,
+                    Rank = 9495,
+                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/mistral-large-2512",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "qwen/qwen3.5-27b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9435,
+                    Rank = 9490,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "z-ai/glm-4.7",
+                    Model = "qwen/qwen3.5-plus-02-15",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9485,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-2.0",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9430,
+                    Rank = 9480,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9475,
                     ContextLimit = 202752,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "bytedance-seed/seed-1.6",
+                    Model = "qwen/qwen3.6-plus",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9425,
-                    ContextLimit = 262144,
+                    Rank = 9470,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/devstral-2512",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "bytedance-seed/seed-2.0-lite",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9420,
+                    Rank = 9465,
                     ContextLimit = 262144,
                 },
 
@@ -1344,14 +1204,113 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9415,
+                    Rank = 9460,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.1-codex-mini",
+                    Model = "qwen/qwen3.5-122b-a10b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9455,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-lite-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9450,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3.5-397b-a17b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9445,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4.20",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9440,
+                    ContextLimit = 2000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4.20-multi-agent",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9435,
+                    ContextLimit = 2000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9430,
+                    ContextLimit = 202752,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-max-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9425,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9420,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5v-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9415,
+                    ContextLimit = 202752,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.4-mini",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
@@ -1362,56 +1321,12 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "amazon/nova-2-lite-v1",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9405,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
                     Model = "openai/gpt-audio-mini",
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9400,
+                    Rank = 9405,
                     ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "relace/relace-search",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9395,
-                    ContextLimit = 256000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-max-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9390,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3-flash-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9385,
-                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -1421,74 +1336,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9380,
+                    Rank = 9400,
                     ContextLimit = 1040000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.1",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9375,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.1-chat",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9370,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.1-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9365,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.1-codex-max",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9360,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.2",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9355,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.2-chat",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9350,
-                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -1498,30 +1347,74 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9345,
+                    Rank = 9395,
                     ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-3-pro-image-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5.3-chat",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9340,
-                    ContextLimit = 65536,
+                    Rank = 9390,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-opus-4.5",
+                    Model = "openai/gpt-5.3-codex",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9335,
-                    ContextLimit = 200000,
+                    Rank = 9385,
+                    ContextLimit = 400000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-sonnet-4.6",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9380,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.4",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9375,
+                    ContextLimit = 1050000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-pro-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9370,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-pro-preview-customtools",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9365,
+                    ContextLimit = 1048756,
                 },
 
                 new AIModelCapabilities
@@ -1531,8 +1424,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9330,
+                    Rank = 9360,
                     ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-image-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9355,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -1542,24 +1446,46 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9325,
+                    Rank = 9350,
                     ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.2-pro",
+                    Model = "openai/gpt-5.4-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9320,
-                    ContextLimit = 400000,
+                    Rank = 9345,
+                    ContextLimit = 1050000,
                 },
 
 
 
-                // Released between August 2025 and November 2025
+                // Released between October 2025 and January 2026
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openrouter/bodybuilder",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9340,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/nemotron-3-nano-30b-a3b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9335,
+                    ContextLimit = 256000,
+                },
 
                 new AIModelCapabilities
                 {
@@ -1568,26 +1494,59 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9315,
+                    Rank = 9330,
                     ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-nano-9b-v2:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "mistralai/ministral-3b-2512",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9325,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "ibm-granite/granite-4.0-h-micro",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9320,
+                    ContextLimit = 131000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/ministral-8b-2512",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9315,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/ministral-14b-2512",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9310,
-                    ContextLimit = 128000,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3-next-80b-a3b-instruct:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "nvidia/nemotron-3-nano-30b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9305,
@@ -1597,18 +1556,18 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "ibm-granite/granite-4.0-h-micro",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "bytedance-seed/seed-1.6-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9300,
-                    ContextLimit = 131000,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-nano-9b-v2",
+                    Model = "openai/gpt-oss-safeguard-20b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
@@ -1619,88 +1578,12 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "baidu/ernie-4.5-21b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    Model = "deepseek/deepseek-v3.2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9290,
-                    ContextLimit = 120000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "baidu/ernie-4.5-21b-a3b-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9285,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-oss-safeguard-20b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9280,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "microsoft/phi-4-mini-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    Verified = false,
-                    Rank = 9275,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nousresearch/hermes-4-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9270,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9265,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-30b-a3b-thinking-2507",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9260,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-v3.2-exp",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9255,
-                    ContextLimit = 163840,
                 },
 
                 new AIModelCapabilities
@@ -1710,19 +1593,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9250,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "alibaba/tongyi-deepresearch-30b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9245,
-                    ContextLimit = 131072,
+                    Rank = 9285,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -1732,129 +1604,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9240,
+                    Rank = 9280,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "allenai/olmo-3-32b-think",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9275,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-4.6v",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9270,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "thedrummer/cydonia-24b-v4.1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9235,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-vl-30b-a3b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9230,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "baidu/ernie-4.5-vl-28b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9225,
-                    ContextLimit = 30000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-chat-v3.1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9220,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-plus-2025-07-28",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9215,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-plus-2025-07-28:thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9210,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-next-80b-a3b-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9205,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-2.5-flash-lite-preview-09-2025",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9200,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-vl-235b-a22b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9195,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-v3.1-terminus",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9190,
-                    ContextLimit = 163840,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-coder-flash",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9185,
-                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -1864,30 +1637,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9180,
-                    ContextLimit = 196608,
+                    Rank = 9265,
+                    ContextLimit = 204800,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3-next-80b-a3b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "minimax/minimax-m2.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9175,
-                    ContextLimit = 262144,
+                    Rank = 9260,
+                    ContextLimit = 204800,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "relace/relace-apply-3",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "deepcogito/cogito-v2.1-671b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9170,
-                    ContextLimit = 256000,
+                    Rank = 9255,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -1897,52 +1670,74 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9165,
-                    ContextLimit = 131072,
+                    Rank = 9250,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3-vl-30b-a3b-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9160,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-4.5v",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9155,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-medium-3.1",
+                    Model = "mistralai/mistral-large-2512",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9150,
-                    ContextLimit = 131072,
+                    Rank = 9245,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5-image-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "z-ai/glm-4.7",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9145,
+                    Rank = 9240,
+                    ContextLimit = 202752,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "bytedance-seed/seed-1.6",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9235,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/devstral-2512",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9230,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.1-codex-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9225,
                     ContextLimit = 400000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "amazon/nova-2-lite-v1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9220,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -1952,63 +1747,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9140,
+                    Rank = 9215,
                     ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3-vl-235b-a22b-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9135,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nousresearch/hermes-4-405b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9130,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-coder-plus",
+                    Model = "relace/relace-search",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9125,
-                    ContextLimit = 1000000,
+                    Rank = 9210,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-2.5-flash-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput,
+                    Model = "google/gemini-3-flash-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9120,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-max",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9115,
-                    ContextLimit = 262144,
+                    Rank = 9205,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -2018,40 +1780,62 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9110,
+                    Rank = 9200,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/o4-mini-deep-research",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5-image-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9105,
-                    ContextLimit = 200000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9100,
+                    Rank = 9195,
                     ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5.1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9095,
+                    Rank = 9190,
+                    ContextLimit = 400000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.1-chat",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9185,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.1-codex",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9180,
+                    ContextLimit = 400000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.1-codex-max",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9175,
                     ContextLimit = 400000,
                 },
 
@@ -2062,19 +1846,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9090,
+                    Rank = 9170,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-sonnet-4.5",
+                    Model = "openai/gpt-5.2",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9085,
-                    ContextLimit = 1000000,
+                    Rank = 9165,
+                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
@@ -2084,30 +1868,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9080,
+                    Rank = 9160,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/o3-deep-research",
+                    Model = "anthropic/claude-opus-4.5",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9075,
+                    Rank = 9155,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-4o-audio-preview",
-                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "openai/gpt-5-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9070,
-                    ContextLimit = 128000,
+                    Rank = 9150,
+                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
@@ -2117,111 +1901,56 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9065,
+                    Rank = 9145,
                     ContextLimit = 32000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5-pro",
+                    Model = "google/gemini-3-pro-image-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9140,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.2-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9060,
+                    Rank = 9135,
                     ContextLimit = 400000,
                 },
 
 
 
-                // Released between May 2025 and August 2025
+                // Released between July 2025 and October 2025
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    Model = "nvidia/nemotron-nano-9b-v2:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9055,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-oss-120b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9050,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-oss-20b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9045,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-coder:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9040,
-                    ContextLimit = 262000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-4.5-air:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9035,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-235b-a22b-2507",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9030,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-4-32b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9025,
+                    Rank = 9130,
                     ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemma-3n-e4b-it",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "openai/gpt-oss-20b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9020,
-                    ContextLimit = 32768,
+                    Rank = 9125,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -2231,7 +1960,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9015,
+                    Rank = 9120,
                     ContextLimit = 131072,
                 },
 
@@ -2242,51 +1971,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9010,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "bytedance/ui-tars-1.5-7b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9005,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-small-3.2-24b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9000,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-coder-30b-a3b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8995,
-                    ContextLimit = 160000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/devstral-small",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8990,
+                    Rank = 9115,
                     ContextLimit = 131072,
                 },
 
@@ -2297,8 +1982,41 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8985,
-                    ContextLimit = 262144,
+                    Rank = 9110,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "bytedance/ui-tars-1.5-7b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9105,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-coder-30b-a3b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9100,
+                    ContextLimit = 160000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nousresearch/hermes-4-70b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9095,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -2308,19 +2026,85 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8980,
+                    Rank = 9090,
                     ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "tencent/hunyuan-a13b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "deepseek/deepseek-v3.2-exp",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8975,
+                    Rank = 9085,
+                    ContextLimit = 163840,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "thedrummer/cydonia-24b-v4.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9080,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-vl-30b-a3b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9075,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-235b-a22b-2507",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9070,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-plus-2025-07-28",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9065,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-plus-2025-07-28:thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9060,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-next-80b-a3b-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9055,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -2330,7 +2114,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8970,
+                    Rank = 9050,
                     ContextLimit = 1048576,
                 },
 
@@ -2341,8 +2125,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8965,
+                    Rank = 9045,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-vl-235b-a22b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9040,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -2352,41 +2147,63 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8960,
+                    Rank = 9035,
                     ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "baidu/ernie-4.5-300b-a47b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "deepseek/deepseek-chat-v3.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8955,
-                    ContextLimit = 123000,
+                    Rank = 9030,
+                    ContextLimit = 163840,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "morph/morph-v3-fast",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "deepseek/deepseek-v3.1-terminus",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8950,
-                    ContextLimit = 81920,
+                    Rank = 9025,
+                    ContextLimit = 163840,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "baidu/ernie-4.5-vl-424b-a47b",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "qwen/qwen3-coder-flash",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8945,
-                    ContextLimit = 123000,
+                    Rank = 9020,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-next-80b-a3b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9015,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "relace/relace-apply-3",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9010,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -2396,7 +2213,29 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8940,
+                    Rank = 9005,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-30b-a3b-thinking-2507",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9000,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-vl-30b-a3b-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8995,
                     ContextLimit = 131072,
                 },
 
@@ -2407,29 +2246,29 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8935,
-                    ContextLimit = 262144,
+                    Rank = 8990,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "morph/morph-v3-large",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "z-ai/glm-4.5v",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8930,
-                    ContextLimit = 262144,
+                    Rank = 8985,
+                    ContextLimit = 65536,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/devstral-medium",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "mistralai/mistral-medium-3.1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8925,
+                    Rank = 8980,
                     ContextLimit = 131072,
                 },
 
@@ -2441,74 +2280,52 @@ namespace SmartHopper.Providers.OpenRouter
                     Default = AICapability.Text2Text | AICapability.Text2Json,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8920,
+                    Rank = 8975,
                     ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepseek/deepseek-r1-0528",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "qwen/qwen3-vl-235b-a22b-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8915,
-                    ContextLimit = 163840,
+                    Rank = 8970,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "minimax/minimax-m1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "nousresearch/hermes-4-405b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8910,
+                    Rank = 8965,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-coder-plus",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8960,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "z-ai/glm-4.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "qwen/qwen3-max",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8905,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "moonshotai/kimi-k2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8900,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "switchpoint/router",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8895,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-2.5-flash",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8890,
-                    ContextLimit = 1048576,
+                    Rank = 8955,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -2518,8 +2335,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8885,
+                    Rank = 8950,
                     ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/o4-mini-deep-research",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8945,
+                    ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
@@ -2529,7 +2357,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8880,
+                    Rank = 8940,
                     ContextLimit = 400000,
                 },
 
@@ -2540,51 +2368,51 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8875,
+                    Rank = 8935,
                     ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-2.5-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5-codex",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8870,
-                    ContextLimit = 1048576,
+                    Rank = 8930,
+                    ContextLimit = 400000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-2.5-pro-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "anthropic/claude-sonnet-4.5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8865,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "anthropic/claude-sonnet-4",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8860,
+                    Rank = 8925,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-opus-4",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "google/gemini-2.5-flash-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8855,
+                    Rank = 8920,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/o3-deep-research",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8915,
                     ContextLimit = 200000,
                 },
 
@@ -2595,78 +2423,34 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8850,
+                    Rank = 8910,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/o3-pro",
+                    Model = "openai/gpt-5-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8845,
-                    ContextLimit = 200000,
+                    Rank = 8905,
+                    ContextLimit = 400000,
                 },
 
 
 
-                // Released between February 2025 and May 2025
+                // Released between April 2025 and July 2025
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "meta-llama/llama-guard-3-8b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "google/gemma-3n-e4b-it",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8840,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-3-4b-it",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8835,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-3-12b-it",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8830,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-3-27b-it",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8825,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "arcee-ai/spotlight",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8820,
-                    ContextLimit = 131072,
+                    Rank = 8900,
+                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
@@ -2676,19 +2460,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8815,
+                    Rank = 8895,
                     ContextLimit = 163840,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "rekaai/reka-flash-3",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "mistralai/mistral-small-3.2-24b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8810,
-                    ContextLimit = 65536,
+                    Rank = 8890,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -2698,8 +2482,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8805,
-                    ContextLimit = 40960,
+                    Rank = 8885,
+                    ContextLimit = 131702,
                 },
 
                 new AIModelCapabilities
@@ -2709,19 +2493,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8800,
-                    ContextLimit = 40960,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-4-scout",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8795,
-                    ContextLimit = 327680,
+                    Rank = 8880,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -2731,7 +2504,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8790,
+                    Rank = 8875,
                     ContextLimit = 1047576,
                 },
 
@@ -2742,8 +2515,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8785,
-                    ContextLimit = 40960,
+                    Rank = 8870,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -2753,63 +2526,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8780,
-                    ContextLimit = 40960,
+                    Rank = 8865,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/mistral-small-3.1-24b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
+                    Model = "tencent/hunyuan-a13b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8775,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-4-maverick",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8770,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-saba",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8765,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-4o-mini-search-preview",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8760,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-chat-v3-0324",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8755,
-                    ContextLimit = 163840,
+                    Rank = 8860,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -2819,30 +2548,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8750,
+                    Rank = 8855,
                     ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "thedrummer/skyfall-36b-v2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
+                    Model = "cognitivecomputations/dolphin-mistral-24b-venice-edition",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     Verified = false,
-                    Rank = 8745,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "alfredpros/codellama-7b-instruct-solidity",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8740,
-                    ContextLimit = 4096,
+                    Rank = 8850,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -2852,7 +2569,29 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8735,
+                    Rank = 8845,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "morph/morph-v3-fast",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8840,
+                    ContextLimit = 81920,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/ernie-4.5-vl-424b-a47b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8835,
                     ContextLimit = 131072,
                 },
 
@@ -2863,7 +2602,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8730,
+                    Rank = 8830,
                     ContextLimit = 1047576,
                 },
 
@@ -2874,8 +2613,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8725,
+                    Rank = 8825,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "morph/morph-v3-large",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8820,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -2885,30 +2635,52 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8720,
+                    Rank = 8815,
                     ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "arcee-ai/maestro-reasoning",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8715,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/o3-mini-high",
+                    Model = "deepseek/deepseek-r1-0528",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8710,
-                    ContextLimit = 200000,
+                    Rank = 8810,
+                    ContextLimit = 163840,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "minimax/minimax-m1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8805,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "moonshotai/kimi-k2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8800,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-2.5-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8795,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -2918,7 +2690,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8705,
+                    Rank = 8790,
                     ContextLimit = 200000,
                 },
 
@@ -2929,7 +2701,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8700,
+                    Rank = 8785,
                     ContextLimit = 200000,
                 },
 
@@ -2940,7 +2712,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8695,
+                    Rank = 8780,
                     ContextLimit = 1047576,
                 },
 
@@ -2951,52 +2723,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8690,
+                    Rank = 8775,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "perplexity/sonar-deep-research",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "google/gemini-2.5-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8685,
-                    ContextLimit = 128000,
+                    Rank = 8770,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "perplexity/sonar-reasoning-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "google/gemini-2.5-pro-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8680,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "cohere/command-a",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8675,
-                    ContextLimit = 256000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-4o-search-preview",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8670,
-                    ContextLimit = 128000,
+                    Rank = 8765,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -3006,46 +2756,46 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8665,
+                    Rank = 8760,
                     ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "perplexity/sonar-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
+                    Model = "anthropic/claude-sonnet-4",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8660,
+                    Rank = 8755,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-opus-4",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8750,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/o1-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/o3-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8655,
+                    Rank = 8745,
                     ContextLimit = 200000,
                 },
 
 
 
-                // Released between November 2024 and February 2025
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3.3-70b-instruct:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8650,
-                    ContextLimit = 65536,
-                },
+                // Released between January 2025 and April 2025
 
                 new AIModelCapabilities
                 {
@@ -3054,96 +2804,96 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8645,
+                    Rank = 8740,
                     ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8640,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "amazon/nova-micro-v1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8635,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "microsoft/phi-4",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8630,
-                    ContextLimit = 16384,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "cohere/command-r7b-12-2024",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8625,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "amazon/nova-lite-v1",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8620,
-                    ContextLimit = 300000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-r1-distill-qwen-32b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8615,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3.3-70b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8610,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-vl-plus",
+                    Model = "google/gemma-3-4b-it",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8605,
+                    Rank = 8735,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemma-3-12b-it",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8730,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemma-3-27b-it",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8725,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "rekaai/reka-flash-3",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8720,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-4-scout",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8715,
+                    ContextLimit = 10000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-small-3.1-24b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8710,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-saba",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8705,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4o-mini-search-preview",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8700,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -3153,18 +2903,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8600,
-                    ContextLimit = 32000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "sao10k/l3.3-euryale-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8595,
+                    Rank = 8695,
                     ContextLimit = 131072,
                 },
 
@@ -3175,7 +2914,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8590,
+                    Rank = 8690,
                     ContextLimit = 1000000,
                 },
 
@@ -3183,21 +2922,43 @@ namespace SmartHopper.Providers.OpenRouter
                 {
                     Provider = provider,
                     Model = "deepseek/deepseek-r1-distill-llama-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8585,
-                    ContextLimit = 131072,
+                    Rank = 8685,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepseek/deepseek-chat",
+                    Model = "meta-llama/llama-4-maverick",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8680,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "thedrummer/skyfall-36b-v2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8675,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "deepseek/deepseek-chat-v3-0324",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8580,
+                    Rank = 8670,
                     ContextLimit = 163840,
                 },
 
@@ -3208,19 +2969,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8575,
+                    Rank = 8665,
                     ContextLimit = 127072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-2.5-coder-32b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8570,
-                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
@@ -3230,19 +2980,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8565,
+                    Rank = 8660,
                     ContextLimit = 1000192,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "aion-labs/aion-1.0-mini",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8560,
-                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -3252,40 +2991,231 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8555,
+                    Rank = 8655,
                     ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen-vl-max",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "deepseek/deepseek-r1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8550,
+                    Rank = 8650,
+                    ContextLimit = 163840,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/o3-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8645,
+                    ContextLimit = 200000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/o3-mini-high",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8640,
+                    ContextLimit = 200000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "perplexity/sonar-deep-research",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8635,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "perplexity/sonar-reasoning-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8630,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "cohere/command-a",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8625,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4o-search-preview",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8620,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "perplexity/sonar-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8615,
+                    ContextLimit = 200000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/o1-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8610,
+                    ContextLimit = 200000,
+                },
+
+
+
+                // Released between October 2024 and January 2025
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-2.5-7b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8605,
                     ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "deepseek/deepseek-r1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Model = "amazon/nova-micro-v1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8545,
-                    ContextLimit = 64000,
+                    Rank = 8600,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "microsoft/phi-4",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8595,
+                    ContextLimit = 16384,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "cohere/command-r7b-12-2024",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8590,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "amazon/nova-lite-v1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8585,
+                    ContextLimit = 300000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-3.3-70b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8580,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "thedrummer/unslopnemo-12b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8575,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "sao10k/l3.3-euryale-70b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8570,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "deepseek/deepseek-chat",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8565,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-2.5-coder-32b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8560,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "sao10k/l3.1-70b-hanami-x1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8540,
+                    Rank = 8555,
                     ContextLimit = 16000,
                 },
 
@@ -3296,30 +3226,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8535,
+                    Rank = 8550,
                     ContextLimit = 300000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen-max",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "anthracite-org/magnum-v4-72b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8530,
+                    Rank = 8545,
                     ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/o3-mini",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8525,
-                    ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
@@ -3329,40 +3248,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8520,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-large-2411",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8515,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/pixtral-large-2411",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8510,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "aion-labs/aion-1.0",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8505,
+                    Rank = 8540,
                     ContextLimit = 131072,
                 },
 
@@ -3373,7 +3259,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8500,
+                    Rank = 8535,
                     ContextLimit = 128000,
                 },
 
@@ -3384,33 +3270,33 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8495,
+                    Rank = 8530,
                     ContextLimit = 200000,
                 },
 
 
 
-                // Released between August 2024 and November 2024
+                // Released between July 2024 and October 2024
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "meta-llama/llama-3.2-3b-instruct:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "meta-llama/llama-3.1-8b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8490,
+                    Rank = 8525,
                     ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nousresearch/hermes-3-llama-3.1-405b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "mistralai/mistral-nemo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8485,
+                    Rank = 8520,
                     ContextLimit = 131072,
                 },
 
@@ -3421,19 +3307,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8480,
+                    Rank = 8515,
                     ContextLimit = 8192,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-2.5-7b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8475,
-                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
@@ -3443,29 +3318,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8470,
-                    ContextLimit = 60000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3.2-11b-vision-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8465,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nousresearch/hermes-3-llama-3.1-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8460,
+                    Rank = 8510,
                     ContextLimit = 131072,
                 },
 
@@ -3473,169 +3326,11 @@ namespace SmartHopper.Providers.OpenRouter
                 {
                     Provider = provider,
                     Model = "meta-llama/llama-3.2-3b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8455,
-                    ContextLimit = 80000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-2.5-72b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8450,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "thedrummer/unslopnemo-12b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8445,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "thedrummer/rocinante-12b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8440,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "cohere/command-r-08-2024",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8435,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "sao10k/l3.1-euryale-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8430,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nousresearch/hermes-3-llama-3.1-405b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8425,
+                    Rank = 8505,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "anthropic/claude-3.5-haiku",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8420,
-                    ContextLimit = 200000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "anthracite-org/magnum-v4-72b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8415,
-                    ContextLimit = 16384,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "cohere/command-r-plus-08-2024",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8410,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "inflection/inflection-3-pi",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8405,
-                    ContextLimit = 8000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "inflection/inflection-3-productivity",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8400,
-                    ContextLimit = 8000,
-                },
-
-
-
-                // Released between May 2024 and August 2024
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-nemo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8395,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3.1-8b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8390,
-                    ContextLimit = 16384,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nousresearch/hermes-2-pro-llama-3-8b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8385,
-                    ContextLimit = 8192,
                 },
 
                 new AIModelCapabilities
@@ -3645,8 +3340,41 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8380,
+                    Rank = 8500,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-2.5-72b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8495,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "thedrummer/rocinante-12b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8490,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "cohere/command-r-08-2024",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8485,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -3656,7 +3384,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8375,
+                    Rank = 8480,
                     ContextLimit = 128000,
                 },
 
@@ -3667,41 +3395,74 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8370,
+                    Rank = 8475,
                     ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemma-2-27b-it",
+                    Model = "nousresearch/hermes-3-llama-3.1-70b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8365,
-                    ContextLimit = 8192,
+                    Rank = 8470,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "sao10k/l3-euryale-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    Model = "sao10k/l3.1-euryale-70b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8360,
-                    ContextLimit = 8192,
+                    Rank = 8465,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-4o",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "nousresearch/hermes-3-llama-3.1-405b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8355,
+                    Rank = 8460,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "cohere/command-r-plus-08-2024",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8455,
                     ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "inflection/inflection-3-pi",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8450,
+                    ContextLimit = 8000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "inflection/inflection-3-productivity",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8445,
+                    ContextLimit = 8000,
                 },
 
                 new AIModelCapabilities
@@ -3711,24 +3472,13 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8350,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-4o-2024-05-13",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8345,
+                    Rank = 8440,
                     ContextLimit = 128000,
                 },
 
 
 
-                // Released before May 2024 or unknown release date
+                // Released before July 2024 or unknown release date
 
                 new AIModelCapabilities
                 {
@@ -3737,7 +3487,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8340,
+                    Rank = 8435,
                     ContextLimit = 2000000,
                 },
 
@@ -3748,7 +3498,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8335,
+                    Rank = 8430,
                     ContextLimit = 4096,
                 },
 
@@ -3756,11 +3506,22 @@ namespace SmartHopper.Providers.OpenRouter
                 {
                     Provider = provider,
                     Model = "microsoft/wizardlm-2-8x22b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8330,
-                    ContextLimit = 65535,
+                    Rank = 8425,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemma-2-27b-it",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8420,
+                    ContextLimit = 8192,
                 },
 
                 new AIModelCapabilities
@@ -3770,19 +3531,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8325,
+                    Rank = 8415,
                     ContextLimit = 6144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3-70b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8320,
-                    ContextLimit = 8192,
                 },
 
                 new AIModelCapabilities
@@ -3792,7 +3542,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8315,
+                    Rank = 8410,
                     ContextLimit = 8000,
                 },
 
@@ -3803,7 +3553,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8310,
+                    Rank = 8405,
                     ContextLimit = 200000,
                 },
 
@@ -3814,7 +3564,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8305,
+                    Rank = 8400,
                     ContextLimit = 16385,
                 },
 
@@ -3825,7 +3575,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8300,
+                    Rank = 8395,
                     ContextLimit = 4095,
                 },
 
@@ -3836,7 +3586,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8295,
+                    Rank = 8390,
                     ContextLimit = 4095,
                 },
 
@@ -3847,7 +3597,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8290,
+                    Rank = 8385,
                     ContextLimit = 16385,
                 },
 
@@ -3858,7 +3608,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8285,
+                    Rank = 8380,
                     ContextLimit = 128000,
                 },
 
@@ -3869,29 +3619,29 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8280,
+                    Rank = 8375,
                     ContextLimit = 65536,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "alpindale/goliath-120b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    Model = "openai/gpt-4o",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8275,
-                    ContextLimit = 6144,
+                    Rank = 8370,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-4-1106-preview",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "openai/gpt-4o-2024-05-13",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8270,
+                    Rank = 8365,
                     ContextLimit = 128000,
                 },
 
@@ -3902,7 +3652,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8265,
+                    Rank = 8360,
                     ContextLimit = 128000,
                 },
 
@@ -3913,7 +3663,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8260,
+                    Rank = 8355,
                     ContextLimit = 128000,
                 },
 
@@ -3924,18 +3674,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8255,
-                    ContextLimit = 8191,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-4-0314",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8250,
+                    Rank = 8350,
                     ContextLimit = 8191,
                 },
 
@@ -3946,37 +3685,60 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4.1-fast",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "tencent/hy3:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
                     Deprecated = true,
                     Rank = 0,
-                    ContextLimit = 2000000,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4-fast",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5.2-chat",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -5,
-                    ContextLimit = 2000000,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-code-fast-1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "qwen/qwen3-coder:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -10,
-                    ContextLimit = 256000,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-next-80b-a3b-instruct:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -15,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -20,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -3987,39 +3749,15 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -15,
-                    ContextLimit = 204800,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "moonshotai/kimi-k2-0905",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -20,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "x-ai/grok-3-mini",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
                     Rank = -25,
-                    ContextLimit = 131072,
+                    ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-3",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "z-ai/glm-4.5",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
@@ -4030,32 +3768,32 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-4",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "moonshotai/kimi-k2-0905",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -35,
-                    ContextLimit = 256000,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-2.0-flash-lite-001",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -40,
-                    ContextLimit = 1048576,
+                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-3-mini-beta",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "meta-llama/llama-3.3-70b-instruct:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
@@ -4066,12 +3804,132 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "meta-llama/llama-3.2-3b-instruct:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -50,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nousresearch/hermes-3-llama-3.1-405b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -55,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-3.2-11b-vision-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -60,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-1.0",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -65,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-1.0-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -70,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "alfredpros/codellama-7b-instruct-solidity",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -75,
+                    ContextLimit = 4096,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "alibaba/tongyi-deepresearch-30b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -80,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "allenai/olmo-3.1-32b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -85,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "alpindale/goliath-120b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -90,
+                    ContextLimit = 6144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-3.5-haiku",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -95,
+                    ContextLimit = 200000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "anthropic/claude-3.7-sonnet",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -50,
+                    Rank = -100,
                     ContextLimit = 200000,
                 },
 
@@ -4083,20 +3941,175 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -55,
+                    Rank = -105,
                     ContextLimit = 200000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "x-ai/grok-3-beta",
+                    Model = "anthropic/claude-opus-4.6-fast",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -110,
+                    ContextLimit = 1000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/maestro-reasoning",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -115,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/spotlight",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -120,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/trinity-large-preview",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -60,
+                    Rank = -125,
+                    ContextLimit = 131000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/trinity-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -130,
                     ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/cobuddy:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -135,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/ernie-4.5-21b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -140,
+                    ContextLimit = 120000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/ernie-4.5-21b-a3b-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -145,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/ernie-4.5-300b-a47b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -150,
+                    ContextLimit = 123000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/ernie-4.5-vl-28b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -155,
+                    ContextLimit = 30000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "baidu/qianfan-ocr-fast:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -160,
+                    ContextLimit = 65536,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "deepseek/deepseek-r1-distill-qwen-32b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -165,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "deepseek/deepseek-v3.2-speciale",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -170,
+                    ContextLimit = 163840,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "essentialai/rnj-1-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -175,
+                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
@@ -4107,44 +4120,32 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -65,
+                    Rank = -180,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "meta-llama/llama-3-8b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "google/gemini-2.0-flash-lite-001",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -70,
-                    ContextLimit = 8192,
+                    Rank = -185,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/mistral-7b-instruct-v0.1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Model = "google/gemini-2.5-flash-lite-preview-09-2025",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -75,
-                    ContextLimit = 2824,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "allenai/olmo-3.1-32b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -80,
-                    ContextLimit = 65536,
+                    Rank = -190,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -4155,7 +4156,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -85,
+                    Rank = -195,
                     ContextLimit = 32768,
                 },
 
@@ -4167,7 +4168,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -90,
+                    Rank = -200,
                     ContextLimit = 131072,
                 },
 
@@ -4179,7 +4180,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -95,
+                    Rank = -205,
                     ContextLimit = 32768,
                 },
 
@@ -4191,7 +4192,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -100,
+                    Rank = -210,
                     ContextLimit = 8192,
                 },
 
@@ -4203,7 +4204,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -105,
+                    Rank = -215,
                     ContextLimit = 8192,
                 },
 
@@ -4215,8 +4216,162 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -110,
+                    Rank = -220,
                     ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "inclusionai/ring-2.6-1t:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -225,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "liquid/lfm-2-24b-a2b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -230,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "liquid/lfm-2.5-1.2b-instruct:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -235,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "liquid/lfm-2.5-1.2b-thinking:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -240,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-3-70b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -245,
+                    ContextLimit = 8192,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-3-8b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -250,
+                    ContextLimit = 8192,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-guard-3-8b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -255,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "microsoft/phi-4-mini-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -260,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "minimax/minimax-m2.5:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -265,
+                    ContextLimit = 196608,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/devstral-medium",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -270,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/devstral-small",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -275,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-7b-instruct-v0.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -280,
+                    ContextLimit = 2824,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-large-2411",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -285,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -4227,8 +4382,44 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -115,
+                    Rank = -290,
                     ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/pixtral-large-2411",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -295,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nex-agi/deepseek-v3.1-nex-n1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -300,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nousresearch/hermes-2-pro-llama-3-8b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -305,
+                    ContextLimit = 8192,
                 },
 
                 new AIModelCapabilities
@@ -4239,7 +4430,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -120,
+                    Rank = -310,
                     ContextLimit = 131072,
                 },
 
@@ -4251,7 +4442,175 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -125,
+                    Rank = -315,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/nemotron-nano-9b-v2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -320,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4-0314",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -325,
+                    ContextLimit = 8191,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4-1106-preview",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -330,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4o-audio-preview",
+                    Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -335,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-oss-120b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -340,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openrouter/owl-alpha",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -345,
+                    ContextLimit = 1048756,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "poolside/laguna-xs.2:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -350,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "prime-intellect/intellect-3",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -355,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-max",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -360,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -365,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-vl-max",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -370,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-vl-plus",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -375,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "sao10k/l3-euryale-70b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -380,
+                    ContextLimit = 8192,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "switchpoint/router",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -385,
                     ContextLimit = 131072,
                 },
 
@@ -4263,7 +4622,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -130,
+                    Rank = -390,
                     ContextLimit = 262144,
                 },
 
@@ -4275,8 +4634,164 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -135,
+                    Rank = -395,
                     ContextLimit = 163840,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-3",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -400,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-3-beta",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -405,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-3-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -410,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-3-mini-beta",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -415,
+                    ContextLimit = 131072,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -420,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4-fast",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -425,
+                    ContextLimit = 2000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-4.1-fast",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -430,
+                    ContextLimit = 2000000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "x-ai/grok-code-fast-1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -435,
+                    ContextLimit = 256000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "xiaomi/mimo-v2-flash",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -440,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "xiaomi/mimo-v2-omni",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -445,
+                    ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "xiaomi/mimo-v2-pro",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -450,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-4-32b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -455,
+                    ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-4.5-air:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -460,
+                    ContextLimit = 131072,
                 }
             };
 

--- a/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
+++ b/src/SmartHopper.Providers.OpenRouter/OpenRouterProviderModels.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SmartHopper - AI-powered Grasshopper Plugin
  * Copyright (C) 2024-2026 Marc Roca Musach
  *
@@ -48,7 +48,6 @@ namespace SmartHopper.Providers.OpenRouter
         {
             var provider = this.openRouterProvider.Name.ToLowerInvariant();
 
-            // Sample curated models exposed via OpenRouter
             var models = new List<AIModelCapabilities>
             {
                 // Released between April 2026 and July 2026
@@ -61,7 +60,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 10000,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -72,6 +71,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9995,
                     ContextLimit = 2000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "poolside/laguna-xs-2.1:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.ToolChat | AICapability.ReasoningChat | AICapability.ToolReasoningChat,
+                    Verified = false,
+                    Rank = 9990,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -80,19 +90,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "cohere/north-mini-code:free",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9990,
+                    Rank = 9985,
                     ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
+                    Model = "nvidia/nemotron-3.5-content-safety:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Default = AICapability.Image2Text,
                     Verified = false,
-                    Rank = 9985,
-                    ContextLimit = 256000,
+                    Rank = 9980,
+                    ContextLimit = 128000,
                 },
 
                 new AIModelCapabilities
@@ -101,18 +111,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "nvidia/nemotron-3-ultra-550b-a55b:free",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9980,
+                    Rank = 9975,
                     ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "nvidia/nemotron-3.5-content-safety:free",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Default = AICapability.Speech2Text,
+                    SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9975,
-                    ContextLimit = 128000,
+                    Rank = 9970,
+                    ContextLimit = 256000,
                 },
 
                 new AIModelCapabilities
@@ -121,16 +133,6 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "poolside/laguna-m.1:free",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9970,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "poolside/laguna-xs-2.1:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
                     Rank = 9965,
                     ContextLimit = 262144,
@@ -145,7 +147,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9960,
                     ContextLimit = 262144,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nex-agi/nex-n2-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9955,
+                    ContextLimit = 262144,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -154,19 +166,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9955,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nex-agi/nex-n2-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
                     Rank = 9950,
-                    ContextLimit = 262144,
-                },
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -176,7 +178,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9945,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -187,7 +189,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9940,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -197,7 +199,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9935,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -208,7 +210,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9930,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -218,7 +220,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9925,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -228,17 +230,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9920,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "kwaipilot/kat-coder-air-v2.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "inclusionai/ring-2.6-1t",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
                     Rank = 9915,
-                    ContextLimit = 256000,
-                },
+                    ContextLimit = 262144,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -248,17 +250,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9910,
                     ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "inclusionai/ring-2.6-1t",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9905,
-                    ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -267,9 +259,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9900,
+                    Rank = 9905,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -278,9 +270,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9895,
+                    Rank = 9900,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -288,9 +280,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "nex-agi/nex-n2-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9890,
+                    Rank = 9895,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -299,9 +291,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9885,
+                    Rank = 9890,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -310,9 +302,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9880,
+                    Rank = 9885,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -320,9 +312,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "stepfun/step-3.7-flash",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9875,
+                    Rank = 9880,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -330,9 +322,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "minimax/minimax-m3",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9870,
+                    Rank = 9875,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -340,9 +332,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "qwen/qwen3.7-plus",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9865,
+                    Rank = 9870,
                     ContextLimit = 1000000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5.2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9865,
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -352,7 +354,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9860,
                     ContextLimit = 131072,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-lite-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Default = AICapability.Text2Image | AICapability.Image2Image,
+                    Verified = false,
+                    Rank = 9855,
+                    ContextLimit = 65536,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -360,9 +373,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "perceptron/perceptron-mk1",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9855,
+                    Rank = 9850,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -371,9 +384,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9850,
+                    Rank = 9845,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -381,9 +394,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "x-ai/grok-build-0.1",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9845,
+                    Rank = 9840,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -391,9 +404,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "nvidia/nemotron-3-ultra-550b-a55b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9840,
+                    Rank = 9835,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -401,9 +414,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "google/gemini-3.1-flash-lite",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9835,
+                    Rank = 9830,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -412,9 +425,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9830,
+                    Rank = 9825,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -423,29 +436,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9825,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5.2",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
                     Rank = 9820,
-                    ContextLimit = 1048576,
-                },
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "kwaipilot/kat-coder-pro-v2.5",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "google/gemini-3.1-flash-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
                     Rank = 9815,
-                    ContextLimit = 256000,
-                },
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -456,7 +459,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9810,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -467,7 +470,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9805,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -477,7 +480,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9800,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -487,7 +490,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9795,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -498,7 +501,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9790,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -509,37 +512,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9785,
                     ContextLimit = 200000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "~x-ai/grok-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9780,
-                    ContextLimit = 500000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "aion-labs/aion-3.0",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9775,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.6-luna",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9770,
-                    ContextLimit = 1050000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -547,9 +520,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "openai/gpt-5.6-luna-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9765,
+                    Rank = 9780,
                     ContextLimit = 1050000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-luna",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9775,
+                    ContextLimit = 1050000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -557,9 +540,29 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "x-ai/grok-4.5",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9760,
+                    Rank = 9770,
                     ContextLimit = 500000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "~x-ai/grok-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9765,
+                    ContextLimit = 500000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "aion-labs/aion-3.0",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9760,
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -570,7 +573,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9755,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -580,7 +583,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9750,
                     ContextLimit = 262144,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-sonnet-5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9745,
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -589,19 +602,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9745,
+                    Rank = 9740,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-sonnet-5",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "google/gemini-3.5-flash",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9740,
-                    ContextLimit = 1000000,
-                },
+                    Rank = 9735,
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -610,29 +623,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9735,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.5-flash",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
                     Rank = 9730,
                     ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.6-terra",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9725,
-                    ContextLimit = 1050000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -640,9 +633,40 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "openai/gpt-5.6-terra-pro",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
+                    Rank = 9725,
+                    ContextLimit = 1050000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-terra",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
                     Rank = 9720,
                     ContextLimit = 1050000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.4-image-2",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9715,
+                    ContextLimit = 272000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3-pro-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9710,
+                    ContextLimit = 65536,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -651,31 +675,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9715,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "~anthropic/claude-opus-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9710,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "anthropic/claude-opus-4.7",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 9705,
-                    ContextLimit = 1000000,
-                },
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -685,7 +687,69 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9700,
                     ContextLimit = 1000000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "~anthropic/claude-opus-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9695,
+                    ContextLimit = 1000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "anthropic/claude-opus-4.7",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9690,
+                    ContextLimit = 1000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-sol-pro",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9685,
+                    ContextLimit = 1050000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.6-sol",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9680,
+                    ContextLimit = 1050000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "sakana/fugu-ultra",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Rank = 9675,
+                    ContextLimit = 1000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-chat-latest",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Verified = false,
+                    Rank = 9670,
+                    ContextLimit = 400000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -694,9 +758,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9695,
+                    Rank = 9665,
                     ContextLimit = 1050000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -705,70 +769,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9690,
-                    ContextLimit = 1050000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.6-sol",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9685,
-                    ContextLimit = 1050000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.6-sol-pro",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9680,
-                    ContextLimit = 1050000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-chat-latest",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    Verified = false,
-                    Rank = 9675,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "sakana/fugu-ultra",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9670,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-flash-lite-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9665,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.4-image-2",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 9660,
-                    ContextLimit = 272000,
-                },
+                    ContextLimit = 1050000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -778,7 +781,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9655,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -788,7 +791,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9650,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -798,27 +801,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9645,
                     ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-flash-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9640,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3-pro-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    Verified = false,
-                    Rank = 9635,
-                    ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -826,9 +809,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Model = "anthropic/claude-opus-4.7-fast",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     Verified = false,
-                    Rank = 9630,
+                    Rank = 9640,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -837,9 +820,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9625,
+                    Rank = 9635,
                     ContextLimit = 1050000,
-                },
+                                    },
 
 
 
@@ -852,7 +835,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9620,
+                    Rank = 9630,
                     ContextLimit = 262144,
                 },
 
@@ -863,8 +846,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9615,
+                    Rank = 9625,
                     ContextLimit = 262144,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/lyria-3-pro-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
+                    Default = AICapability.Text2Speech,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9620,
+                    ContextLimit = 1048576,
                 },
 
                 new AIModelCapabilities
@@ -874,18 +869,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9610,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/lyria-3-pro-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9605,
+                    Rank = 9615,
                     ContextLimit = 1048576,
                 },
 
@@ -896,7 +880,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9600,
+                    Rank = 9610,
                     ContextLimit = 1000000,
                 },
 
@@ -907,8 +891,30 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9595,
+                    Rank = 9605,
                     ContextLimit = 200000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "liquid/lfm-2.5-1.2b-thinking:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9600,
+                    ContextLimit = 32768,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "liquid/lfm-2.5-1.2b-instruct:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9595,
+                    ContextLimit = 32768,
                 },
 
                 new AIModelCapabilities
@@ -920,7 +926,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9590,
                     ContextLimit = 16384,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -931,7 +937,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9585,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -942,7 +948,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9580,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -953,7 +959,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9575,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -964,7 +970,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9570,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -975,7 +981,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9565,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -986,7 +992,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9560,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -997,7 +1003,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9555,
                     ContextLimit = 202752,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1008,7 +1014,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9550,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1019,7 +1025,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9545,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1030,7 +1036,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9540,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1041,7 +1047,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9535,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1052,7 +1058,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9530,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1063,7 +1069,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9525,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1074,7 +1080,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9520,
                     ContextLimit = 204800,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1085,7 +1091,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9515,
                     ContextLimit = 204800,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1096,7 +1102,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9510,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1107,7 +1113,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9505,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1118,7 +1124,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9500,
                     ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1129,7 +1135,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9495,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1140,7 +1146,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9490,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1151,7 +1157,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9485,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1162,7 +1168,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9480,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1173,7 +1179,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9475,
                     ContextLimit = 202752,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1184,7 +1190,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9470,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1195,7 +1201,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9465,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1206,7 +1212,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9460,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1217,7 +1223,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9455,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1228,7 +1234,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9450,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1239,18 +1245,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9445,
                     ContextLimit = 256000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "x-ai/grok-4.20",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9440,
-                    ContextLimit = 2000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1259,64 +1254,31 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9435,
+                    Rank = 9440,
                     ContextLimit = 2000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "z-ai/glm-5.1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9430,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-max-thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9425,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9420,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-5v-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9415,
-                    ContextLimit = 202752,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.4-mini",
+                    Model = "x-ai/grok-4.20",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9410,
-                    ContextLimit = 400000,
-                },
+                    Rank = 9435,
+                    ContextLimit = 2000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-flash-image-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9430,
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1325,9 +1287,53 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9405,
+                    Rank = 9425,
                     ContextLimit = 128000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5.1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9420,
+                    ContextLimit = 202752,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-max-thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9415,
+                    ContextLimit = 262144,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-5-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9410,
+                    ContextLimit = 262144,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5.4-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9405,
+                    ContextLimit = 400000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1338,18 +1344,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9400,
                     ContextLimit = 1040000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5.2-codex",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9395,
-                    ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1358,9 +1353,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9390,
+                    Rank = 9395,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1369,20 +1364,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9385,
+                    Rank = 9390,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "anthropic/claude-sonnet-4.6",
+                    Model = "openai/gpt-5.2-codex",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9380,
-                    ContextLimit = 1000000,
-                },
+                    Rank = 9385,
+                    ContextLimit = 400000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1391,20 +1386,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9375,
+                    Rank = 9380,
                     ContextLimit = 1050000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-3.1-pro-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "anthropic/claude-sonnet-4.6",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9370,
-                    ContextLimit = 1048576,
-                },
+                    Rank = 9375,
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1413,9 +1408,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9365,
+                    Rank = 9370,
                     ContextLimit = 1048756,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3.1-pro-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9365,
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1426,18 +1432,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9360,
                     ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3.1-flash-image-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9355,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1446,9 +1441,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.AudioInput | AICapability.TextOutput | AICapability.AudioOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9350,
+                    Rank = 9355,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1457,9 +1452,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9345,
+                    Rank = 9350,
                     ContextLimit = 1050000,
-                },
+                                    },
 
 
 
@@ -1472,9 +1467,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9340,
+                    Rank = 9345,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1483,7 +1478,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9335,
+                    Rank = 9340,
                     ContextLimit = 256000,
                 },
 
@@ -1494,7 +1489,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9330,
+                    Rank = 9335,
                     ContextLimit = 128000,
                 },
 
@@ -1505,9 +1500,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9325,
+                    Rank = 9330,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1516,9 +1511,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9320,
+                    Rank = 9325,
                     ContextLimit = 131000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1527,9 +1522,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 9320,
+                    ContextLimit = 262144,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nvidia/nemotron-3-nano-30b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 9315,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1540,18 +1546,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9310,
                     ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/nemotron-3-nano-30b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9305,
-                    ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1560,9 +1555,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9300,
+                    Rank = 9305,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1571,9 +1566,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9295,
+                    Rank = 9300,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1582,9 +1577,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9290,
+                    Rank = 9295,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1593,9 +1588,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9285,
+                    Rank = 9290,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1604,9 +1599,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9280,
+                    Rank = 9285,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1615,9 +1610,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9275,
+                    Rank = 9280,
                     ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1626,9 +1621,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9270,
+                    Rank = 9275,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1637,9 +1632,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9265,
+                    Rank = 9270,
                     ContextLimit = 204800,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1648,9 +1643,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9260,
+                    Rank = 9265,
                     ContextLimit = 204800,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1659,9 +1654,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9255,
+                    Rank = 9260,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1670,9 +1665,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9250,
+                    Rank = 9255,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1681,9 +1676,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9245,
+                    Rank = 9250,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1692,9 +1687,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9240,
+                    Rank = 9245,
                     ContextLimit = 202752,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1703,9 +1698,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9235,
+                    Rank = 9240,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1714,9 +1709,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9230,
+                    Rank = 9235,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1725,9 +1720,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 9230,
+                    ContextLimit = 400000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5-image-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 9225,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1738,7 +1744,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9220,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1749,7 +1755,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9215,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1760,7 +1766,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9210,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1771,7 +1777,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9205,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1782,18 +1788,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9200,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5-image-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5.1-codex-max",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9195,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1804,7 +1810,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9190,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1815,7 +1821,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9185,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1826,18 +1832,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9180,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5.1-codex-max",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "openai/gpt-5-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 9175,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1848,7 +1854,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9170,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1859,7 +1865,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9165,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1870,7 +1876,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9160,
                     ContextLimit = 200000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-3-pro-image-preview",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9155,
+                    ContextLimit = 65536,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1879,20 +1896,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9155,
-                    ContextLimit = 200000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 9150,
-                    ContextLimit = 400000,
-                },
+                    ContextLimit = 200000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1903,18 +1909,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9145,
                     ContextLimit = 32000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-3-pro-image-preview",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9140,
-                    ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1923,9 +1918,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9135,
+                    Rank = 9140,
                     ContextLimit = 400000,
-                },
+                                    },
 
 
 
@@ -1938,8 +1933,19 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9130,
+                    Rank = 9135,
                     ContextLimit = 128000,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-oss-120b:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9130,
+                    ContextLimit = 131072,
                 },
 
                 new AIModelCapabilities
@@ -1956,13 +1962,24 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "qwen/qwen3-235b-a22b-2507",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9120,
+                    ContextLimit = 262144,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "openai/gpt-oss-20b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9120,
+                    Rank = 9115,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1971,9 +1988,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9115,
+                    Rank = 9110,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1982,9 +1999,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9110,
+                    Rank = 9105,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -1993,9 +2010,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9105,
+                    Rank = 9100,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2004,9 +2021,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9100,
+                    Rank = 9095,
                     ContextLimit = 160000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2015,9 +2032,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9095,
+                    Rank = 9090,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2026,9 +2043,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9090,
+                    Rank = 9085,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2037,9 +2054,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9085,
+                    Rank = 9080,
                     ContextLimit = 163840,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2048,9 +2065,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9080,
+                    Rank = 9075,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2059,42 +2076,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9075,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-235b-a22b-2507",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 9070,
                     ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-plus-2025-07-28",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9065,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-plus-2025-07-28:thinking",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9060,
-                    ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2103,53 +2087,31 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9055,
+                    Rank = 9065,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "google/gemini-2.5-flash-lite",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9050,
-                    ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "z-ai/glm-4.5-air",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9045,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-vl-235b-a22b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9040,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/codestral-2508",
+                    Model = "qwen/qwen-plus-2025-07-28",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9035,
-                    ContextLimit = 256000,
-                },
+                    Rank = 9060,
+                    ContextLimit = 1000000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-plus-2025-07-28:thinking",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9055,
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2158,9 +2120,53 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 9030,
+                    Rank = 9050,
                     ContextLimit = 163840,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-2.5-flash-lite",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9045,
+                    ContextLimit = 1048576,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "z-ai/glm-4.5-air",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9040,
+                    ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-vl-235b-a22b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9035,
+                    ContextLimit = 262144,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/codestral-2508",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 9030,
+                    ContextLimit = 256000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2171,7 +2177,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9025,
                     ContextLimit = 163840,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2182,7 +2188,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9020,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2193,7 +2199,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9015,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2204,7 +2210,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9010,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2215,18 +2221,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 9005,
                     ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-30b-a3b-thinking-2507",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 9000,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2235,20 +2230,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8995,
+                    Rank = 9000,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen3-coder",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "qwen/qwen3-30b-a3b-thinking-2507",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8990,
-                    ContextLimit = 1048576,
-                },
+                    Rank = 8995,
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2257,9 +2252,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8985,
+                    Rank = 8990,
                     ContextLimit = 65536,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen3-coder",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8985,
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2270,7 +2276,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8980,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2282,7 +2288,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8975,
                     ContextLimit = 400000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2293,7 +2299,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8970,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2304,7 +2310,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8965,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2315,7 +2321,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8960,
                     ContextLimit = 1000000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemini-2.5-flash-image",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8955,
+                    ContextLimit = 32768,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2324,20 +2341,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8955,
-                    ContextLimit = 262144,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "ai21/jamba-large-1.7",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 8950,
-                    ContextLimit = 256000,
-                },
+                    ContextLimit = 262144,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2348,29 +2354,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8945,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-5",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Model = "ai21/jamba-large-1.7",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 8940,
-                    ContextLimit = 400000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-5-chat",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8935,
-                    ContextLimit = 128000,
-                },
+                    ContextLimit = 256000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2379,9 +2374,31 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8930,
+                    Rank = 8935,
                     ContextLimit = 400000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5-chat",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8930,
+                    ContextLimit = 128000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-5",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8925,
+                    ContextLimit = 400000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2390,20 +2407,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8925,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemini-2.5-flash-image",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 8920,
-                    ContextLimit = 32768,
-                },
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2414,7 +2420,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8915,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2425,7 +2431,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8910,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2436,7 +2442,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8905,
                     ContextLimit = 400000,
-                },
+                                    },
 
 
 
@@ -2451,7 +2457,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8900,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2462,7 +2468,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8895,
                     ContextLimit = 163840,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2473,7 +2479,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8890,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2484,7 +2490,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8885,
                     ContextLimit = 131702,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2495,7 +2501,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8880,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2506,7 +2512,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8875,
                     ContextLimit = 1047576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2517,7 +2523,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8870,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2528,7 +2534,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8865,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2539,7 +2545,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8860,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2550,7 +2556,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8855,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2560,18 +2566,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8850,
                     ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "arcee-ai/virtuoso-large",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8845,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2580,9 +2575,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8840,
+                    Rank = 8845,
                     ContextLimit = 81920,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "arcee-ai/virtuoso-large",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8840,
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2593,7 +2599,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8835,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2604,7 +2610,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8830,
                     ContextLimit = 1047576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2615,7 +2621,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8825,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2626,7 +2632,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8820,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2637,7 +2643,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8815,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2648,7 +2654,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8810,
                     ContextLimit = 163840,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2659,7 +2665,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8805,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2670,7 +2676,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8800,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2681,18 +2687,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8795,
                     ContextLimit = 1048576,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/o4-mini",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8790,
-                    ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2701,20 +2696,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8785,
+                    Rank = 8790,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "openai/gpt-4.1",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "openai/o4-mini",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8780,
-                    ContextLimit = 1047576,
-                },
+                    Rank = 8785,
+                    ContextLimit = 200000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2723,9 +2718,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8775,
+                    Rank = 8780,
                     ContextLimit = 200000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "openai/gpt-4.1",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8775,
+                    ContextLimit = 1047576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2736,7 +2742,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8770,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2747,7 +2753,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8765,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2758,7 +2764,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8760,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2769,7 +2775,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8755,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2780,7 +2786,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8750,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2791,7 +2797,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8745,
                     ContextLimit = 200000,
-                },
+                                    },
 
 
 
@@ -2806,7 +2812,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8740,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2817,7 +2823,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8735,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2828,7 +2834,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8730,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2839,7 +2845,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8725,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2850,7 +2856,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8720,
                     ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2861,7 +2867,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8715,
                     ContextLimit = 10000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2872,18 +2878,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8710,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "mistralai/mistral-saba",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    Model = "meta-llama/llama-4-maverick",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Rank = 8705,
-                    ContextLimit = 32768,
-                },
+                    ContextLimit = 1048576,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2894,7 +2900,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8700,
                     ContextLimit = 128000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-saba",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8695,
+                    ContextLimit = 32768,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2903,9 +2920,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8695,
+                    Rank = 8690,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2914,31 +2931,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8690,
-                    ContextLimit = 1000000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "deepseek/deepseek-r1-distill-llama-70b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 8685,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-4-maverick",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8680,
-                    ContextLimit = 1048576,
-                },
+                    ContextLimit = 1000000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2947,9 +2942,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8675,
+                    Rank = 8680,
                     ContextLimit = 32768,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "deepseek/deepseek-r1-distill-llama-70b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8675,
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2960,7 +2966,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8670,
                     ContextLimit = 163840,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2971,7 +2977,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8665,
                     ContextLimit = 127072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2982,7 +2988,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8660,
                     ContextLimit = 1000192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -2993,7 +2999,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8655,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3004,18 +3010,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8650,
                     ContextLimit = 163840,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/o3-mini",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8645,
-                    ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3024,20 +3019,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8640,
+                    Rank = 8645,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "perplexity/sonar-deep-research",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Model = "openai/o3-mini",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8635,
-                    ContextLimit = 128000,
-                },
+                    Rank = 8640,
+                    ContextLimit = 200000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3046,9 +3041,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 8635,
+                    ContextLimit = 128000,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "perplexity/sonar-deep-research",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 8630,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3059,7 +3065,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8625,
                     ContextLimit = 256000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3070,7 +3076,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8620,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3081,7 +3087,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8615,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3092,7 +3098,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8610,
                     ContextLimit = 200000,
-                },
+                                    },
 
 
 
@@ -3107,18 +3113,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8605,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "amazon/nova-micro-v1",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8600,
-                    ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3127,9 +3122,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8595,
+                    Rank = 8600,
                     ContextLimit = 16384,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "amazon/nova-micro-v1",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8595,
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3140,7 +3146,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8590,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3151,7 +3157,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8585,
                     ContextLimit = 300000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3162,18 +3168,17 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8580,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "thedrummer/unslopnemo-12b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
                     Verified = false,
                     Rank = 8575,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3184,7 +3189,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8570,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3195,7 +3200,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8565,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3206,7 +3211,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8560,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3217,7 +3222,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8555,
                     ContextLimit = 16000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3228,7 +3233,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8550,
                     ContextLimit = 300000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3239,7 +3244,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8545,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3250,7 +3255,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8540,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3261,7 +3266,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8535,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3272,7 +3277,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8530,
                     ContextLimit = 200000,
-                },
+                                    },
 
 
 
@@ -3287,7 +3292,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8525,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3298,7 +3303,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8520,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3309,7 +3314,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8515,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3320,7 +3325,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8510,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3331,18 +3336,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8505,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "meta-llama/llama-3.1-70b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8500,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3351,9 +3345,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
+                    Rank = 8500,
+                    ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "meta-llama/llama-3.1-70b-instruct",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
                     Rank = 8495,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3364,7 +3369,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8490,
                     ContextLimit = 65536,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3375,7 +3380,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8485,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3386,7 +3391,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8480,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3397,7 +3402,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8475,
                     ContextLimit = 128000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "google/gemma-2-27b-it",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8470,
+                    ContextLimit = 8192,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3406,9 +3422,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8470,
+                    Rank = 8465,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3417,9 +3433,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8465,
+                    Rank = 8460,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3428,20 +3444,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8460,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "cohere/command-r-plus-08-2024",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 8455,
-                    ContextLimit = 128000,
-                },
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3452,7 +3457,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8450,
                     ContextLimit = 8000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3463,7 +3468,18 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8445,
                     ContextLimit = 8000,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "cohere/command-r-plus-08-2024",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8440,
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3472,9 +3488,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8440,
+                    Rank = 8435,
                     ContextLimit = 128000,
-                },
+                                    },
 
 
 
@@ -3487,9 +3503,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.AudioInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.ImageOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8435,
+                    Rank = 8430,
                     ContextLimit = 2000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3498,9 +3514,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8430,
+                    Rank = 8425,
                     ContextLimit = 4096,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3509,20 +3525,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8425,
-                    ContextLimit = 65536,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "google/gemma-2-27b-it",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
                     Rank = 8420,
-                    ContextLimit = 8192,
-                },
+                    ContextLimit = 65536,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3533,7 +3538,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8415,
                     ContextLimit = 6144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3544,7 +3549,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8410,
                     ContextLimit = 8000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3555,7 +3560,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8405,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3566,7 +3571,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8400,
                     ContextLimit = 16385,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3577,7 +3582,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8395,
                     ContextLimit = 4095,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3588,7 +3593,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8390,
                     ContextLimit = 4095,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3599,18 +3604,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8385,
                     ContextLimit = 16385,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "mistralai/mistral-large",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Rank = 8380,
-                    ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3619,9 +3613,20 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
-                    Rank = 8375,
+                    Rank = 8380,
                     ContextLimit = 65536,
-                },
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "mistralai/mistral-large",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Rank = 8375,
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3632,7 +3637,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8370,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3643,7 +3648,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8365,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3654,7 +3659,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8360,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3665,7 +3670,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8355,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3676,7 +3681,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Rank = 8350,
                     ContextLimit = 8191,
-                },
+                                    },
 
 
 
@@ -3696,26 +3701,26 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "z-ai/glm-5v-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -5,
+                    ContextLimit = 202752,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "openai/gpt-5.2-chat",
                     Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -5,
-                    ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen3-coder:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
                     Rank = -10,
-                    ContextLimit = 1048576,
-                },
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3732,14 +3737,26 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "qwen/qwen3-coder:free",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -20,
+                    ContextLimit = 1048576,
+                },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "nvidia/llama-3.3-nemotron-super-49b-v1.5",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -20,
+                    Rank = -25,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3749,9 +3766,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -25,
-                    ContextLimit = 200000,
-                },
+                    Rank = -30,
+                    ContextLimit = 202752,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3761,9 +3778,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -30,
+                    Rank = -35,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3773,9 +3790,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -35,
+                    Rank = -40,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3785,7 +3802,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -40,
+                    Rank = -45,
                     ContextLimit = 32768,
                 },
 
@@ -3797,7 +3814,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -45,
+                    Rank = -50,
                     ContextLimit = 131072,
                 },
 
@@ -3809,7 +3826,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -50,
+                    Rank = -55,
                     ContextLimit = 131072,
                 },
 
@@ -3821,7 +3838,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -55,
+                    Rank = -60,
                     ContextLimit = 131072,
                 },
 
@@ -3833,21 +3850,20 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -60,
+                    Rank = -65,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "aion-labs/aion-1.0",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -65,
+                    Rank = -70,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3857,27 +3873,15 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -70,
+                    Rank = -75,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "alfredpros/codellama-7b-instruct-solidity",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -75,
-                    ContextLimit = 4096,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "alibaba/tongyi-deepresearch-30b-a3b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
@@ -3888,12 +3892,24 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
+                    Model = "alibaba/tongyi-deepresearch-30b-a3b",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -85,
+                    ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
                     Model = "allenai/olmo-3.1-32b-instruct",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -85,
+                    Rank = -90,
                     ContextLimit = 65536,
                 },
 
@@ -3905,9 +3921,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -90,
+                    Rank = -95,
                     ContextLimit = 6144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3917,9 +3933,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -95,
+                    Rank = -100,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3929,9 +3945,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -100,
+                    Rank = -105,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3941,9 +3957,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -105,
+                    Rank = -110,
                     ContextLimit = 200000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3953,9 +3969,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -110,
+                    Rank = -115,
                     ContextLimit = 1000000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3965,7 +3981,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -115,
+                    Rank = -120,
                     ContextLimit = 131072,
                 },
 
@@ -3977,9 +3993,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -120,
+                    Rank = -125,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -3989,9 +4005,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -125,
+                    Rank = -130,
                     ContextLimit = 131000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4001,20 +4017,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -130,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "baidu/cobuddy:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    Verified = false,
-                    Deprecated = true,
                     Rank = -135,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4026,7 +4031,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -140,
                     ContextLimit = 120000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4038,7 +4043,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -145,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4050,7 +4055,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -150,
                     ContextLimit = 123000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4062,7 +4067,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -155,
                     ContextLimit = 30000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4085,8 +4090,8 @@ namespace SmartHopper.Providers.OpenRouter
                     Verified = false,
                     Deprecated = true,
                     Rank = -165,
-                    ContextLimit = 32768,
-                },
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4110,7 +4115,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -175,
                     ContextLimit = 32768,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4134,7 +4139,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -185,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4146,7 +4151,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -190,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4194,7 +4199,7 @@ namespace SmartHopper.Providers.OpenRouter
                     Deprecated = true,
                     Rank = -210,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4235,61 +4240,37 @@ namespace SmartHopper.Providers.OpenRouter
                 {
                     Provider = provider,
                     Model = "liquid/lfm-2-24b-a2b",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
                     Rank = -230,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "liquid/lfm-2.5-1.2b-instruct:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -235,
-                    ContextLimit = 32768,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "liquid/lfm-2.5-1.2b-thinking:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -240,
-                    ContextLimit = 32768,
-                },
+                    ContextLimit = 128000,
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "meta-llama/llama-3-70b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -245,
+                    Rank = -235,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "meta-llama/llama-3-8b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -250,
+                    Rank = -240,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4299,9 +4280,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -255,
+                    Rank = -245,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4310,9 +4291,9 @@ namespace SmartHopper.Providers.OpenRouter
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -260,
-                    ContextLimit = 128000,
-                },
+                    Rank = -250,
+                    ContextLimit = 131072,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4322,7 +4303,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -265,
+                    Rank = -255,
                     ContextLimit = 196608,
                 },
 
@@ -4334,9 +4315,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -270,
+                    Rank = -260,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4346,9 +4327,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -275,
+                    Rank = -265,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4358,7 +4339,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -280,
+                    Rank = -270,
                     ContextLimit = 2824,
                 },
 
@@ -4370,9 +4351,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -285,
+                    Rank = -275,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4382,7 +4363,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -290,
+                    Rank = -280,
                     ContextLimit = 32768,
                 },
 
@@ -4394,9 +4375,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -295,
+                    Rank = -285,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4406,8 +4387,19 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -300,
+                    Rank = -290,
                     ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "nex-agi/nex-n2-pro:free",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput | AICapability.Reasoning,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -295,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -4418,33 +4410,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -305,
+                    Rank = -300,
                     ContextLimit = 8192,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/llama-3.1-nemotron-70b-instruct",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -310,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "nvidia/nemotron-nano-12b-v2-vl",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.VideoInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -315,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4454,7 +4422,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -320,
+                    Rank = -305,
                     ContextLimit = 131072,
                 },
 
@@ -4466,9 +4434,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -325,
+                    Rank = -310,
                     ContextLimit = 8191,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4478,9 +4446,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -330,
+                    Rank = -315,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4490,21 +4458,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -335,
+                    Rank = -320,
                     ContextLimit = 128000,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "openai/gpt-oss-120b:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -340,
-                    ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4514,9 +4470,20 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -345,
+                    Rank = -325,
                     ContextLimit = 1048756,
                 },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "poolside/laguna-xs.2",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -330,
+                    ContextLimit = 262144,
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4526,8 +4493,8 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -350,
-                    ContextLimit = 131072,
+                    Rank = -335,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -4538,15 +4505,51 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -355,
+                    Rank = -340,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "qwen/qwen-max",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -345,
+                    ContextLimit = 32768,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-turbo",
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -350,
+                    ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-vl-max",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
+                    SupportsStreaming = true,
+                    Verified = false,
+                    Deprecated = true,
+                    Rank = -355,
+                    ContextLimit = 131072,
+                                    },
+
+                new AIModelCapabilities
+                {
+                    Provider = provider,
+                    Model = "qwen/qwen-vl-plus",
+                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
@@ -4557,74 +4560,26 @@ namespace SmartHopper.Providers.OpenRouter
                 new AIModelCapabilities
                 {
                     Provider = provider,
-                    Model = "qwen/qwen-turbo",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -365,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-vl-max",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -370,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "qwen/qwen-vl-plus",
-                    Capabilities = AICapability.TextInput | AICapability.ImageInput | AICapability.TextOutput | AICapability.JsonOutput,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -375,
-                    ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
                     Model = "sao10k/l3-euryale-70b",
                     Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -380,
+                    Rank = -365,
                     ContextLimit = 8192,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
                     Provider = provider,
                     Model = "switchpoint/router",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.Reasoning,
+                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.JsonOutput | AICapability.Reasoning,
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -385,
+                    Rank = -370,
                     ContextLimit = 131072,
-                },
-
-                new AIModelCapabilities
-                {
-                    Provider = provider,
-                    Model = "tencent/hy3-preview:free",
-                    Capabilities = AICapability.TextInput | AICapability.TextOutput | AICapability.FunctionCalling | AICapability.Reasoning,
-                    SupportsStreaming = true,
-                    Verified = false,
-                    Deprecated = true,
-                    Rank = -390,
-                    ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4634,7 +4589,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -395,
+                    Rank = -375,
                     ContextLimit = 163840,
                 },
 
@@ -4646,7 +4601,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -400,
+                    Rank = -380,
                     ContextLimit = 131072,
                 },
 
@@ -4658,9 +4613,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -405,
+                    Rank = -385,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4670,9 +4625,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -410,
+                    Rank = -390,
                     ContextLimit = 131072,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4682,8 +4637,8 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -415,
-                    ContextLimit = 131072,
+                    Rank = -395,
+                    ContextLimit = 1000000,
                 },
 
                 new AIModelCapabilities
@@ -4694,7 +4649,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -420,
+                    Rank = -400,
                     ContextLimit = 256000,
                 },
 
@@ -4706,8 +4661,8 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -425,
-                    ContextLimit = 2000000,
+                    Rank = -405,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -4718,8 +4673,8 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -430,
-                    ContextLimit = 2000000,
+                    Rank = -410,
+                    ContextLimit = 262144,
                 },
 
                 new AIModelCapabilities
@@ -4730,8 +4685,8 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -435,
-                    ContextLimit = 256000,
+                    Rank = -415,
+                    ContextLimit = 65536,
                 },
 
                 new AIModelCapabilities
@@ -4742,9 +4697,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -440,
+                    Rank = -420,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4754,9 +4709,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -445,
+                    Rank = -425,
                     ContextLimit = 262144,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4766,9 +4721,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -450,
+                    Rank = -430,
                     ContextLimit = 1048576,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4778,9 +4733,9 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -455,
+                    Rank = -435,
                     ContextLimit = 128000,
-                },
+                                    },
 
                 new AIModelCapabilities
                 {
@@ -4790,7 +4745,7 @@ namespace SmartHopper.Providers.OpenRouter
                     SupportsStreaming = true,
                     Verified = false,
                     Deprecated = true,
-                    Rank = -460,
+                    Rank = -440,
                     ContextLimit = 131072,
                 }
             };


### PR DESCRIPTION
## Description

This hotfix prepares release **1.4.4** on top of the `main-1.4.3` stabilization branch. It focuses on the DeepSeek provider and synchronizes the provider model catalogs.

- **DeepSeek provider settings**: Added `ReasoningEffort` (a single dropdown that controls thinking mode and reasoning depth) and `TopP` (nucleus sampling). `ReasoningEffort` is mapped to DeepSeek's `thinking` and `reasoning_effort` parameters for `deepseek-v4` and `deepseek-reasoner` models; `TopP` is included in every chat completion request. Removed the artificial `MaxTokens` cap of `8192`.
- **DeepSeek tool-call reliability**: Fixed multi-step tool call requests that failed with `invalid_request_error` because consecutive tool results were merged into a single message. Assistant tool calls and reasoning are now coalesced into one message while tool result messages remain separate; `reasoning_content` is emitted on assistant messages with `tool_calls`; and tool result content is now sent as a compact JSON string, matching OpenAI and MistralAI behavior.
- **Tool result messages**: Removed the optional `name` field from `role=tool` result messages in the DeepSeek and OpenRouter providers to comply with DeepSeek's strict validator and OpenRouter's documented schema. Preserved for MistralAI because its official examples include it.
- **Provider model catalogs**: Refreshed available models and aliases for Anthropic, DeepSeek, MistralAI, OpenAI, and OpenRouter.
- **Chores/docs**: Bumped `Solution.props` to `1.4.4` and simplified the hotfix workflow validation checklist.

## Breaking Changes

No breaking changes.

## Testing Done

- Validated that DeepSeek `ReasoningEffort` and `TopP` settings are serialized into chat completion requests.
- Verified multi-step tool call sequences no longer produce `invalid_request_error` / `insufficient tool messages` for DeepSeek.
- Confirmed OpenRouter and DeepSeek tool result messages omit `name`, while MistralAI retains it.
- Ran the provider model catalog verification workflow to ensure updated model lists load correctly.
- Built the solution in Release and ran the CI test suite.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [x] CHANGELOG.md has been updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.1.0/) format
- [x] PR description follows [Pull Request Description Template](https://github.com/architects-toolkit/SmartHopper/blob/main/CONTRIBUTING.md#pull-request-description-template)