### PR TITLE
test(provider-sdk): expand Provider SDK test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent Notes
+
+## Testing
+
+- The `SmartHopper.ProviderSdk.Tests` project can be built and run without a strong-name key:
+
+  ```powershell
+  dotnet test src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj -p:SignAssembly=false
+  ```
+
+- All Provider SDK test classes use `[Collection("ProviderSdk")]` to disable xUnit parallelization. This lets tests safely reset shared mutable state such as `AIModelCapabilityRegistry.Instance.Models`.
+
+## Signing
+
+- The official build scripts expect `signing.snk` / `signing.pfx` and update `SmartHopperPublicKey` in `src/SmartHopper.Infrastructure/SmartHopper.Infrastructure.csproj`.
+- Do not commit generated signing keys, certificates, or API keys.
+- `SmartHopperPublicKey` changes made by local build tooling should be reverted before committing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added centralized `AIMetrics.EstimatedCost` (USD) and `AICostCalculator` that derive estimated call cost from provider/model pricing and token buckets (input prompt, cached, cache-write, output generation, reasoning). Falls back to `EstimatedInputTokens`/`EstimatedOutputTokens` when actual token counts are zero; free, negative, or missing prices contribute `0`.
 - Added `Estimated Cost` output to `Deconstruct SmartHopper Metrics` and `estimated_cost` field to metrics JSON.
-- Added `SmartHopper.ProviderSdk.Tests` xUnit project with initial coverage for `AICostCalculator`, `AIMetrics`, `AIModelCapabilityRegistry`, and `AIBody`.
+- Added `SmartHopper.ProviderSdk.Tests` xUnit project with coverage for `AICostCalculator`, `AIMetrics`, `AIModelCapabilityRegistry`, `AIBody`/`AIBodyBuilder`, `AIRequestBase`/`AIRequestCall`, `AIReturn`, all `AIInteraction*` types, `AICallStatus`/`AIAgent`/`AIRequestKind`, `AICapability`/`AIModelCapabilities`, and `SHRuntimeMessage`.
 - Added `.github/workflows/pr-linear-history.yml` to enforce that pull requests targeting `main` (and release/hotfix branches) are rebased and contain no merge commits.
 - Added `.github/workflows/sync-dev-from-main.yml` to automatically rebase `dev` onto `main` and force-push; if the rebase fails, the workflow run fails so it surfaces in GitHub Actions.
 - Added `.github/actions/utils/rebase-onto-base` composite action to centralize rebase/base-management operations for GitHub Actions workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added centralized `AIMetrics.EstimatedCost` (USD) and `AICostCalculator` that derive estimated call cost from provider/model pricing and token buckets (input prompt, cached, cache-write, output generation, reasoning). Falls back to `EstimatedInputTokens`/`EstimatedOutputTokens` when actual token counts are zero; free, negative, or missing prices contribute `0`.
 - Added `Estimated Cost` output to `Deconstruct SmartHopper Metrics` and `estimated_cost` field to metrics JSON.
+- Added `SmartHopper.ProviderSdk.Tests` xUnit project with initial coverage for `AICostCalculator`, `AIMetrics`, `AIModelCapabilityRegistry`, and `AIBody`.
 - Added `.github/workflows/pr-linear-history.yml` to enforce that pull requests targeting `main` (and release/hotfix branches) are rebased and contain no merge commits.
 - Added `.github/workflows/sync-dev-from-main.yml` to automatically rebase `dev` onto `main` and force-push; if the rebase fails, the workflow run fails so it surfaces in GitHub Actions.
 - Added `.github/actions/utils/rebase-onto-base` composite action to centralize rebase/base-management operations for GitHub Actions workflows.

--- a/SmartHopper.sln
+++ b/SmartHopper.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartHopper.Core.Tests", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartHopper.ProviderSdk", "src\SmartHopper.ProviderSdk\SmartHopper.ProviderSdk.csproj", "{F59F33CC-DCD6-4EEE-9766-6E3C08E8AD43}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartHopper.ProviderSdk.Tests", "src\SmartHopper.ProviderSdk.Tests\SmartHopper.ProviderSdk.Tests.csproj", "{65EB1E04-E30E-4708-B413-51A22FECBD9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -238,9 +240,24 @@ Global
 		{F59F33CC-DCD6-4EEE-9766-6E3C08E8AD43}.Release|x64.Build.0 = Release|Any CPU
 		{F59F33CC-DCD6-4EEE-9766-6E3C08E8AD43}.Release|x86.ActiveCfg = Release|Any CPU
 		{F59F33CC-DCD6-4EEE-9766-6E3C08E8AD43}.Release|x86.Build.0 = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|x64.Build.0 = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Debug|x86.Build.0 = Debug|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|x64.ActiveCfg = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|x64.Build.0 = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|x86.ActiveCfg = Release|Any CPU
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{65EB1E04-E30E-4708-B413-51A22FECBD9E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D5011CB-B808-41E4-A6FC-C01F3190649C}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Base/AICallBaseEnumTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Base/AICallBaseEnumTests.cs
@@ -1,0 +1,186 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Base
+{
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AICallStatusExtensions"/>, <see cref="AIAgentExtensions"/> and <see cref="AIRequestKind"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AICallBaseEnumTests
+    {
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AICallStatusExtensions_ToString_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AICallStatusExtensions_ToString_ReturnsExpected [Core]")]
+#endif
+        [InlineData(AICallStatus.Idle, "idle")]
+        [InlineData(AICallStatus.Processing, "processing")]
+        [InlineData(AICallStatus.Streaming, "streaming")]
+        [InlineData(AICallStatus.CallingTools, "calling_tools")]
+        [InlineData(AICallStatus.Finished, "finished")]
+        public void AICallStatusExtensions_ToString_ReturnsExpected(AICallStatus status, string expected)
+        {
+            Assert.Equal(expected, AICallStatusExtensions.ToString(status));
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AICallStatusExtensions_ToDescription_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AICallStatusExtensions_ToDescription_ReturnsExpected [Core]")]
+#endif
+        [InlineData(AICallStatus.Idle, "Idle")]
+        [InlineData(AICallStatus.Processing, "Processing")]
+        [InlineData(AICallStatus.Streaming, "Streaming")]
+        [InlineData(AICallStatus.CallingTools, "Calling tools")]
+        [InlineData(AICallStatus.Finished, "Finished")]
+        public void AICallStatusExtensions_ToDescription_ReturnsExpected(AICallStatus status, string expected)
+        {
+            Assert.Equal(expected, AICallStatusExtensions.ToDescription(status));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AICallStatusExtensions_ToString_UnknownFallback [Windows]")]
+#else
+        [Fact(DisplayName = "AICallStatusExtensions_ToString_UnknownFallback [Core]")]
+#endif
+        public void AICallStatusExtensions_ToString_UnknownFallback()
+        {
+            var unknown = (AICallStatus)999;
+            Assert.Equal("unknown", AICallStatusExtensions.ToString(unknown));
+            Assert.Equal("Unknown", AICallStatusExtensions.ToDescription(unknown));
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AICallStatusExtensions_FromString_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AICallStatusExtensions_FromString_ReturnsExpected [Core]")]
+#endif
+        [InlineData("idle", AICallStatus.Idle)]
+        [InlineData("processing", AICallStatus.Processing)]
+        [InlineData("streaming", AICallStatus.Streaming)]
+        [InlineData("calling_tools", AICallStatus.CallingTools)]
+        [InlineData("finished", AICallStatus.Finished)]
+        public void AICallStatusExtensions_FromString_ReturnsExpected(string input, AICallStatus expected)
+        {
+            Assert.Equal(expected, AICallStatusExtensions.FromString(input));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AICallStatusExtensions_FromString_UnknownFallback [Windows]")]
+#else
+        [Fact(DisplayName = "AICallStatusExtensions_FromString_UnknownFallback [Core]")]
+#endif
+        public void AICallStatusExtensions_FromString_UnknownFallback()
+        {
+            Assert.Equal(AICallStatus.Idle, AICallStatusExtensions.FromString("not_a_status"));
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AIAgentExtensions_ToString_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AIAgentExtensions_ToString_ReturnsExpected [Core]")]
+#endif
+        [InlineData(AIAgent.Context, "context")]
+        [InlineData(AIAgent.System, "system")]
+        [InlineData(AIAgent.User, "user")]
+        [InlineData(AIAgent.Assistant, "assistant")]
+        [InlineData(AIAgent.ToolCall, "tool_call")]
+        [InlineData(AIAgent.ToolResult, "tool_result")]
+        [InlineData(AIAgent.Summary, "summary")]
+        [InlineData(AIAgent.Error, "error")]
+        [InlineData(AIAgent.Warning, "warning")]
+        [InlineData(AIAgent.Info, "info")]
+        [InlineData(AIAgent.Debug, "debug")]
+        [InlineData(AIAgent.Unknown, "unknown")]
+        public void AIAgentExtensions_ToString_ReturnsExpected(AIAgent agent, string expected)
+        {
+            Assert.Equal(expected, AIAgentExtensions.ToString(agent));
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AIAgentExtensions_ToDescription_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AIAgentExtensions_ToDescription_ReturnsExpected [Core]")]
+#endif
+        [InlineData(AIAgent.Context, "Context")]
+        [InlineData(AIAgent.System, "System")]
+        [InlineData(AIAgent.User, "User")]
+        [InlineData(AIAgent.Assistant, "Assistant")]
+        [InlineData(AIAgent.ToolCall, "Tool Call")]
+        [InlineData(AIAgent.ToolResult, "Tool Result")]
+        [InlineData(AIAgent.Summary, "Summary")]
+        [InlineData(AIAgent.Error, "Error")]
+        [InlineData(AIAgent.Warning, "Warning")]
+        [InlineData(AIAgent.Info, "Info")]
+        [InlineData(AIAgent.Debug, "Debug")]
+        [InlineData(AIAgent.Unknown, "Unknown")]
+        public void AIAgentExtensions_ToDescription_ReturnsExpected(AIAgent agent, string expected)
+        {
+            Assert.Equal(expected, AIAgentExtensions.ToDescription(agent));
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AIAgentExtensions_FromString_ReturnsExpected [Windows]")]
+#else
+        [Theory(DisplayName = "AIAgentExtensions_FromString_ReturnsExpected [Core]")]
+#endif
+        [InlineData("context", AIAgent.Context)]
+        [InlineData("system", AIAgent.System)]
+        [InlineData("developer", AIAgent.System)]
+        [InlineData("user", AIAgent.User)]
+        [InlineData("assistant", AIAgent.Assistant)]
+        [InlineData("tool_call", AIAgent.ToolCall)]
+        [InlineData("tool_result", AIAgent.ToolResult)]
+        [InlineData("tool", AIAgent.ToolResult)]
+        [InlineData("summary", AIAgent.Summary)]
+        [InlineData("error", AIAgent.Error)]
+        [InlineData("warning", AIAgent.Warning)]
+        [InlineData("info", AIAgent.Info)]
+        [InlineData("debug", AIAgent.Debug)]
+        [InlineData("unknown", AIAgent.Unknown)]
+        public void AIAgentExtensions_FromString_ReturnsExpected(string input, AIAgent expected)
+        {
+            Assert.Equal(expected, AIAgentExtensions.FromString(input));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AIAgentExtensions_FromString_UnknownFallback [Windows]")]
+#else
+        [Fact(DisplayName = "AIAgentExtensions_FromString_UnknownFallback [Core]")]
+#endif
+        public void AIAgentExtensions_FromString_UnknownFallback()
+        {
+            Assert.Equal(AIAgent.Unknown, AIAgentExtensions.FromString("not_an_agent"));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AIRequestKind_Values [Windows]")]
+#else
+        [Fact(DisplayName = "AIRequestKind_Values [Core]")]
+#endif
+        public void AIRequestKind_Values()
+        {
+            Assert.Equal(0, (int)AIRequestKind.Generation);
+            Assert.Equal(1, (int)AIRequestKind.Backoffice);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyBuilderTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyBuilderTests.cs
@@ -1,0 +1,800 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Interactions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json.Linq;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIBodyBuilder"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIBodyBuilderTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Create_Build_ProducesEmptyBody [Windows]")]
+#else
+        [Fact(DisplayName = "Create_Build_ProducesEmptyBody [Core]")]
+#endif
+        public void Create_Build_ProducesEmptyBody()
+        {
+            var body = AIBodyBuilder.Create().Build();
+
+            Assert.Equal(0, body.InteractionsCount);
+            Assert.Equal("-*", body.ToolFilter);
+            Assert.Equal("-*", body.ContextFilter);
+            Assert.Null(body.JsonOutputSchema);
+            Assert.False(body.RequiresJsonOutput);
+            Assert.Empty(body.InteractionsNew);
+            Assert.True(body.AreTurnIdsValid());
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "FromImmutable_PreservesFiltersAndNewMarkers [Windows]")]
+#else
+        [Fact(DisplayName = "FromImmutable_PreservesFiltersAndNewMarkers [Core]")]
+#endif
+        public void FromImmutable_PreservesFiltersAndNewMarkers()
+        {
+            var original = AIBodyBuilder.Create()
+                .WithToolFilter("+gh_*")
+                .WithContextFilter("+context")
+                .WithJsonOutputSchema("{}")
+                .AddUser("hello")
+                .Build();
+
+            var body = AIBodyBuilder.FromImmutable(original)
+                .AddAssistant("reply")
+                .Build();
+
+            Assert.Equal("+gh_*", body.ToolFilter);
+            Assert.Equal("+context", body.ContextFilter);
+            Assert.Equal("{}", body.JsonOutputSchema);
+            Assert.True(body.RequiresJsonOutput);
+            Assert.Equal(2, body.InteractionsCount);
+            Assert.Equal(new[] { 0, 1 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Add_DefaultNewness_MarksAsNew [Windows]")]
+#else
+        [Fact(DisplayName = "Add_DefaultNewness_MarksAsNew [Core]")]
+#endif
+        public void Add_DefaultNewness_MarksAsNew()
+        {
+            var body = AIBodyBuilder.Create()
+                .Add(new AIInteractionText { Agent = AIAgent.User, Content = "x" })
+                .Build();
+
+            Assert.Equal(1, body.InteractionsCount);
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(0, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Add_ExplicitNewness_False_DoesNotMark [Windows]")]
+#else
+        [Fact(DisplayName = "Add_ExplicitNewness_False_DoesNotMark [Core]")]
+#endif
+        public void Add_ExplicitNewness_False_DoesNotMark()
+        {
+            var body = AIBodyBuilder.Create()
+                .Add(new AIInteractionText { Agent = AIAgent.User, Content = "x" }, false)
+                .Build();
+
+            Assert.Empty(body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Add_Null_Ignored [Windows]")]
+#else
+        [Fact(DisplayName = "Add_Null_Ignored [Core]")]
+#endif
+        public void Add_Null_Ignored()
+        {
+            var body = AIBodyBuilder.Create()
+                .Add((IAIInteraction)null!)
+                .Build();
+
+            Assert.Equal(0, body.InteractionsCount);
+            Assert.Empty(body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddRange_DefaultNewness_MarksAll [Windows]")]
+#else
+        [Fact(DisplayName = "AddRange_DefaultNewness_MarksAll [Core]")]
+#endif
+        public void AddRange_DefaultNewness_MarksAll()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddRange(new IAIInteraction[]
+                {
+                    new AIInteractionText { Agent = AIAgent.User, Content = "a" },
+                    new AIInteractionText { Agent = AIAgent.Assistant, Content = "b" },
+                })
+                .Build();
+
+            Assert.Equal(2, body.InteractionsCount);
+            Assert.Equal(new[] { 0, 1 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddRange_Tuples_RespectsPerItemNewness [Windows]")]
+#else
+        [Fact(DisplayName = "AddRange_Tuples_RespectsPerItemNewness [Core]")]
+#endif
+        public void AddRange_Tuples_RespectsPerItemNewness()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddRange(new (IAIInteraction, bool)[]
+                {
+                    (new AIInteractionText { Agent = AIAgent.User, Content = "a" }, true),
+                    (new AIInteractionText { Agent = AIAgent.Assistant, Content = "b" }, false),
+                })
+                .Build();
+
+            Assert.Equal(2, body.InteractionsCount);
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(0, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "AddUser_AddsUserText [Windows]")]
+#else
+        [Theory(DisplayName = "AddUser_AddsUserText [Core]")]
+#endif
+        [InlineData("hello", true)]
+        [InlineData("hello", false)]
+        public void AddUser_AddsUserText(string content, bool markAsNew)
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser(content, markAsNew)
+                .Build();
+
+            Assert.Single(body.Interactions);
+            var text = Assert.IsType<AIInteractionText>(body.Interactions[0]);
+            Assert.Equal(AIAgent.User, text.Agent);
+            Assert.Equal(content, text.Content);
+
+            if (markAsNew)
+            {
+                Assert.Single(body.InteractionsNew);
+                Assert.Contains(0, body.InteractionsNew);
+            }
+            else
+            {
+                Assert.Empty(body.InteractionsNew);
+            }
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddAssistant_AddsAssistantText [Windows]")]
+#else
+        [Fact(DisplayName = "AddAssistant_AddsAssistantText [Core]")]
+#endif
+        public void AddAssistant_AddsAssistantText()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddAssistant("reply")
+                .Build();
+
+            var text = Assert.IsType<AIInteractionText>(body.Interactions[0]);
+            Assert.Equal(AIAgent.Assistant, text.Agent);
+            Assert.Equal("reply", text.Content);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddSystem_AddsSystemText [Windows]")]
+#else
+        [Fact(DisplayName = "AddSystem_AddsSystemText [Core]")]
+#endif
+        public void AddSystem_AddsSystemText()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddSystem("system prompt")
+                .Build();
+
+            var text = Assert.IsType<AIInteractionText>(body.Interactions[0]);
+            Assert.Equal(AIAgent.System, text.Agent);
+            Assert.Equal("system prompt", text.Content);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddText_WithReasoningAndMetrics [Windows]")]
+#else
+        [Fact(DisplayName = "AddText_WithReasoningAndMetrics [Core]")]
+#endif
+        public void AddText_WithReasoningAndMetrics()
+        {
+            var metrics = new AIMetrics { InputTokensPrompt = 5 };
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "answer", metrics, "reasoning chain")
+                .Build();
+
+            var text = Assert.IsType<AIInteractionText>(body.Interactions[0]);
+            Assert.Equal(AIAgent.Assistant, text.Agent);
+            Assert.Equal("answer", text.Content);
+            Assert.Equal("reasoning chain", text.Reasoning);
+            Assert.Same(metrics, text.Metrics);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddImageRequest_AddsImageGenerationInteraction [Windows]")]
+#else
+        [Fact(DisplayName = "AddImageRequest_AddsImageGenerationInteraction [Core]")]
+#endif
+        public void AddImageRequest_AddsImageGenerationInteraction()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddImageRequest("a red cube", "1024x1024", "hd", "vivid", "1:1")
+                .Build();
+
+            var img = Assert.IsType<AIInteractionImage>(body.Interactions[0]);
+            Assert.Equal(AIAgent.User, img.Agent);
+            Assert.Equal("a red cube", img.OriginalPrompt);
+            Assert.Equal("1024x1024", img.ImageSize);
+            Assert.Equal("hd", img.ImageQuality);
+            Assert.Equal("vivid", img.ImageStyle);
+            Assert.Equal("1:1", img.AspectRatio);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddImageInput_WithString_AddsVisionInput [Windows]")]
+#else
+        [Fact(DisplayName = "AddImageInput_WithString_AddsVisionInput [Core]")]
+#endif
+        public void AddImageInput_WithString_AddsVisionInput()
+        {
+#pragma warning disable CA2234
+            var body = AIBodyBuilder.Create()
+                .AddImageInput("https://example.com/image.png")
+                .Build();
+#pragma warning restore CA2234
+
+            var img = Assert.IsType<AIInteractionImage>(body.Interactions[0]);
+            Assert.Equal(new Uri("https://example.com/image.png"), img.ImageUrl);
+            Assert.Null(img.ImageData);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddImageInput_WithUri_AddsVisionInput [Windows]")]
+#else
+        [Fact(DisplayName = "AddImageInput_WithUri_AddsVisionInput [Core]")]
+#endif
+        public void AddImageInput_WithUri_AddsVisionInput()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddImageInput(new Uri("https://example.com/image.png"))
+                .Build();
+
+            var img = Assert.IsType<AIInteractionImage>(body.Interactions[0]);
+            Assert.Equal(new Uri("https://example.com/image.png"), img.ImageUrl);
+            Assert.Null(img.ImageData);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddImageInputFromBase64_AddsVisionInput [Windows]")]
+#else
+        [Fact(DisplayName = "AddImageInputFromBase64_AddsVisionInput [Core]")]
+#endif
+        public void AddImageInputFromBase64_AddsVisionInput()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddImageInputFromBase64("abc123", "image/jpeg")
+                .Build();
+
+            var img = Assert.IsType<AIInteractionImage>(body.Interactions[0]);
+            Assert.Equal("abc123", img.ImageData);
+            Assert.Equal("image/jpeg", img.MimeType);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddToolCall_AddsToolCall [Windows]")]
+#else
+        [Fact(DisplayName = "AddToolCall_AddsToolCall [Core]")]
+#endif
+        public void AddToolCall_AddsToolCall()
+        {
+            var args = new JObject(new JProperty("x", 1));
+
+            var body = AIBodyBuilder.Create()
+                .AddToolCall("call-1", "test_tool", args)
+                .Build();
+
+            var tc = Assert.IsType<AIInteractionToolCall>(body.Interactions[0]);
+            Assert.Equal(AIAgent.ToolCall, tc.Agent);
+            Assert.Equal("call-1", tc.Id);
+            Assert.Equal("test_tool", tc.Name);
+            Assert.Same(args, tc.Arguments);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddToolResult_AddsToolResult [Windows]")]
+#else
+        [Fact(DisplayName = "AddToolResult_AddsToolResult [Core]")]
+#endif
+        public void AddToolResult_AddsToolResult()
+        {
+            var result = new JObject(new JProperty("ok", true));
+            var messages = new List<SHRuntimeMessage>
+            {
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Provider, SHMessageCode.Unknown, "note"),
+            };
+            var metrics = new AIMetrics { InputTokensPrompt = 10 };
+
+            var body = AIBodyBuilder.Create()
+                .AddToolResult(result, "call-1", "test_tool", metrics, messages)
+                .Build();
+
+            var tr = Assert.IsType<AIInteractionToolResult>(body.Interactions[0]);
+            Assert.Equal(AIAgent.ToolResult, tr.Agent);
+            Assert.Equal("call-1", tr.Id);
+            Assert.Equal("test_tool", tr.Name);
+            Assert.Same(result, tr.Result);
+            Assert.Same(messages, tr.Messages);
+            Assert.Same(metrics, tr.Metrics);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddError_AddsErrorDiagnostic [Windows]")]
+#else
+        [Fact(DisplayName = "AddError_AddsErrorDiagnostic [Core]")]
+#endif
+        public void AddError_AddsErrorDiagnostic()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddError("boom")
+                .Build();
+
+            var diag = Assert.IsType<AIInteractionRuntimeMessage>(body.Interactions[0]);
+            Assert.Equal(SHRuntimeMessageSeverity.Error, diag.Severity);
+            Assert.Equal("boom", diag.Content);
+            Assert.True(diag.Surfaceable);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddWarning_AddsWarningDiagnostic [Windows]")]
+#else
+        [Fact(DisplayName = "AddWarning_AddsWarningDiagnostic [Core]")]
+#endif
+        public void AddWarning_AddsWarningDiagnostic()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddWarning("watch out")
+                .Build();
+
+            var diag = Assert.IsType<AIInteractionRuntimeMessage>(body.Interactions[0]);
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, diag.Severity);
+            Assert.Equal("watch out", diag.Content);
+            Assert.True(diag.Surfaceable);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddInfo_AddsInfoDiagnostic [Windows]")]
+#else
+        [Fact(DisplayName = "AddInfo_AddsInfoDiagnostic [Core]")]
+#endif
+        public void AddInfo_AddsInfoDiagnostic()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddInfo("noted")
+                .Build();
+
+            var diag = Assert.IsType<AIInteractionRuntimeMessage>(body.Interactions[0]);
+            Assert.Equal(SHRuntimeMessageSeverity.Info, diag.Severity);
+            Assert.Equal("noted", diag.Content);
+            Assert.True(diag.Surfaceable);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddDebug_AddsDebugDiagnosticNonSurfaceable [Windows]")]
+#else
+        [Fact(DisplayName = "AddDebug_AddsDebugDiagnosticNonSurfaceable [Core]")]
+#endif
+        public void AddDebug_AddsDebugDiagnosticNonSurfaceable()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddDebug("trace")
+                .Build();
+
+            var diag = Assert.IsType<AIInteractionRuntimeMessage>(body.Interactions[0]);
+            Assert.Equal(SHRuntimeMessageSeverity.Debug, diag.Severity);
+            Assert.Equal("trace", diag.Content);
+            Assert.False(diag.Surfaceable);
+        }
+
+#if NET7_WINDOWS
+        [Theory(DisplayName = "Diagnostics_RespectNewness [Windows]")]
+#else
+        [Theory(DisplayName = "Diagnostics_RespectNewness [Core]")]
+#endif
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Diagnostics_RespectNewness(bool markAsNew)
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddError("err", markAsNew)
+                .Build();
+
+            if (markAsNew)
+            {
+                Assert.Single(body.InteractionsNew);
+                Assert.Contains(0, body.InteractionsNew);
+            }
+            else
+            {
+                Assert.Empty(body.InteractionsNew);
+            }
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "WithToolFilter_WithContextFilter_WithJsonOutputSchema_PreservedOnBuild [Windows]")]
+#else
+        [Fact(DisplayName = "WithToolFilter_WithContextFilter_WithJsonOutputSchema_PreservedOnBuild [Core]")]
+#endif
+        public void WithToolFilter_WithContextFilter_WithJsonOutputSchema_PreservedOnBuild()
+        {
+            var body = AIBodyBuilder.Create()
+                .WithToolFilter("+gh_*")
+                .WithContextFilter("+ctx")
+                .WithJsonOutputSchema("{\"type\":\"object\"}")
+                .WithToolFilter(null!)
+                .WithContextFilter(null!)
+                .WithJsonOutputSchema(null!)
+                .AddUser("hi")
+                .Build();
+
+            Assert.Equal("+gh_*", body.ToolFilter);
+            Assert.Equal("+ctx", body.ContextFilter);
+            Assert.Equal("{\"type\":\"object\"}", body.JsonOutputSchema);
+            Assert.True(body.RequiresJsonOutput);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "WithTurnId_AssignedToInteractionsWithoutTurnId [Windows]")]
+#else
+        [Fact(DisplayName = "WithTurnId_AssignedToInteractionsWithoutTurnId [Core]")]
+#endif
+        public void WithTurnId_AssignedToInteractionsWithoutTurnId()
+        {
+            var body = AIBodyBuilder.Create()
+                .WithTurnId("turn-shared")
+                .AddUser("u1")
+                .AddAssistant("a1")
+                .Build();
+
+            Assert.True(body.AreTurnIdsValid());
+            Assert.All(body.Interactions, i => Assert.Equal("turn-shared", i.TurnId));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "WithTurnId_PreservesPreExistingTurnId [Windows]")]
+#else
+        [Fact(DisplayName = "WithTurnId_PreservesPreExistingTurnId [Core]")]
+#endif
+        public void WithTurnId_PreservesPreExistingTurnId()
+        {
+            var existing = new AIInteractionText { Agent = AIAgent.User, Content = "u", TurnId = "existing" };
+
+            var body = AIBodyBuilder.Create()
+                .WithTurnId("default")
+                .Add(existing)
+                .Build();
+
+            Assert.Equal("existing", body.Interactions[0].TurnId);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AsHistory_AsNew_ControlDefaultNewness [Windows]")]
+#else
+        [Fact(DisplayName = "AsHistory_AsNew_ControlDefaultNewness [Core]")]
+#endif
+        public void AsHistory_AsNew_ControlDefaultNewness()
+        {
+            var historyBody = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("u")
+                .Build();
+
+            Assert.Empty(historyBody.InteractionsNew);
+
+            var newBody = AIBodyBuilder.Create()
+                .AsNew()
+                .AddUser("u")
+                .Build();
+
+            Assert.Single(newBody.InteractionsNew);
+            Assert.Contains(0, newBody.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ClearNewMarkers_ClearsAndAllowsFurtherMarking [Windows]")]
+#else
+        [Fact(DisplayName = "ClearNewMarkers_ClearsAndAllowsFurtherMarking [Core]")]
+#endif
+        public void ClearNewMarkers_ClearsAndAllowsFurtherMarking()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("u")
+                .ClearNewMarkers()
+                .AddAssistant("a")
+                .Build();
+
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(1, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "MarkLastAsNew_MarksLastInteraction [Windows]")]
+#else
+        [Fact(DisplayName = "MarkLastAsNew_MarksLastInteraction [Core]")]
+#endif
+        public void MarkLastAsNew_MarksLastInteraction()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("u")
+                .AddAssistant("a")
+                .MarkLastAsNew()
+                .Build();
+
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(1, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "MarkLastNAsNew_MarksLastN [Windows]")]
+#else
+        [Fact(DisplayName = "MarkLastNAsNew_MarksLastN [Core]")]
+#endif
+        public void MarkLastNAsNew_MarksLastN()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("u")
+                .AddAssistant("a")
+                .AddSystem("s")
+                .MarkLastNAsNew(2)
+                .Build();
+
+            Assert.Equal(new[] { 1, 2 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "MarkIndicesAsNew_MarksProvidedIndices [Windows]")]
+#else
+        [Fact(DisplayName = "MarkIndicesAsNew_MarksProvidedIndices [Core]")]
+#endif
+        public void MarkIndicesAsNew_MarksProvidedIndices()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("u")
+                .AddAssistant("a")
+                .AddSystem("s")
+                .MarkIndicesAsNew(new[] { 0, 2 })
+                .Build();
+
+            Assert.Equal(new[] { 0, 2 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLast_DefaultNewness_ReplacesAndMarks [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLast_DefaultNewness_ReplacesAndMarks [Core]")]
+#endif
+        public void ReplaceLast_DefaultNewness_ReplacesAndMarks()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("a")
+                .AddAssistant("b")
+                .ReplaceLast(new AIInteractionText { Agent = AIAgent.Assistant, Content = "c" })
+                .Build();
+
+            Assert.Equal(2, body.InteractionsCount);
+            var last = Assert.IsType<AIInteractionText>(body.Interactions[1]);
+            Assert.Equal("c", last.Content);
+            Assert.Equal(new[] { 0, 1 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLast_ExplicitNewness_False_DoesNotMark [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLast_ExplicitNewness_False_DoesNotMark [Core]")]
+#endif
+        public void ReplaceLast_ExplicitNewness_False_DoesNotMark()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("a")
+                .AddAssistant("b")
+                .ReplaceLast(new AIInteractionText { Agent = AIAgent.Assistant, Content = "c" }, false)
+                .Build();
+
+            Assert.Equal(2, body.InteractionsCount);
+            Assert.Empty(body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLast_WhenEmpty_TreatsAsAdd [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLast_WhenEmpty_TreatsAsAdd [Core]")]
+#endif
+        public void ReplaceLast_WhenEmpty_TreatsAsAdd()
+        {
+            var body = AIBodyBuilder.Create()
+                .ReplaceLast(new AIInteractionText { Agent = AIAgent.User, Content = "x" })
+                .Build();
+
+            Assert.Single(body.Interactions);
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(0, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLastRange_Slice_WithDefaultNewness [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLastRange_Slice_WithDefaultNewness [Core]")]
+#endif
+        public void ReplaceLastRange_Slice_WithDefaultNewness()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("a")
+                .AddAssistant("b")
+                .AddSystem("c")
+                .AsNew()
+                .ReplaceLastRange(new List<IAIInteraction>
+                {
+                    new AIInteractionText { Agent = AIAgent.Assistant, Content = "y" },
+                    new AIInteractionText { Agent = AIAgent.Assistant, Content = "z" },
+                })
+                .Build();
+
+            Assert.Equal(3, body.InteractionsCount);
+            Assert.IsType<AIInteractionText>(body.Interactions[0]);
+            Assert.Equal("y", ((AIInteractionText)body.Interactions[1]).Content);
+            Assert.Equal("z", ((AIInteractionText)body.Interactions[2]).Content);
+            Assert.Equal(new[] { 1, 2 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLastRange_Slice_ExplicitNewness [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLastRange_Slice_ExplicitNewness [Core]")]
+#endif
+        public void ReplaceLastRange_Slice_ExplicitNewness()
+        {
+            var replacements = new List<IAIInteraction>
+            {
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "y" },
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "z" },
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("a")
+                .AddAssistant("b")
+                .AddSystem("c")
+                .ReplaceLastRange(replacements, false)
+                .Build();
+
+            Assert.Equal(3, body.InteractionsCount);
+            Assert.Empty(body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLastRange_ResetWhenReplacingMoreThanExisting [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLastRange_ResetWhenReplacingMoreThanExisting [Core]")]
+#endif
+        public void ReplaceLastRange_ResetWhenReplacingMoreThanExisting()
+        {
+            var replacements = new List<IAIInteraction>
+            {
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "x" },
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "y" },
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "z" },
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("a")
+                .AddAssistant("b")
+                .ReplaceLastRange(replacements, true)
+                .Build();
+
+            Assert.Equal(3, body.InteractionsCount);
+            Assert.Equal(new[] { 0, 1, 2 }, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLastRange_TupleOverload_RespectsPerItemNewness [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLastRange_TupleOverload_RespectsPerItemNewness [Core]")]
+#endif
+        public void ReplaceLastRange_TupleOverload_RespectsPerItemNewness()
+        {
+            var replacements = new List<(IAIInteraction, bool)>
+            {
+                (new AIInteractionText { Agent = AIAgent.Assistant, Content = "y" }, true),
+                (new AIInteractionText { Agent = AIAgent.Assistant, Content = "z" }, false),
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("a")
+                .AddAssistant("b")
+                .AddSystem("c")
+                .ReplaceLastRange(replacements)
+                .Build();
+
+            Assert.Equal(3, body.InteractionsCount);
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(1, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ReplaceLastRange_EmptyList_DoesNothing [Windows]")]
+#else
+        [Fact(DisplayName = "ReplaceLastRange_EmptyList_DoesNothing [Core]")]
+#endif
+        public void ReplaceLastRange_EmptyList_DoesNothing()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("u")
+                .ReplaceLastRange(new List<IAIInteraction>())
+                .Build();
+
+            Assert.Single(body.Interactions);
+            Assert.Equal("u", ((AIInteractionText)body.Interactions[0]).Content);
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(0, body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Build_ClampsAndDeduplicatesNewMarkers [Windows]")]
+#else
+        [Fact(DisplayName = "Build_ClampsAndDeduplicatesNewMarkers [Core]")]
+#endif
+        public void Build_ClampsAndDeduplicatesNewMarkers()
+        {
+            var body = AIBodyBuilder.Create()
+                .AsHistory()
+                .AddUser("u")
+                .MarkLastAsNew()
+                .MarkLastAsNew()
+                .MarkIndicesAsNew(new[] { 0, 0, 99 })
+                .Build();
+
+            Assert.Single(body.InteractionsNew);
+            Assert.Contains(0, body.InteractionsNew);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyTests.cs
@@ -1,0 +1,135 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Interactions
+{
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Tests.TestHelpers;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIBody"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIBodyTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Metrics_CombinesInteractions [Windows]")]
+#else
+        [Fact(DisplayName = "Metrics_CombinesInteractions [Core]")]
+#endif
+        public void Metrics_CombinesInteractions()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+
+            var first = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            var second = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 50,
+                OutputTokensGeneration = 25,
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "first", first)
+                .AddText(AIAgent.Assistant, "second", second)
+                .Build();
+
+            var metrics = body.Metrics;
+
+            Assert.Equal(150, metrics.InputTokensPrompt);
+            Assert.Equal(75, metrics.OutputTokensGeneration);
+            Assert.Equal(225, metrics.TotalTokens);
+            Assert.Equal("openai", metrics.Provider);
+            Assert.Equal("gpt-test", metrics.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Metrics_CombinesEstimatedCost [Windows]")]
+#else
+        [Fact(DisplayName = "Metrics_CombinesEstimatedCost [Core]")]
+#endif
+        public void Metrics_CombinesEstimatedCost()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            AIModelCapabilityRegistry.Instance.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                Pricing = new AIModelPricing { Prompt = 0.000001m, Completion = 0.000004m },
+            });
+
+            var first = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            var second = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 50,
+                OutputTokensGeneration = 25,
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "first", first)
+                .AddText(AIAgent.Assistant, "second", second)
+                .Build();
+
+            var expected = (150m * 0.000001m) + (75m * 0.000004m);
+            Assert.Equal(expected, body.Metrics.EstimatedCost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "GetEffectiveTokenCount_UsesMaxOfActualAndEstimated [Windows]")]
+#else
+        [Fact(DisplayName = "GetEffectiveTokenCount_UsesMaxOfActualAndEstimated [Core]")]
+#endif
+        public void GetEffectiveTokenCount_UsesMaxOfActualAndEstimated()
+        {
+            var metrics = new AIMetrics
+            {
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+                EstimatedInputTokens = 500,
+                EstimatedOutputTokens = 100,
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "test", metrics)
+                .Build();
+
+            Assert.Equal(600, body.GetEffectiveTokenCount());
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyValidationTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIBodyValidationTests.cs
@@ -1,0 +1,344 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Interactions
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json.Linq;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIBody"/> validation, messages and metrics aggregation.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIBodyValidationTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Empty_Body_HasExpectedDefaults [Windows]")]
+#else
+        [Fact(DisplayName = "Empty_Body_HasExpectedDefaults [Core]")]
+#endif
+        public void Empty_Body_HasExpectedDefaults()
+        {
+            var body = AIBody.Empty;
+
+            Assert.Equal(0, body.InteractionsCount);
+            Assert.Equal("-*", body.ToolFilter);
+            Assert.Equal("-*", body.ContextFilter);
+            Assert.Null(body.JsonOutputSchema);
+            Assert.False(body.RequiresJsonOutput);
+            Assert.Empty(body.InteractionsNew);
+            Assert.True(body.AreTurnIdsValid());
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "InteractionsCount_ReflectsInteractionCount [Windows]")]
+#else
+        [Fact(DisplayName = "InteractionsCount_ReflectsInteractionCount [Core]")]
+#endif
+        public void InteractionsCount_ReflectsInteractionCount()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("u")
+                .AddAssistant("a")
+                .Build();
+
+            Assert.Equal(2, body.InteractionsCount);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "RequiresJsonOutput_TrueWhenSchemaPresent [Windows]")]
+#else
+        [Fact(DisplayName = "RequiresJsonOutput_TrueWhenSchemaPresent [Core]")]
+#endif
+        public void RequiresJsonOutput_TrueWhenSchemaPresent()
+        {
+            var withSchema = AIBodyBuilder.Create()
+                .WithJsonOutputSchema("{\"type\":\"object\"}")
+                .Build();
+
+            Assert.True(withSchema.RequiresJsonOutput);
+
+            var withoutSchema = AIBodyBuilder.Create().Build();
+            Assert.False(withoutSchema.RequiresJsonOutput);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AreTurnIdsValid_True_WhenAllHaveTurnId [Windows]")]
+#else
+        [Fact(DisplayName = "AreTurnIdsValid_True_WhenAllHaveTurnId [Core]")]
+#endif
+        public void AreTurnIdsValid_True_WhenAllHaveTurnId()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("u")
+                .AddAssistant("a")
+                .Build();
+
+            Assert.True(body.AreTurnIdsValid());
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AreTurnIdsValid_False_WhenMissingTurnId [Windows]")]
+#else
+        [Fact(DisplayName = "AreTurnIdsValid_False_WhenMissingTurnId [Core]")]
+#endif
+        public void AreTurnIdsValid_False_WhenMissingTurnId()
+        {
+            var text = new AIInteractionText
+            {
+                Agent = AIAgent.User,
+                Content = "u",
+                TurnId = null!,
+            };
+
+            var body = new AIBody(
+                new List<IAIInteraction> { text },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            Assert.False(body.AreTurnIdsValid());
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ResetNew_ClearsNewMarkers [Windows]")]
+#else
+        [Fact(DisplayName = "ResetNew_ClearsNewMarkers [Core]")]
+#endif
+        public void ResetNew_ClearsNewMarkers()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("u")
+                .Build();
+
+            Assert.Single(body.InteractionsNew);
+
+            body.ResetNew();
+
+            Assert.Empty(body.InteractionsNew);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_AggregatesFromToolResultImageAndRuntimeMessage [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_AggregatesFromToolResultImageAndRuntimeMessage [Core]")]
+#endif
+        public void Messages_AggregatesFromToolResultImageAndRuntimeMessage()
+        {
+            var toolResult = new AIInteractionToolResult
+            {
+                Id = "call-1",
+                Name = "test_tool",
+                Result = new JObject(new JProperty("ok", true)),
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Provider, SHMessageCode.Unknown, "tool message"),
+                },
+            };
+
+            var image = new AIInteractionImage
+            {
+                Agent = AIAgent.User,
+                OriginalPrompt = "a red cube",
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Provider, SHMessageCode.Unknown, "image message"),
+                },
+            };
+
+            var runtime = new AIInteractionRuntimeMessage
+            {
+                Severity = SHRuntimeMessageSeverity.Info,
+                Content = "runtime message",
+            };
+
+            var body = new AIBody(
+                new List<IAIInteraction> { toolResult, image, runtime },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            var messages = body.Messages;
+
+            Assert.Equal(3, messages.Count);
+            Assert.Contains(messages, m => m.Message == "tool message");
+            Assert.Contains(messages, m => m.Message == "image message");
+            Assert.Contains(messages, m => m.Message == "runtime message");
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_DeduplicatesByMessageText [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_DeduplicatesByMessageText [Core]")]
+#endif
+        public void Messages_DeduplicatesByMessageText()
+        {
+            var toolResult = new AIInteractionToolResult
+            {
+                Result = new JObject(),
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Provider, SHMessageCode.Unknown, "duplicate"),
+                },
+            };
+
+            var image = new AIInteractionImage
+            {
+                Agent = AIAgent.User,
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Provider, SHMessageCode.Unknown, "duplicate"),
+                },
+            };
+
+            var runtime = new AIInteractionRuntimeMessage
+            {
+                Severity = SHRuntimeMessageSeverity.Info,
+                Content = "duplicate",
+            };
+
+            var body = new AIBody(
+                new List<IAIInteraction> { toolResult, image, runtime },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            var messages = body.Messages;
+
+            Assert.Single(messages);
+            Assert.Equal("duplicate", messages[0].Message);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Metrics_AggregatesAcrossInteractions [Windows]")]
+#else
+        [Fact(DisplayName = "Metrics_AggregatesAcrossInteractions [Core]")]
+#endif
+        public void Metrics_AggregatesAcrossInteractions()
+        {
+            var toolResult = new AIInteractionToolResult
+            {
+                Result = new JObject(),
+                Metrics = new AIMetrics
+                {
+                    Provider = "openai",
+                    Model = "gpt-test",
+                    InputTokensPrompt = 10,
+                    OutputTokensGeneration = 5,
+                },
+            };
+
+            var image = new AIInteractionImage
+            {
+                Agent = AIAgent.User,
+                Metrics = new AIMetrics
+                {
+                    InputTokensPrompt = 5,
+                    OutputTokensReasoning = 2,
+                },
+            };
+
+            var text = new AIInteractionText
+            {
+                Agent = AIAgent.User,
+                Content = "u",
+                Metrics = new AIMetrics
+                {
+                    InputTokensCached = 3,
+                },
+            };
+
+            var body = new AIBody(
+                new List<IAIInteraction> { toolResult, image, text },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            Assert.Equal(15, body.Metrics.InputTokensPrompt);
+            Assert.Equal(3, body.Metrics.InputTokensCached);
+            Assert.Equal(18, body.Metrics.InputTokens);
+            Assert.Equal(5, body.Metrics.OutputTokensGeneration);
+            Assert.Equal(2, body.Metrics.OutputTokensReasoning);
+            Assert.Equal(7, body.Metrics.OutputTokens);
+            Assert.Equal(25, body.Metrics.TotalTokens);
+            Assert.Equal("openai", body.Metrics.Provider);
+            Assert.Equal("gpt-test", body.Metrics.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Metrics_IterationsCount_DefaultsToOne [Windows]")]
+#else
+        [Fact(DisplayName = "Metrics_IterationsCount_DefaultsToOne [Core]")]
+#endif
+        public void Metrics_IterationsCount_DefaultsToOne()
+        {
+            var body = new AIBody(
+                new List<IAIInteraction>
+                {
+                    new AIInteractionText { Agent = AIAgent.User, Content = "u" },
+                    new AIInteractionText { Agent = AIAgent.Assistant, Content = "a" },
+                },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            Assert.Equal(1, body.Metrics.IterationsCount);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Metrics_IterationsCount_AggregatesExplicitValues [Windows]")]
+#else
+        [Fact(DisplayName = "Metrics_IterationsCount_AggregatesExplicitValues [Core]")]
+#endif
+        public void Metrics_IterationsCount_AggregatesExplicitValues()
+        {
+            var first = new AIInteractionText
+            {
+                Agent = AIAgent.User,
+                Content = "u",
+                Metrics = new AIMetrics { IterationsCount = 2 },
+            };
+
+            var second = new AIInteractionText
+            {
+                Agent = AIAgent.Assistant,
+                Content = "a",
+                Metrics = new AIMetrics { IterationsCount = 3 },
+            };
+
+            var body = new AIBody(
+                new List<IAIInteraction> { first, second },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            Assert.Equal(5, body.Metrics.IterationsCount);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIInteractionTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Interactions/AIInteractionTests.cs
@@ -1,0 +1,845 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Interactions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Newtonsoft.Json.Linq;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.AICall.Utilities;
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the <see cref="AIInteractionText"/>, <see cref="AIInteractionToolCall"/>,
+    /// <see cref="AIInteractionToolResult"/>, <see cref="AIInteractionImage"/>,
+    /// <see cref="AIInteractionRuntimeMessage"/> and <see cref="AIInteractionAudio"/> interactions.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIInteractionTests
+    {
+#if NET7_WINDOWS
+        private const string PlatformSuffix = " [Windows]";
+#else
+        private const string PlatformSuffix = " [Core]";
+#endif
+
+        #region AIInteractionText
+
+        [Fact(DisplayName = nameof(Text_SetResult) + PlatformSuffix)]
+        public void Text_SetResult()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "content", "reasoning");
+
+            Assert.Equal(AIAgent.Assistant, interaction.Agent);
+            Assert.Equal("content", interaction.Content);
+            Assert.Equal("reasoning", interaction.Reasoning);
+        }
+
+        [Fact(DisplayName = nameof(Text_AppendDeltaCombinesContentReasoningAndMetrics) + PlatformSuffix)]
+        public void Text_AppendDeltaCombinesContentReasoningAndMetrics()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "Hello", "think");
+
+            var metrics = new AIMetrics
+            {
+                InputTokensPrompt = 10,
+                OutputTokensGeneration = 5,
+            };
+
+            interaction.AppendDelta(
+                contentDelta: " world",
+                reasoningDelta: " more",
+                metricsDelta: metrics);
+
+            Assert.Equal("Hello world", interaction.Content);
+            Assert.Equal("think more", interaction.Reasoning);
+            Assert.Equal(10, interaction.Metrics.InputTokensPrompt);
+            Assert.Equal(5, interaction.Metrics.OutputTokensGeneration);
+            Assert.Equal(15, interaction.Metrics.TotalTokens);
+        }
+
+        [Fact(DisplayName = nameof(Text_ToStringWithoutReasoning) + PlatformSuffix)]
+        public void Text_ToStringWithoutReasoning()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "only content");
+
+            Assert.Equal("only content", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(Text_ToStringWithReasoning) + PlatformSuffix)]
+        public void Text_ToStringWithReasoning()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "answer", "thinking");
+
+            var result = interaction.ToString();
+
+            Assert.Contains("<think>", result);
+            Assert.Contains("<think>", result);
+            Assert.Contains("thinking", result);
+            Assert.Contains("answer", result);
+        }
+
+        [Fact(DisplayName = nameof(Text_GetStreamKeyWithoutTurnId) + PlatformSuffix)]
+        public void Text_GetStreamKeyWithoutTurnId()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "content");
+
+            Assert.Equal("text:assistant", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetStreamKeyWithTurnId) + PlatformSuffix)]
+        public void Text_GetStreamKeyWithTurnId()
+        {
+            var interaction = new AIInteractionText
+            {
+                TurnId = "turn-1",
+            };
+            interaction.SetResult(AIAgent.User, "content");
+
+            Assert.Equal("turn:turn-1:user", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetDedupKey) + PlatformSuffix)]
+        public void Text_GetDedupKey()
+        {
+            var interaction = new AIInteractionText
+            {
+                TurnId = "turn-1",
+            };
+            interaction.SetResult(AIAgent.Assistant, "content");
+
+            var hash = HashUtility.ComputeShortHash("turn-1:assistant:content");
+            var expected = $"turn:turn-1:assistant:{hash}";
+
+            Assert.Equal(expected, interaction.GetDedupKey());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetRoleClassForRender) + PlatformSuffix)]
+        public void Text_GetRoleClassForRender()
+        {
+            var assistant = new AIInteractionText();
+            assistant.SetResult(AIAgent.Assistant, "a");
+
+            var user = new AIInteractionText();
+            user.SetResult(AIAgent.User, "b");
+
+            Assert.Equal("assistant", assistant.GetRoleClassForRender());
+            Assert.Equal("user", user.GetRoleClassForRender());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetDisplayNameForRender) + PlatformSuffix)]
+        public void Text_GetDisplayNameForRender()
+        {
+            var assistant = new AIInteractionText();
+            assistant.SetResult(AIAgent.Assistant, "a");
+
+            Assert.Equal("Assistant", assistant.GetDisplayNameForRender());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetRawContentForRender) + PlatformSuffix)]
+        public void Text_GetRawContentForRender()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "content");
+
+            Assert.Equal("content", interaction.GetRawContentForRender());
+        }
+
+        [Fact(DisplayName = nameof(Text_GetRawReasoningForRender) + PlatformSuffix)]
+        public void Text_GetRawReasoningForRender()
+        {
+            var interaction = new AIInteractionText();
+            interaction.SetResult(AIAgent.Assistant, "content", "reasoning");
+
+            Assert.Equal("reasoning", interaction.GetRawReasoningForRender());
+
+            var emptyReasoning = new AIInteractionText();
+            Assert.Equal(string.Empty, emptyReasoning.GetRawReasoningForRender());
+        }
+
+        #endregion
+
+        #region AIInteractionToolCall
+
+        [Fact(DisplayName = nameof(ToolCall_ToStringWithoutIdNameAndArguments) + PlatformSuffix)]
+        public void ToolCall_ToStringWithoutIdNameAndArguments()
+        {
+            var interaction = new AIInteractionToolCall();
+
+            Assert.Equal("Calling tool", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_ToStringWithId) + PlatformSuffix)]
+        public void ToolCall_ToStringWithId()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Id = "tc_1",
+            };
+
+            Assert.Equal("Calling tool (tc_1)", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_ToStringWithName) + PlatformSuffix)]
+        public void ToolCall_ToStringWithName()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Name = "my_tool",
+            };
+
+            Assert.Equal("Calling tool my_tool", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_ToStringWithArguments) + PlatformSuffix)]
+        public void ToolCall_ToStringWithArguments()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Id = "tc_1",
+                Name = "my_tool",
+                Arguments = new JObject { ["x"] = 1 },
+            };
+
+            var result = interaction.ToString();
+
+            Assert.Contains("Calling tool (tc_1) my_tool", result);
+            Assert.Contains("with the following arguments:", result);
+            Assert.Contains("\"x\": 1", result);
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetStreamKeyWithoutTurnId) + PlatformSuffix)]
+        public void ToolCall_GetStreamKeyWithoutTurnId()
+        {
+            var byId = new AIInteractionToolCall { Id = "tc_1" };
+            var byName = new AIInteractionToolCall { Name = "my_tool" };
+            var empty = new AIInteractionToolCall();
+
+            Assert.Equal("tool.call:tc_1", byId.GetStreamKey());
+            Assert.Equal("tool.call:my_tool", byName.GetStreamKey());
+            Assert.Equal("tool.call:", empty.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetStreamKeyWithTurnId) + PlatformSuffix)]
+        public void ToolCall_GetStreamKeyWithTurnId()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                TurnId = "turn-1",
+                Id = "tc_1",
+            };
+
+            Assert.Equal("turn:turn-1:tool.call:tc_1", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetDedupKey) + PlatformSuffix)]
+        public void ToolCall_GetDedupKey()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                TurnId = "turn-1",
+                Id = "tc_1",
+                Arguments = new JObject { ["x"] = 1 },
+            };
+
+            var argsHash = HashUtility.ComputeShortHash(interaction.Arguments.ToString(Newtonsoft.Json.Formatting.None));
+            var expected = $"turn:turn-1:tool.call:tc_1:{argsHash}";
+
+            Assert.Equal(expected, interaction.GetDedupKey());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetDedupKeyWithNoArguments) + PlatformSuffix)]
+        public void ToolCall_GetDedupKeyWithNoArguments()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Id = "tc_1",
+            };
+
+            Assert.Equal("tool.call:tc_1:none", interaction.GetDedupKey());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetRoleClassForRender) + PlatformSuffix)]
+        public void ToolCall_GetRoleClassForRender()
+        {
+            var interaction = new AIInteractionToolCall();
+
+            Assert.Equal("tool", interaction.GetRoleClassForRender());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetDisplayNameForRender) + PlatformSuffix)]
+        public void ToolCall_GetDisplayNameForRender()
+        {
+            var unnamed = new AIInteractionToolCall();
+            var named = new AIInteractionToolCall { Name = "my_tool" };
+
+            Assert.Equal("Tool Call", unnamed.GetDisplayNameForRender());
+            Assert.Equal("Tool Call: my_tool", named.GetDisplayNameForRender());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetRawContentForRender) + PlatformSuffix)]
+        public void ToolCall_GetRawContentForRender()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Arguments = new JObject { ["x"] = 1 },
+            };
+
+            var result = interaction.GetRawContentForRender();
+
+            Assert.Contains("\"x\": 1", result);
+
+            var empty = new AIInteractionToolCall();
+
+            Assert.Equal(string.Empty, empty.GetRawContentForRender());
+        }
+
+        [Fact(DisplayName = nameof(ToolCall_GetRawReasoningForRender) + PlatformSuffix)]
+        public void ToolCall_GetRawReasoningForRender()
+        {
+            var interaction = new AIInteractionToolCall
+            {
+                Reasoning = "some thought",
+            };
+
+            Assert.Equal("some thought", interaction.GetRawReasoningForRender());
+
+            var emptyReasoning = new AIInteractionToolCall();
+            Assert.Equal(string.Empty, emptyReasoning.GetRawReasoningForRender());
+        }
+
+        #endregion
+
+        #region AIInteractionToolResult
+
+        [Fact(DisplayName = nameof(ToolResult_ToString) + PlatformSuffix)]
+        public void ToolResult_ToString()
+        {
+            var interaction = new AIInteractionToolResult
+            {
+                Name = "my_tool",
+                Result = new JObject { ["ok"] = true },
+            };
+
+            var result = interaction.ToString();
+
+            Assert.Contains("Tool result from my_tool", result);
+            Assert.Contains("\"ok\": true", result);
+        }
+
+        [Fact(DisplayName = nameof(ToolResult_GetStreamKey) + PlatformSuffix)]
+        public void ToolResult_GetStreamKey()
+        {
+            var withoutTurn = new AIInteractionToolResult
+            {
+                Id = "tr_1",
+            };
+
+            var withTurn = new AIInteractionToolResult
+            {
+                TurnId = "turn-1",
+                Name = "my_tool",
+            };
+
+            Assert.Equal("tool.result:tr_1", withoutTurn.GetStreamKey());
+            Assert.Equal("turn:turn-1:tool.result:my_tool", withTurn.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(ToolResult_GetDedupKey) + PlatformSuffix)]
+        public void ToolResult_GetDedupKey()
+        {
+            var interaction = new AIInteractionToolResult
+            {
+                Id = "tr_1",
+                Result = new JObject { ["ok"] = true },
+            };
+
+            var key = interaction.GetDedupKey();
+
+            Assert.StartsWith("tool.result:tr_1:", key);
+            Assert.Equal("tool.result:tr_1:".Length + 16, key.Length);
+        }
+
+        [Fact(DisplayName = nameof(ToolResult_MessagesPropagation) + PlatformSuffix)]
+        public void ToolResult_MessagesPropagation()
+        {
+            var messages = new List<SHRuntimeMessage>
+            {
+                new SHRuntimeMessage(
+                    SHRuntimeMessageSeverity.Warning,
+                    SHRuntimeMessageOrigin.Tool,
+                    SHMessageCode.ToolExecutionError,
+                    "warning message"),
+            };
+
+            var interaction = new AIInteractionToolResult
+            {
+                Messages = messages,
+            };
+
+            Assert.Single(interaction.Messages);
+            Assert.Equal("warning message", interaction.Messages[0].Message);
+        }
+
+        #endregion
+
+        #region AIInteractionImage
+
+        [Fact(DisplayName = nameof(Image_CreateVisionInputWithValidUrl) + PlatformSuffix)]
+        public void Image_CreateVisionInputWithValidUrl()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.CreateVisionInput("https://example.com/image.png");
+
+            Assert.Equal("https://example.com/image.png", interaction.ImageUrl.ToString());
+            Assert.Contains("[vision input]", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(Image_CreateVisionInputWithInvalidUrlThrows) + PlatformSuffix)]
+        public void Image_CreateVisionInputWithInvalidUrlThrows()
+        {
+            var interaction = new AIInteractionImage();
+
+            Assert.Throws<ArgumentException>(() => interaction.CreateVisionInput("not a valid url"));
+        }
+
+        [Fact(DisplayName = nameof(Image_CreateVisionInputWithNullOrEmptyThrows) + PlatformSuffix)]
+        public void Image_CreateVisionInputWithNullOrEmptyThrows()
+        {
+            var interaction = new AIInteractionImage();
+
+            Assert.Throws<ArgumentException>(() => interaction.CreateVisionInput(string.Empty));
+            Assert.Throws<ArgumentException>(() => interaction.CreateVisionInput("   "));
+        }
+
+        [Fact(DisplayName = nameof(Image_CreateVisionInputFromBase64) + PlatformSuffix)]
+        public void Image_CreateVisionInputFromBase64()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.CreateVisionInputFromBase64("base64data");
+
+            Assert.Equal("base64data", interaction.ImageData);
+            Assert.Equal("image/png", interaction.MimeType);
+
+            var withMime = new AIInteractionImage();
+            withMime.CreateVisionInputFromBase64("base64data", "image/jpeg");
+
+            Assert.Equal("image/jpeg", withMime.MimeType);
+        }
+
+        [Fact(DisplayName = nameof(Image_CreateRequestSetsProperties) + PlatformSuffix)]
+        public void Image_CreateRequestSetsProperties()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.CreateRequest(
+                prompt: "a red apple",
+                size: "512x512",
+                quality: "hd",
+                style: "natural",
+                aspectRatio: "16:9");
+
+            Assert.Equal("a red apple", interaction.OriginalPrompt);
+            Assert.Equal("512x512", interaction.ImageSize);
+            Assert.Equal("hd", interaction.ImageQuality);
+            Assert.Equal("natural", interaction.ImageStyle);
+            Assert.Equal("16:9", interaction.AspectRatio);
+        }
+
+        [Fact(DisplayName = nameof(Image_SetResultWithValidUrl) + PlatformSuffix)]
+        public void Image_SetResultWithValidUrl()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.SetResult("https://example.com/image.png");
+
+            Assert.Equal("https://example.com/image.png", interaction.ImageUrl.ToString());
+        }
+
+        [Fact(DisplayName = nameof(Image_SetResultInvalidUrlWithoutImageDataThrows) + PlatformSuffix)]
+        public void Image_SetResultInvalidUrlWithoutImageDataThrows()
+        {
+            var interaction = new AIInteractionImage();
+
+            Assert.Throws<ArgumentException>(() => interaction.SetResult("not a valid url"));
+        }
+
+        [Fact(DisplayName = nameof(Image_SetResultInvalidUrlWithImageDataSucceeds) + PlatformSuffix)]
+        public void Image_SetResultInvalidUrlWithImageDataSucceeds()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.CreateRequest("a cat");
+            interaction.SetResult("not a valid url", "base64data");
+
+            Assert.Null(interaction.ImageUrl);
+            Assert.Equal("base64data", interaction.ImageData);
+            Assert.Contains("generated from 'a cat'", interaction.ToString());
+            Assert.Contains("data:image/png;base64,base64data", interaction.GetRawContentForRender());
+        }
+
+        [Fact(DisplayName = nameof(Image_ToStringForVisionInput) + PlatformSuffix)]
+        public void Image_ToStringForVisionInput()
+        {
+            var interaction = new AIInteractionImage();
+            interaction.CreateVisionInput("https://example.com/image.png");
+
+            Assert.Equal("AIInteractionImage (1024x1024) [vision input]", interaction.ToString());
+        }
+
+        [Fact(DisplayName = nameof(Image_ToStringForGeneratedImage) + PlatformSuffix)]
+        public void Image_ToStringForGeneratedImage()
+        {
+            var shortPrompt = new AIInteractionImage();
+            shortPrompt.CreateRequest("a cat");
+
+            Assert.Equal("AIInteractionImage (1024x1024) generated from 'a cat'", shortPrompt.ToString());
+
+            var longPrompt = new AIInteractionImage();
+            longPrompt.CreateRequest("a very long prompt that should be truncated in the output");
+
+            Assert.Contains("generated from '", longPrompt.ToString());
+            Assert.Contains("...", longPrompt.ToString());
+        }
+
+        [Fact(DisplayName = nameof(Image_GetRoleClassForRender) + PlatformSuffix)]
+        public void Image_GetRoleClassForRender()
+        {
+            var defaultImage = new AIInteractionImage();
+            var userImage = new AIInteractionImage { Agent = AIAgent.User };
+
+            Assert.Equal("assistant", defaultImage.GetRoleClassForRender());
+            Assert.Equal("user", userImage.GetRoleClassForRender());
+        }
+
+        [Fact(DisplayName = nameof(Image_GetDisplayNameForRender) + PlatformSuffix)]
+        public void Image_GetDisplayNameForRender()
+        {
+            var defaultImage = new AIInteractionImage();
+            var userImage = new AIInteractionImage { Agent = AIAgent.User };
+
+            Assert.Equal("Assistant", defaultImage.GetDisplayNameForRender());
+            Assert.Equal("User", userImage.GetDisplayNameForRender());
+        }
+
+        [Fact(DisplayName = nameof(Image_GetRawContentForRender) + PlatformSuffix)]
+        public void Image_GetRawContentForRender()
+        {
+            var withUrl = new AIInteractionImage();
+            withUrl.SetResult("https://example.com/image.png");
+
+            Assert.Equal("![generated image](https://example.com/image.png)", withUrl.GetRawContentForRender());
+
+            var withData = new AIInteractionImage();
+            withData.CreateVisionInputFromBase64("data");
+
+            Assert.Equal("![generated image](data:image/png;base64,data)", withData.GetRawContentForRender());
+
+            var neither = new AIInteractionImage();
+            neither.CreateRequest("a cat");
+
+            Assert.Contains("generated from 'a cat'", neither.GetRawContentForRender());
+        }
+
+        #endregion
+
+        #region AIInteractionRuntimeMessage
+
+        [Fact(DisplayName = nameof(RuntimeMessage_CreateDebugIsNonSurfaceable) + PlatformSuffix)]
+        public void RuntimeMessage_CreateDebugIsNonSurfaceable()
+        {
+            var interaction = AIInteractionRuntimeMessage.CreateDebug("debug content");
+
+            Assert.Equal(SHRuntimeMessageSeverity.Debug, interaction.Severity);
+            Assert.False(interaction.Surfaceable);
+            Assert.Equal("debug content", interaction.Content);
+            Assert.Equal(AIAgent.Debug, interaction.Agent);
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_FromRuntimeMessageNullReturnsNull) + PlatformSuffix)]
+        public void RuntimeMessage_FromRuntimeMessageNullReturnsNull()
+        {
+            Assert.Null(AIInteractionRuntimeMessage.FromRuntimeMessage(null!));
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_FromRuntimeMessageRoundTrip) + PlatformSuffix)]
+        public void RuntimeMessage_FromRuntimeMessageRoundTrip()
+        {
+            var message = new SHRuntimeMessage(
+                SHRuntimeMessageSeverity.Warning,
+                SHRuntimeMessageOrigin.Provider,
+                SHMessageCode.NetworkTimeout,
+                "timeout",
+                false);
+
+            var interaction = AIInteractionRuntimeMessage.FromRuntimeMessage(message);
+
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, interaction.Severity);
+            Assert.Equal(SHRuntimeMessageOrigin.Provider, interaction.Origin);
+            Assert.Equal(SHMessageCode.NetworkTimeout, interaction.Code);
+            Assert.Equal("timeout", interaction.Content);
+            Assert.False(interaction.Surfaceable);
+            Assert.Equal(AIAgent.Warning, interaction.Agent);
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_AgentDerivedFromSeverity) + PlatformSuffix)]
+        public void RuntimeMessage_AgentDerivedFromSeverity()
+        {
+            var error = new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Error };
+            var warning = new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Warning };
+            var info = new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Info };
+            var debug = new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Debug };
+
+            Assert.Equal(AIAgent.Error, error.Agent);
+            Assert.Equal(AIAgent.Warning, warning.Agent);
+            Assert.Equal(AIAgent.Info, info.Agent);
+            Assert.Equal(AIAgent.Debug, debug.Agent);
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_ToRuntimeMessage) + PlatformSuffix)]
+        public void RuntimeMessage_ToRuntimeMessage()
+        {
+            var interaction = new AIInteractionRuntimeMessage
+            {
+                Severity = SHRuntimeMessageSeverity.Error,
+                Origin = SHRuntimeMessageOrigin.Tool,
+                Code = SHMessageCode.ToolExecutionError,
+                Content = "error content",
+                Surfaceable = false,
+            };
+
+            var message = interaction.ToRuntimeMessage();
+
+            Assert.Equal(SHRuntimeMessageSeverity.Error, message.Severity);
+            Assert.Equal(SHRuntimeMessageOrigin.Tool, message.Origin);
+            Assert.Equal(SHMessageCode.ToolExecutionError, message.Code);
+            Assert.Equal("error content", message.Message);
+            Assert.False(message.Surfaceable);
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetRoleClassForRender) + PlatformSuffix)]
+        public void RuntimeMessage_GetRoleClassForRender()
+        {
+            Assert.Equal("error", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Error }.GetRoleClassForRender());
+            Assert.Equal("warning", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Warning }.GetRoleClassForRender());
+            Assert.Equal("info", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Info }.GetRoleClassForRender());
+            Assert.Equal("debug", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Debug }.GetRoleClassForRender());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetDisplayNameForRender) + PlatformSuffix)]
+        public void RuntimeMessage_GetDisplayNameForRender()
+        {
+            Assert.Equal("Error", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Error }.GetDisplayNameForRender());
+            Assert.Equal("Warning", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Warning }.GetDisplayNameForRender());
+            Assert.Equal("Info", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Info }.GetDisplayNameForRender());
+            Assert.Equal("Debug", new AIInteractionRuntimeMessage { Severity = SHRuntimeMessageSeverity.Debug }.GetDisplayNameForRender());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetRawContentForRender) + PlatformSuffix)]
+        public void RuntimeMessage_GetRawContentForRender()
+        {
+            var interaction = new AIInteractionRuntimeMessage { Content = "content" };
+
+            Assert.Equal("content", interaction.GetRawContentForRender());
+
+            var emptyContent = new AIInteractionRuntimeMessage();
+            Assert.Equal(string.Empty, emptyContent.GetRawContentForRender());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetRawReasoningForRender) + PlatformSuffix)]
+        public void RuntimeMessage_GetRawReasoningForRender()
+        {
+            var interaction = new AIInteractionRuntimeMessage();
+
+            Assert.Equal(string.Empty, interaction.GetRawReasoningForRender());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetStreamKeyWithoutTurnId) + PlatformSuffix)]
+        public void RuntimeMessage_GetStreamKeyWithoutTurnId()
+        {
+            var interaction = new AIInteractionRuntimeMessage
+            {
+                Severity = SHRuntimeMessageSeverity.Info,
+                Content = "info message",
+            };
+
+            var hash = HashUtility.ComputeShortHash("info message");
+
+            Assert.Equal($"info:{hash}", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetStreamKeyWithTurnId) + PlatformSuffix)]
+        public void RuntimeMessage_GetStreamKeyWithTurnId()
+        {
+            var interaction = new AIInteractionRuntimeMessage
+            {
+                TurnId = "turn-1",
+                Severity = SHRuntimeMessageSeverity.Warning,
+                Content = "warning message",
+            };
+
+            var hash = HashUtility.ComputeShortHash("warning message");
+
+            Assert.Equal($"turn:turn-1:warning:{hash}", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(RuntimeMessage_GetDedupKey) + PlatformSuffix)]
+        public void RuntimeMessage_GetDedupKey()
+        {
+            var interaction = new AIInteractionRuntimeMessage
+            {
+                Severity = SHRuntimeMessageSeverity.Info,
+                Content = "info message",
+            };
+
+            Assert.Equal(interaction.GetStreamKey(), interaction.GetDedupKey());
+        }
+
+        #endregion
+
+        #region AIInteractionAudio
+
+        [Fact(DisplayName = nameof(Audio_GetAudioSizeWithData) + PlatformSuffix)]
+        public void Audio_GetAudioSizeWithData()
+        {
+            var interaction = new AIInteractionAudio
+            {
+                Data = new byte[] { 1, 2, 3 },
+            };
+
+            Assert.Equal(3, interaction.GetAudioSize());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetAudioSizeWithMissingFile) + PlatformSuffix)]
+        public void Audio_GetAudioSizeWithMissingFile()
+        {
+            var interaction = new AIInteractionAudio
+            {
+                FilePath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid()}.wav"),
+            };
+
+            Assert.Equal(0, interaction.GetAudioSize());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetAudioSizeWithNoData) + PlatformSuffix)]
+        public void Audio_GetAudioSizeWithNoData()
+        {
+            var interaction = new AIInteractionAudio();
+
+            Assert.Equal(0, interaction.GetAudioSize());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetStreamKeyForData) + PlatformSuffix)]
+        public void Audio_GetStreamKeyForData()
+        {
+            var data = new byte[] { 1, 2, 3 };
+            var interaction = new AIInteractionAudio
+            {
+                Data = data,
+            };
+
+            var hash = HashUtility.ComputeShortHash(Convert.ToBase64String(data));
+
+            Assert.Equal($"audio:{hash}", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetStreamKeyForFile) + PlatformSuffix)]
+        public void Audio_GetStreamKeyForFile()
+        {
+            var interaction = new AIInteractionAudio
+            {
+                FilePath = @"C:\audio.wav",
+            };
+
+            Assert.Equal("audio:C:\\audio.wav", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetStreamKeyForEmpty) + PlatformSuffix)]
+        public void Audio_GetStreamKeyForEmpty()
+        {
+            var interaction = new AIInteractionAudio();
+
+            Assert.Equal("audio:empty", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetStreamKeyWithTurnId) + PlatformSuffix)]
+        public void Audio_GetStreamKeyWithTurnId()
+        {
+            var interaction = new AIInteractionAudio
+            {
+                TurnId = "turn-1",
+                FilePath = @"C:\audio.wav",
+            };
+
+            Assert.Equal("turn:turn-1:audio:C:\\audio.wav", interaction.GetStreamKey());
+        }
+
+        [Fact(DisplayName = nameof(Audio_GetDedupKey) + PlatformSuffix)]
+        public void Audio_GetDedupKey()
+        {
+            var interaction = new AIInteractionAudio
+            {
+                FilePath = @"C:\audio.wav",
+                MimeType = "audio/wav",
+            };
+
+            Assert.Equal("audio:C:\\audio.wav:audio/wav", interaction.GetDedupKey());
+
+            var unknownMime = new AIInteractionAudio
+            {
+                FilePath = @"C:\audio.wav",
+            };
+
+            Assert.Equal("audio:C:\\audio.wav:unknown", unknownMime.GetDedupKey());
+        }
+
+        [Fact(DisplayName = nameof(Audio_ToString) + PlatformSuffix)]
+        public void Audio_ToString()
+        {
+            var inMemory = new AIInteractionAudio
+            {
+                Data = new byte[] { 1, 2, 3 },
+                MimeType = "audio/wav",
+                LanguageHint = "en",
+            };
+
+            Assert.Equal("Audio(audio/wav, in-memory (3 bytes)) [en]", inMemory.ToString());
+
+            var fromFile = new AIInteractionAudio
+            {
+                FilePath = @"C:\audio.wav",
+                MimeType = "audio/wav",
+            };
+
+            Assert.Equal("Audio(audio/wav, C:\\audio.wav)", fromFile.ToString());
+
+            var empty = new AIInteractionAudio { MimeType = "audio/wav" };
+
+            Assert.Equal("Audio(audio/wav, unknown)", empty.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Requests/AIRequestBaseTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Requests/AIRequestBaseTests.cs
@@ -1,0 +1,231 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Requests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Core.Requests;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIRequestBase"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIRequestBaseTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Constructor_DefaultValues [Windows]")]
+#else
+        [Fact(DisplayName = "Constructor_DefaultValues [Core]")]
+#endif
+        public void Constructor_DefaultValues()
+        {
+            var request = new AIRequestBase();
+
+            Assert.Equal(AICapability.None, request.Capability);
+            Assert.False(request.WantsStreaming);
+            Assert.Equal(AIRequestKind.Generation, request.RequestKind);
+            Assert.Equal(AIBody.Empty, request.Body);
+            Assert.Equal(string.Empty, request.Model);
+            Assert.Null(request.Provider);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ForceToolCall_ForceToolNameTriggersIt [Windows]")]
+#else
+        [Fact(DisplayName = "ForceToolCall_ForceToolNameTriggersIt [Core]")]
+#endif
+        public void ForceToolCall_ForceToolNameTriggersIt()
+        {
+            var request = new AIRequestBase();
+
+            Assert.False(request.ForceToolCall);
+            Assert.True(string.IsNullOrEmpty(request.ForceToolName));
+
+            request.ForceToolName = "gh_get";
+            Assert.True(request.ForceToolCall);
+
+            request.ForceToolName = string.Empty;
+            Assert.False(request.ForceToolCall);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ForceToolCall_ExplicitSetterWorks [Windows]")]
+#else
+        [Fact(DisplayName = "ForceToolCall_ExplicitSetterWorks [Core]")]
+#endif
+        public void ForceToolCall_ExplicitSetterWorks()
+        {
+            var request = new AIRequestBase();
+
+            request.ForceToolCall = true;
+            Assert.True(request.ForceToolCall);
+
+            request.ForceToolCall = false;
+            Assert.False(request.ForceToolCall);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ForceToolCall_NameTakesPrecedenceOverExplicitFalse [Windows]")]
+#else
+        [Fact(DisplayName = "ForceToolCall_NameTakesPrecedenceOverExplicitFalse [Core]")]
+#endif
+        public void ForceToolCall_NameTakesPrecedenceOverExplicitFalse()
+        {
+            var request = new AIRequestBase();
+
+            request.ForceToolName = "gh_get";
+            request.ForceToolCall = false;
+
+            Assert.True(request.ForceToolCall);
+
+            request.ForceToolName = string.Empty;
+            Assert.False(request.ForceToolCall);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Initialize_SetsProviderModelEndpointBodyCapabilityAndParameters [Windows]")]
+#else
+        [Fact(DisplayName = "Initialize_SetsProviderModelEndpointBodyCapabilityAndParameters [Core]")]
+#endif
+        public void Initialize_SetsProviderModelEndpointBodyCapabilityAndParameters()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("hello")
+                .Build();
+
+            var request = new AIRequestBase();
+            request.Initialize(
+                provider: null!,
+                model: "test-model",
+                body: body,
+                endpoint: "https://test/endpoint",
+                capability: AICapability.None);
+
+            Assert.Null(request.Provider);
+            Assert.Equal("test-model", request.Model);
+            Assert.Equal("https://test/endpoint", request.Endpoint);
+            Assert.Same(body, request.Body);
+            Assert.Equal(AICapability.None, request.Capability);
+            Assert.NotNull(request.Parameters);
+            Assert.Equal("test-model", request.Parameters.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_ValidBodyWithTurnIds [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_ValidBodyWithTurnIds [Core]")]
+#endif
+        public void IsValid_ValidBodyWithTurnIds()
+        {
+            var request = new AIRequestBase();
+            request.Body = AIBodyBuilder.Create()
+                .AddUser("hello")
+                .Build();
+
+            var (isValid, errors) = request.IsValid();
+
+            Assert.True(isValid);
+            Assert.Empty(errors);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_InvalidBodyMissingTurnId [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_InvalidBodyMissingTurnId [Core]")]
+#endif
+        public void IsValid_InvalidBodyMissingTurnId()
+        {
+            var request = new AIRequestBase();
+            request.Body = new AIBody(
+                new List<IAIInteraction>
+                {
+                    new AIInteractionText { Agent = AIAgent.User, Content = "no turn id" },
+                },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            var (isValid, errors) = request.IsValid();
+
+            Assert.False(isValid);
+            Assert.Contains(errors, e => e.Message.Contains("TurnId", StringComparison.Ordinal));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_SortsBySeverity [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_SortsBySeverity [Core]")]
+#endif
+        public void Messages_SortsBySeverity()
+        {
+            var request = new AIRequestBase();
+            request.Body = AIBodyBuilder.Create()
+                .AddUser("hello")
+                .Build();
+            request.Messages = new List<SHRuntimeMessage>
+            {
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Request, SHMessageCode.Unknown, "info"),
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Error, SHRuntimeMessageOrigin.Request, SHMessageCode.Unknown, "error"),
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Request, SHMessageCode.Unknown, "warning"),
+            };
+
+            var messages = request.Messages;
+
+            Assert.Equal(SHRuntimeMessageSeverity.Error, messages[0].Severity);
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, messages[1].Severity);
+            Assert.Equal(SHRuntimeMessageSeverity.Info, messages[2].Severity);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Exec_ThrowsNotImplementedException [Windows]")]
+#else
+        [Fact(DisplayName = "Exec_ThrowsNotImplementedException [Core]")]
+#endif
+        public async Task Exec_ThrowsNotImplementedException()
+        {
+            var request = new AIRequestBase();
+
+            var ex = await Assert.ThrowsAsync<NotImplementedException>(() => request.Exec()).ConfigureAwait(false);
+            Assert.Contains("Exec()", ex.Message, StringComparison.Ordinal);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SkipMetricsValidation_CanBeSet [Windows]")]
+#else
+        [Fact(DisplayName = "SkipMetricsValidation_CanBeSet [Core]")]
+#endif
+        public void SkipMetricsValidation_CanBeSet()
+        {
+            var request = new AIRequestBase();
+
+            Assert.False(request.SkipMetricsValidation);
+
+            request.SkipMetricsValidation = true;
+
+            Assert.True(request.SkipMetricsValidation);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Requests/AIRequestCallTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Requests/AIRequestCallTests.cs
@@ -1,0 +1,159 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Requests
+{
+    using System.Collections.Generic;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Core.Requests;
+    using SmartHopper.ProviderSdk.AIModels;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIRequestCall"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIRequestCallTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Constructor_Defaults [Windows]")]
+#else
+        [Fact(DisplayName = "Constructor_Defaults [Core]")]
+#endif
+        public void Constructor_Defaults()
+        {
+            var request = new AIRequestCall();
+
+            Assert.Equal("POST", request.HttpMethod);
+            Assert.Equal("bearer", request.Authentication);
+            Assert.Equal("application/json", request.ContentType);
+            Assert.Empty(request.Headers);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Headers_AreCaseInsensitive [Windows]")]
+#else
+        [Fact(DisplayName = "Headers_AreCaseInsensitive [Core]")]
+#endif
+        public void Headers_AreCaseInsensitive()
+        {
+            var request = new AIRequestCall();
+
+            request.Headers["x-custom"] = "value";
+
+            Assert.Single(request.Headers);
+            Assert.Equal("value", request.Headers["X-CUSTOM"]);
+            Assert.Equal("value", request.Headers["X-Custom"]);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Capability_InfersJsonOutput [Windows]")]
+#else
+        [Fact(DisplayName = "Capability_InfersJsonOutput [Core]")]
+#endif
+        public void Capability_InfersJsonOutput()
+        {
+            var request = new AIRequestCall();
+            request.Body = AIBodyBuilder.Create()
+                .WithJsonOutputSchema("{ \"type\": \"object\" }")
+                .Build();
+
+            Assert.True(request.Capability.HasFlag(AICapability.Text2Text));
+            Assert.True(request.Capability.HasFlag(AICapability.JsonOutput));
+            Assert.False(request.Capability.HasFlag(AICapability.FunctionCalling));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Capability_InfersFunctionCalling [Windows]")]
+#else
+        [Fact(DisplayName = "Capability_InfersFunctionCalling [Core]")]
+#endif
+        public void Capability_InfersFunctionCalling()
+        {
+            var request = new AIRequestCall();
+            request.Body = AIBodyBuilder.Create()
+                .WithToolFilter("+gh_*")
+                .Build();
+
+            Assert.True(request.Capability.HasFlag(AICapability.Text2Text));
+            Assert.True(request.Capability.HasFlag(AICapability.FunctionCalling));
+            Assert.False(request.Capability.HasFlag(AICapability.JsonOutput));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Capability_InfersBoth [Windows]")]
+#else
+        [Fact(DisplayName = "Capability_InfersBoth [Core]")]
+#endif
+        public void Capability_InfersBoth()
+        {
+            var request = new AIRequestCall();
+            request.Body = AIBodyBuilder.Create()
+                .WithJsonOutputSchema("{ \"type\": \"object\" }")
+                .WithToolFilter("+gh_*")
+                .Build();
+
+            Assert.True(request.Capability.HasFlag(AICapability.Text2Text));
+            Assert.True(request.Capability.HasFlag(AICapability.JsonOutput));
+            Assert.True(request.Capability.HasFlag(AICapability.FunctionCalling));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Initialize_SetsBodyEndpointAndParameters [Windows]")]
+#else
+        [Fact(DisplayName = "Initialize_SetsBodyEndpointAndParameters [Core]")]
+#endif
+        public void Initialize_SetsBodyEndpointAndParameters()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddUser("hello")
+                .Build();
+
+            var request = new AIRequestCall();
+            request.Initialize(
+                provider: null!,
+                model: "test-model",
+                body: body,
+                endpoint: "https://test/endpoint",
+                capability: AICapability.None);
+
+            Assert.Same(body, request.Body);
+            Assert.Equal("https://test/endpoint", request.Endpoint);
+            Assert.NotNull(request.Parameters);
+            Assert.Equal("test-model", request.Parameters.Model);
+            Assert.Equal("test-model", request.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "RequestKind_DefaultsToGenerationAndCanBeSet [Windows]")]
+#else
+        [Fact(DisplayName = "RequestKind_DefaultsToGenerationAndCanBeSet [Core]")]
+#endif
+        public void RequestKind_DefaultsToGenerationAndCanBeSet()
+        {
+            var request = new AIRequestCall();
+
+            Assert.Equal(AIRequestKind.Generation, request.RequestKind);
+
+            request.RequestKind = AIRequestKind.Backoffice;
+
+            Assert.Equal(AIRequestKind.Backoffice, request.RequestKind);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Returns/AIReturnTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Core/Returns/AIReturnTests.cs
@@ -1,0 +1,413 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Core.Returns
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using SmartHopper.ProviderSdk.AICall.Core.Base;
+    using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+    using SmartHopper.ProviderSdk.AICall.Core.Requests;
+    using SmartHopper.ProviderSdk.AICall.Core.Returns;
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIReturn"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIReturnTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Constructor_DefaultValues [Windows]")]
+#else
+        [Fact(DisplayName = "Constructor_DefaultValues [Core]")]
+#endif
+        public void Constructor_DefaultValues()
+        {
+            var ret = new AIReturn();
+
+            Assert.Equal(AICallStatus.Idle, ret.Status);
+            Assert.Equal(AIBody.Empty, ret.Body);
+            Assert.Null(ret.Request);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SetBody_AIBody_AssignsBody [Windows]")]
+#else
+        [Fact(DisplayName = "SetBody_AIBody_AssignsBody [Core]")]
+#endif
+        public void SetBody_AIBody_AssignsBody()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "hello")
+                .Build();
+
+            var ret = new AIReturn();
+            ret.SetBody(body);
+
+            Assert.Equal(body, ret.Body);
+            Assert.NotEqual(AIBody.Empty, ret.Body);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SetBody_Interactions_BuildsBody [Windows]")]
+#else
+        [Fact(DisplayName = "SetBody_Interactions_BuildsBody [Core]")]
+#endif
+        public void SetBody_Interactions_BuildsBody()
+        {
+            var interactions = new List<IAIInteraction>
+            {
+                new AIInteractionText { Agent = AIAgent.Assistant, Content = "hello" },
+            };
+
+            var ret = new AIReturn();
+            ret.SetBody(interactions);
+
+            Assert.NotEqual(AIBody.Empty, ret.Body);
+            Assert.Equal(1, ret.Body.InteractionsCount);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddRuntimeMessage_AddsToMessages [Windows]")]
+#else
+        [Fact(DisplayName = "AddRuntimeMessage_AddsToMessages [Core]")]
+#endif
+        public void AddRuntimeMessage_AddsToMessages()
+        {
+            var ret = new AIReturn
+            {
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+
+            ret.AddRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Return, "a warning");
+
+            Assert.Single(ret.Messages);
+            Assert.Contains("a warning", ret.Messages[0].Message, StringComparison.Ordinal);
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, ret.Messages[0].Severity);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddRuntimeMessage_Error_MakesSuccessFalse [Windows]")]
+#else
+        [Fact(DisplayName = "AddRuntimeMessage_Error_MakesSuccessFalse [Core]")]
+#endif
+        public void AddRuntimeMessage_Error_MakesSuccessFalse()
+        {
+            var ret = new AIReturn
+            {
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+
+            ret.AddRuntimeMessage(SHRuntimeMessageSeverity.Error, SHRuntimeMessageOrigin.Return, "an error");
+
+            Assert.False(ret.Success);
+            Assert.Contains(ret.Messages, m => m.Severity == SHRuntimeMessageSeverity.Error);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "AddRuntimeMessage_Warning_KeepsSuccessTrue [Windows]")]
+#else
+        [Fact(DisplayName = "AddRuntimeMessage_Warning_KeepsSuccessTrue [Core]")]
+#endif
+        public void AddRuntimeMessage_Warning_KeepsSuccessTrue()
+        {
+            var ret = new AIReturn
+            {
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+
+            ret.AddRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Return, "a warning");
+
+            Assert.True(ret.Success);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_IncludesBodyMessages [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_IncludesBodyMessages [Core]")]
+#endif
+        public void Messages_IncludesBodyMessages()
+        {
+            var image = new AIInteractionImage
+            {
+                Agent = AIAgent.User,
+                OriginalPrompt = "test image",
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Tool, SHMessageCode.Unknown, "body warning"),
+                },
+            };
+
+            var body = AIBodyBuilder.Create()
+                .Add(image)
+                .Build();
+
+            var ret = new AIReturn
+            {
+                Request = CreateFakeRequest(),
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+            ret.SetBody(body);
+
+            Assert.Contains(ret.Messages, m => m.Message == "body warning" && m.Severity == SHRuntimeMessageSeverity.Warning);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_IncludesRequestMessages [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_IncludesRequestMessages [Core]")]
+#endif
+        public void Messages_IncludesRequestMessages()
+        {
+            var request = CreateFakeRequest();
+            request.Messages = new List<SHRuntimeMessage>
+            {
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Request, SHMessageCode.Unknown, "request info"),
+            };
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "hello", new AIMetrics { Provider = "openai", Model = "gpt-test", FinishReason = "stop" })
+                .Build();
+
+            var ret = new AIReturn
+            {
+                Request = request,
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+            ret.SetBody(body);
+
+            Assert.Contains(ret.Messages, m => m.Message == "request info" && m.Severity == SHRuntimeMessageSeverity.Info);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_IncludesValidationErrors [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_IncludesValidationErrors [Core]")]
+#endif
+        public void Messages_IncludesValidationErrors()
+        {
+            var interaction = new AIInteractionText { Agent = AIAgent.User, Content = "missing turn id" };
+            var invalidBody = new AIBody(
+                new List<IAIInteraction> { interaction },
+                "-*",
+                "-*",
+                null!,
+                new List<int>());
+
+            var request = CreateFakeRequest();
+            request.Body = invalidBody;
+
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "hello", new AIMetrics { Provider = "openai", Model = "gpt-test", FinishReason = "stop" })
+                .Build();
+
+            var ret = new AIReturn
+            {
+                Request = request,
+            };
+            ret.SetBody(body);
+
+            Assert.Contains(ret.Messages, m => m.Message.Contains("TurnId", StringComparison.Ordinal));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Messages_SortsBySeverity [Windows]")]
+#else
+        [Fact(DisplayName = "Messages_SortsBySeverity [Core]")]
+#endif
+        public void Messages_SortsBySeverity()
+        {
+            var image = new AIInteractionImage
+            {
+                Agent = AIAgent.User,
+                OriginalPrompt = "test image",
+                Messages = new List<SHRuntimeMessage>
+                {
+                    new SHRuntimeMessage(SHRuntimeMessageSeverity.Warning, SHRuntimeMessageOrigin.Tool, SHMessageCode.Unknown, "body warning"),
+                },
+            };
+
+            var body = AIBodyBuilder.Create()
+                .Add(image)
+                .Build();
+
+            var request = CreateFakeRequest();
+            request.Messages = new List<SHRuntimeMessage>
+            {
+                new SHRuntimeMessage(SHRuntimeMessageSeverity.Info, SHRuntimeMessageOrigin.Request, SHMessageCode.Unknown, "request info"),
+            };
+
+            var ret = new AIReturn
+            {
+                Request = request,
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+            ret.SetBody(body);
+            ret.AddRuntimeMessage(SHRuntimeMessageSeverity.Error, SHRuntimeMessageOrigin.Return, "private error");
+
+            var messages = ret.Messages;
+
+            Assert.Equal(SHRuntimeMessageSeverity.Error, messages[0].Severity);
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, messages[1].Severity);
+            Assert.Equal(SHRuntimeMessageSeverity.Info, messages[2].Severity);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_ValidWithNonEmptyBodyAndSkipFlags [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_ValidWithNonEmptyBodyAndSkipFlags [Core]")]
+#endif
+        public void IsValid_ValidWithNonEmptyBodyAndSkipFlags()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "hello")
+                .Build();
+
+            var ret = new AIReturn
+            {
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+            ret.SetBody(body);
+
+            var (isValid, _) = ret.IsValid();
+
+            Assert.True(isValid);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_ValidWithNonEmptyBodyAndValidMetrics [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_ValidWithNonEmptyBodyAndValidMetrics [Core]")]
+#endif
+        public void IsValid_ValidWithNonEmptyBodyAndValidMetrics()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddText(
+                    AIAgent.Assistant,
+                    "hello",
+                    new AIMetrics
+                    {
+                        Provider = "openai",
+                        Model = "gpt-test",
+                        FinishReason = "stop",
+                        InputTokensPrompt = 1,
+                        OutputTokensGeneration = 1,
+                    })
+                .Build();
+
+            var ret = new AIReturn
+            {
+                Request = CreateFakeRequest(),
+            };
+            ret.SetBody(body);
+
+            var (isValid, _) = ret.IsValid();
+
+            Assert.True(isValid);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_InvalidWhenBodyEmptyAndNoPrivateMessages [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_InvalidWhenBodyEmptyAndNoPrivateMessages [Core]")]
+#endif
+        public void IsValid_InvalidWhenBodyEmptyAndNoPrivateMessages()
+        {
+            var ret = new AIReturn
+            {
+                Request = CreateFakeRequest(),
+                SkipRequestValidation = true,
+                SkipMetricsValidation = true,
+            };
+
+            var (isValid, errors) = ret.IsValid();
+
+            Assert.False(isValid);
+            Assert.Contains(errors, e => e.Message.Contains("Either body or messages must be set", StringComparison.Ordinal));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "CreateSuccess_SetsStatusBodyAndMetrics [Windows]")]
+#else
+        [Fact(DisplayName = "CreateSuccess_SetsStatusBodyAndMetrics [Core]")]
+#endif
+        public void CreateSuccess_SetsStatusBodyAndMetrics()
+        {
+            var body = AIBodyBuilder.Create()
+                .AddText(AIAgent.Assistant, "hello")
+                .Build();
+
+            var request = CreateFakeRequest();
+            request.Provider = "test-provider";
+
+            var ret = new AIReturn();
+            ret.CreateSuccess(body, request);
+
+            Assert.Equal(AICallStatus.Finished, ret.Status);
+            Assert.NotEqual(AIBody.Empty, ret.Body);
+            Assert.Equal(1, ret.Body.InteractionsCount);
+            Assert.Equal("test-provider", ret.Body.Interactions[0].Metrics.Provider);
+            Assert.Equal("test-model", ret.Body.Interactions[0].Metrics.Model);
+            Assert.Equal("test-provider", ret.Metrics.Provider);
+            Assert.Equal("test-model", ret.Metrics.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "CreateError_AddsErrorAndSetsStatusFinished [Windows]")]
+#else
+        [Fact(DisplayName = "CreateError_AddsErrorAndSetsStatusFinished [Core]")]
+#endif
+        public void CreateError_AddsErrorAndSetsStatusFinished()
+        {
+            var ret = new AIReturn();
+            ret.CreateError("something went wrong", CreateFakeRequest());
+
+            ret.Request = CreateFakeRequest();
+            ret.SkipRequestValidation = true;
+            ret.SkipMetricsValidation = true;
+
+            Assert.Equal(AICallStatus.Finished, ret.Status);
+            Assert.False(ret.Success);
+            Assert.Contains(ret.Messages, m => m.Severity == SHRuntimeMessageSeverity.Error && m.Message.Contains("something went wrong", StringComparison.Ordinal));
+        }
+
+        private static AIRequestBase CreateFakeRequest()
+        {
+            return new AIRequestBase
+            {
+                Capability = AICapability.None,
+                Provider = null,
+                WantsStreaming = false,
+                Body = AIBody.Empty,
+                Model = "test-model",
+            };
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Metrics/AICostCalculatorTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Metrics/AICostCalculatorTests.cs
@@ -1,0 +1,285 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Metrics
+{
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Tests.TestHelpers;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AICostCalculator"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AICostCalculatorTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_UnknownPricing_ReturnsZero [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_UnknownPricing_ReturnsZero [Core]")]
+#endif
+        public void Calculate_UnknownPricing_ReturnsZero()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 1000,
+                OutputTokensGeneration = 500,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            Assert.Equal(0m, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_NegativeOrFreePrices_ReturnsZero [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_NegativeOrFreePrices_ReturnsZero [Core]")]
+#endif
+        public void Calculate_NegativeOrFreePrices_ReturnsZero()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "free-model", new AIModelPricing { Prompt = 0m, Completion = -1m });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "free-model",
+                InputTokensPrompt = 1000,
+                OutputTokensGeneration = 500,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            Assert.Equal(0m, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_PromptAndCompletion_ReturnsExpectedCost [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_PromptAndCompletion_ReturnsExpectedCost [Core]")]
+#endif
+        public void Calculate_PromptAndCompletion_ReturnsExpectedCost()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", new AIModelPricing
+            {
+                Prompt = 0.0000025m,
+                Completion = 0.000010m,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 1000,
+                OutputTokensGeneration = 500,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            var expected = (1000m * 0.0000025m) + (500m * 0.000010m);
+            Assert.Equal(expected, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_CacheBuckets_ArePriced [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_CacheBuckets_ArePriced [Core]")]
+#endif
+        public void Calculate_CacheBuckets_ArePriced()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("anthropic", "claude-test", new AIModelPricing
+            {
+                Prompt = 0.000003m,
+                InputCacheRead = 0.0000003m,
+                InputCacheWrite = 0.00000375m,
+                Completion = 0.000015m,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "anthropic",
+                Model = "claude-test",
+                InputTokensPrompt = 100,
+                InputTokensCached = 50,
+                InputTokensCacheWrite = 20,
+                OutputTokensGeneration = 30,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            var expected = (100m * 0.000003m)
+                + (50m * 0.0000003m)
+                + (20m * 0.00000375m)
+                + (30m * 0.000015m);
+            Assert.Equal(expected, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_ReasoningPricedWhenInternalReasoningIsSet [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_ReasoningPricedWhenInternalReasoningIsSet [Core]")]
+#endif
+        public void Calculate_ReasoningPricedWhenInternalReasoningIsSet()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("google", "gemini-test", new AIModelPricing
+            {
+                Prompt = 0.000001m,
+                Completion = 0.000004m,
+                InternalReasoning = 0.000008m,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "google",
+                Model = "gemini-test",
+                InputTokensPrompt = 1000,
+                OutputTokensGeneration = 200,
+                OutputTokensReasoning = 50,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            var expected = (1000m * 0.000001m)
+                + (200m * 0.000004m)
+                + (50m * 0.000008m);
+            Assert.Equal(expected, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_MissingCategoryPrice_ContributesZero [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_MissingCategoryPrice_ContributesZero [Core]")]
+#endif
+        public void Calculate_MissingCategoryPrice_ContributesZero()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", new AIModelPricing
+            {
+                Prompt = 0.000002m,
+                Completion = 0.000006m,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                InputTokensCached = 50,
+                InputTokensCacheWrite = 20,
+                OutputTokensGeneration = 30,
+                OutputTokensReasoning = 10,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            var expected = (100m * 0.000002m) + (30m * 0.000006m);
+            Assert.Equal(expected, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_EstimatedInputTokensFallback_WhenNoActualInput [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_EstimatedInputTokensFallback_WhenNoActualInput [Core]")]
+#endif
+        public void Calculate_EstimatedInputTokensFallback_WhenNoActualInput()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", new AIModelPricing { Prompt = 0.000001m });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                EstimatedInputTokens = 1234,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            Assert.Equal(1234m * 0.000001m, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_EstimatedOutputTokensFallback_WhenNoActualOutput [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_EstimatedOutputTokensFallback_WhenNoActualOutput [Core]")]
+#endif
+        public void Calculate_EstimatedOutputTokensFallback_WhenNoActualOutput()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", new AIModelPricing { Completion = 0.000005m });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                EstimatedOutputTokens = 567,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            Assert.Equal(567m * 0.000005m, cost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Calculate_FallsBackPerSide_IndependentBuckets [Windows]")]
+#else
+        [Fact(DisplayName = "Calculate_FallsBackPerSide_IndependentBuckets [Core]")]
+#endif
+        public void Calculate_FallsBackPerSide_IndependentBuckets()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", new AIModelPricing
+            {
+                Prompt = 0.000001m,
+                Completion = 0.000004m,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                EstimatedOutputTokens = 200,
+            };
+
+            var cost = AICostCalculator.Calculate(metrics);
+
+            var expected = (100m * 0.000001m) + (200m * 0.000004m);
+            Assert.Equal(expected, cost);
+        }
+
+        private static void RegisterPricing(string provider, string model, AIModelPricing pricing)
+        {
+            AIModelCapabilityRegistry.Instance.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = provider,
+                Model = model,
+                Pricing = pricing,
+            });
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AICall/Metrics/AIMetricsTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AICall/Metrics/AIMetricsTests.cs
@@ -1,0 +1,260 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AICall.Metrics
+{
+    using SmartHopper.ProviderSdk.AICall.Metrics;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Tests.TestHelpers;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIMetrics"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIMetricsTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "InputTokens_SumsInputBuckets [Windows]")]
+#else
+        [Fact(DisplayName = "InputTokens_SumsInputBuckets [Core]")]
+#endif
+        public void InputTokens_SumsInputBuckets()
+        {
+            var metrics = new AIMetrics
+            {
+                InputTokensPrompt = 100,
+                InputTokensCached = 50,
+                InputTokensCacheWrite = 25,
+            };
+
+            Assert.Equal(175, metrics.InputTokens);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "OutputTokens_SumsOutputBuckets [Windows]")]
+#else
+        [Fact(DisplayName = "OutputTokens_SumsOutputBuckets [Core]")]
+#endif
+        public void OutputTokens_SumsOutputBuckets()
+        {
+            var metrics = new AIMetrics
+            {
+                OutputTokensGeneration = 80,
+                OutputTokensReasoning = 20,
+            };
+
+            Assert.Equal(100, metrics.OutputTokens);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "TotalTokens_SumsInputAndOutput [Windows]")]
+#else
+        [Fact(DisplayName = "TotalTokens_SumsInputAndOutput [Core]")]
+#endif
+        public void TotalTokens_SumsInputAndOutput()
+        {
+            var metrics = new AIMetrics
+            {
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            Assert.Equal(150, metrics.TotalTokens);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "EffectiveTotalTokens_UsesMaximum [Windows]")]
+#else
+        [Fact(DisplayName = "EffectiveTotalTokens_UsesMaximum [Core]")]
+#endif
+        public void EffectiveTotalTokens_UsesMaximum()
+        {
+            var metrics = new AIMetrics
+            {
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+                EstimatedInputTokens = 500,
+                EstimatedOutputTokens = 100,
+            };
+
+            Assert.Equal(600, metrics.EffectiveTotalTokens);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_ValidMetrics [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_ValidMetrics [Core]")]
+#endif
+        public void IsValid_ValidMetrics()
+        {
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                FinishReason = "stop",
+                InputTokensPrompt = 10,
+                OutputTokensGeneration = 5,
+            };
+
+            Assert.True(metrics.IsValid().IsValid);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "IsValid_InvalidMetrics [Windows]")]
+#else
+        [Fact(DisplayName = "IsValid_InvalidMetrics [Core]")]
+#endif
+        public void IsValid_InvalidMetrics()
+        {
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = -1,
+            };
+
+            Assert.False(metrics.IsValid().IsValid);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Combine_MergesAndAddsTokenCounts [Windows]")]
+#else
+        [Fact(DisplayName = "Combine_MergesAndAddsTokenCounts [Core]")]
+#endif
+        public void Combine_MergesAndAddsTokenCounts()
+        {
+            var first = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            var second = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                InputTokensPrompt = 50,
+                OutputTokensGeneration = 25,
+            };
+
+            first.Combine(second);
+
+            Assert.Equal(150, first.InputTokensPrompt);
+            Assert.Equal(75, first.OutputTokensGeneration);
+            Assert.Equal(225, first.TotalTokens);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "Combine_SumsEstimatedCost [Windows]")]
+#else
+        [Fact(DisplayName = "Combine_SumsEstimatedCost [Core]")]
+#endif
+        public void Combine_SumsEstimatedCost()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", 0.000001m, 0.000004m);
+
+            var first = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            var second = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 50,
+                OutputTokensGeneration = 25,
+            };
+
+            var firstCost = first.EstimatedCost;
+            var secondCost = second.EstimatedCost;
+
+            first.Combine(second);
+
+            Assert.Equal(firstCost + secondCost, first.EstimatedCost);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "EstimatedCost_CachesAfterFirstAccess [Windows]")]
+#else
+        [Fact(DisplayName = "EstimatedCost_CachesAfterFirstAccess [Core]")]
+#endif
+        public void EstimatedCost_CachesAfterFirstAccess()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            RegisterPricing("openai", "gpt-test", 0.000001m, 0.000004m);
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 100,
+                OutputTokensGeneration = 50,
+            };
+
+            var cost1 = metrics.EstimatedCost;
+            var cost2 = metrics.EstimatedCost;
+
+            Assert.Equal(cost1, cost2);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ContextUsagePercent_ComputesFromContextLimit [Windows]")]
+#else
+        [Fact(DisplayName = "ContextUsagePercent_ComputesFromContextLimit [Core]")]
+#endif
+        public void ContextUsagePercent_ComputesFromContextLimit()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            AIModelCapabilityRegistry.Instance.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                ContextLimit = 10000,
+            });
+
+            var metrics = new AIMetrics
+            {
+                Provider = "openai",
+                Model = "gpt-test",
+                InputTokensPrompt = 1000,
+                OutputTokensGeneration = 500,
+            };
+
+            Assert.NotNull(metrics.ContextUsagePercent);
+            Assert.Equal(0.15, metrics.ContextUsagePercent.Value, 4);
+        }
+
+        private static void RegisterPricing(string provider, string model, decimal prompt, decimal completion)
+        {
+            AIModelCapabilityRegistry.Instance.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = provider,
+                Model = model,
+                Pricing = new AIModelPricing { Prompt = prompt, Completion = completion },
+            });
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AIModels/AICapabilityTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AIModels/AICapabilityTests.cs
@@ -1,0 +1,96 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AIModels
+{
+    using System;
+    using SmartHopper.ProviderSdk.AIModels;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AICapability"/> and its extension methods.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AICapabilityTests
+    {
+#if NET7_WINDOWS
+        private const string PlatformSuffix = " [Windows]";
+#else
+        private const string PlatformSuffix = " [Core]";
+#endif
+
+        [Theory(DisplayName = nameof(ToDetailedString_FormatsCapabilities) + PlatformSuffix)]
+        [InlineData(AICapability.None, "None")]
+        [InlineData(AICapability.Text2Text, "TextInput, TextOutput")]
+        [InlineData(AICapability.ToolChat, "TextInput, TextOutput, FunctionCalling")]
+        [InlineData(AICapability.ReasoningChat, "TextInput, TextOutput, Reasoning")]
+        [InlineData(AICapability.Text2Image, "TextInput, ImageOutput")]
+        [InlineData(AICapability.AudioInput, "SpeechInput, AudioInput")]
+        [InlineData(AICapability.AudioOutput, "SpeechOutput, AudioOutput")]
+        public void ToDetailedString_FormatsCapabilities(AICapability capability, string expected)
+        {
+            Assert.Equal(expected, capability.ToDetailedString());
+        }
+
+        [Theory(DisplayName = nameof(HasInput_DetectsInputCapabilities) + PlatformSuffix)]
+        [InlineData(AICapability.None, false)]
+        [InlineData(AICapability.Text2Text, true)]
+        [InlineData(AICapability.Text2Image, true)]
+        [InlineData(AICapability.AudioInput, true)]
+        [InlineData(AICapability.ImageOutput, false)]
+        public void HasInput_DetectsInputCapabilities(AICapability capability, bool expected)
+        {
+            Assert.Equal(expected, capability.HasInput());
+        }
+
+        [Theory(DisplayName = nameof(HasOutput_DetectsOutputCapabilities) + PlatformSuffix)]
+        [InlineData(AICapability.None, false)]
+        [InlineData(AICapability.Text2Text, true)]
+        [InlineData(AICapability.Text2Image, true)]
+        [InlineData(AICapability.AudioOutput, true)]
+        [InlineData(AICapability.TextInput, false)]
+        public void HasOutput_DetectsOutputCapabilities(AICapability capability, bool expected)
+        {
+            Assert.Equal(expected, capability.HasOutput());
+        }
+
+        [Theory(DisplayName = nameof(HasFlag_DetectsIndividualFlags) + PlatformSuffix)]
+        [InlineData(AICapability.Text2Text, AICapability.TextInput, true)]
+        [InlineData(AICapability.Text2Text, AICapability.TextOutput, true)]
+        [InlineData(AICapability.Text2Text, AICapability.FunctionCalling, false)]
+        [InlineData(AICapability.ToolChat, AICapability.FunctionCalling, true)]
+        [InlineData(AICapability.AudioInput, AICapability.SpeechInput, true)]
+        [InlineData(AICapability.AudioOutput, AICapability.SpeechOutput, true)]
+        public void HasFlag_DetectsIndividualFlags(AICapability capability, AICapability flag, bool expected)
+        {
+            Assert.Equal(expected, capability.HasFlag(flag));
+        }
+
+        [Fact(DisplayName = nameof(Text2Text_MatchesTextInputAndTextOutput) + PlatformSuffix)]
+        public void Text2Text_MatchesTextInputAndTextOutput()
+        {
+            Assert.Equal(AICapability.TextInput | AICapability.TextOutput, AICapability.Text2Text);
+        }
+
+        [Fact(DisplayName = nameof(ToolChat_MatchesText2TextAndFunctionCalling) + PlatformSuffix)]
+        public void ToolChat_MatchesText2TextAndFunctionCalling()
+        {
+            Assert.Equal(AICapability.Text2Text | AICapability.FunctionCalling, AICapability.ToolChat);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AIModels/AIModelCapabilitiesTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AIModels/AIModelCapabilitiesTests.cs
@@ -1,0 +1,131 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AIModels
+{
+    using System.Collections.Generic;
+    using SmartHopper.ProviderSdk.AIModels;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIModelCapabilities"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIModelCapabilitiesTests
+    {
+#if NET7_WINDOWS
+        private const string PlatformSuffix = " [Windows]";
+#else
+        private const string PlatformSuffix = " [Core]";
+#endif
+
+        [Fact(DisplayName = nameof(HasCapability_ReturnsTrueForNone) + PlatformSuffix)]
+        public void HasCapability_ReturnsTrueForNone()
+        {
+            var capabilities = new AIModelCapabilities { Capabilities = AICapability.Text2Text };
+
+            Assert.True(capabilities.HasCapability(AICapability.None));
+        }
+
+        [Fact(DisplayName = nameof(HasCapability_ReturnsTrueForMatchingCapability) + PlatformSuffix)]
+        public void HasCapability_ReturnsTrueForMatchingCapability()
+        {
+            var capabilities = new AIModelCapabilities { Capabilities = AICapability.Text2Text };
+
+            Assert.True(capabilities.HasCapability(AICapability.Text2Text));
+            Assert.True(capabilities.HasCapability(AICapability.TextInput));
+            Assert.True(capabilities.HasCapability(AICapability.TextOutput));
+        }
+
+        [Fact(DisplayName = nameof(HasCapability_ReturnsFalseForMissingFlag) + PlatformSuffix)]
+        public void HasCapability_ReturnsFalseForMissingFlag()
+        {
+            var capabilities = new AIModelCapabilities { Capabilities = AICapability.Text2Text };
+
+            Assert.False(capabilities.HasCapability(AICapability.ImageOutput));
+            Assert.False(capabilities.HasCapability(AICapability.FunctionCalling));
+        }
+
+        [Fact(DisplayName = nameof(GetKey_LowercasesProviderAndModel) + PlatformSuffix)]
+        public void GetKey_LowercasesProviderAndModel()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                Provider = "OpenAI",
+                Model = "GPT-4",
+            };
+
+            Assert.Equal("openai.gpt-4", capabilities.GetKey());
+        }
+
+        [Fact(DisplayName = nameof(IsDiscouragedForAnyTool_EmptyListReturnsFalse) + PlatformSuffix)]
+        public void IsDiscouragedForAnyTool_EmptyListReturnsFalse()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                DiscouragedForTools = new List<string>(),
+            };
+
+            Assert.False(capabilities.IsDiscouragedForAnyTool(new List<string> { "Tool" }));
+        }
+
+        [Fact(DisplayName = nameof(IsDiscouragedForAnyTool_WildcardMatchesAll) + PlatformSuffix)]
+        public void IsDiscouragedForAnyTool_WildcardMatchesAll()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                DiscouragedForTools = new List<string> { "*" },
+            };
+
+            Assert.True(capabilities.IsDiscouragedForAnyTool(new List<string> { "AnyTool" }));
+        }
+
+        [Fact(DisplayName = nameof(IsDiscouragedForAnyTool_MatchesToolName) + PlatformSuffix)]
+        public void IsDiscouragedForAnyTool_MatchesToolName()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                DiscouragedForTools = new List<string> { "MyTool" },
+            };
+
+            Assert.True(capabilities.IsDiscouragedForAnyTool(new List<string> { "MyTool" }));
+        }
+
+        [Fact(DisplayName = nameof(IsDiscouragedForAnyTool_NoMatchReturnsFalse) + PlatformSuffix)]
+        public void IsDiscouragedForAnyTool_NoMatchReturnsFalse()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                DiscouragedForTools = new List<string> { "OtherTool" },
+            };
+
+            Assert.False(capabilities.IsDiscouragedForAnyTool(new List<string> { "MyTool" }));
+        }
+
+        [Fact(DisplayName = nameof(IsDiscouragedForAnyTool_MatchesCaseInsensitive) + PlatformSuffix)]
+        public void IsDiscouragedForAnyTool_MatchesCaseInsensitive()
+        {
+            var capabilities = new AIModelCapabilities
+            {
+                DiscouragedForTools = new List<string> { "Tool-A" },
+            };
+
+            Assert.True(capabilities.IsDiscouragedForAnyTool(new List<string> { "tool-a" }));
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/AIModels/AIModelCapabilityRegistryTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/AIModels/AIModelCapabilityRegistryTests.cs
@@ -1,0 +1,298 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.AIModels
+{
+    using System.Collections.Generic;
+    using SmartHopper.ProviderSdk.AIModels;
+    using SmartHopper.ProviderSdk.Tests.TestHelpers;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="AIModelCapabilityRegistry"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class AIModelCapabilityRegistryTests
+    {
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SetCapabilities_ThenGetCapabilities_ExactMatch [Windows]")]
+#else
+        [Fact(DisplayName = "SetCapabilities_ThenGetCapabilities_ExactMatch [Core]")]
+#endif
+        public void SetCapabilities_ThenGetCapabilities_ExactMatch()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            var caps = registry.GetCapabilities("OpenAI", "gpt-4");
+
+            Assert.NotNull(caps);
+            Assert.Equal("openai", caps.Provider);
+            Assert.Equal("gpt-4", caps.Model);
+            Assert.True(caps.HasCapability(AICapability.Text2Text));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "GetCapabilities_AliasMatches [Windows]")]
+#else
+        [Fact(DisplayName = "GetCapabilities_AliasMatches [Core]")]
+#endif
+        public void GetCapabilities_AliasMatches()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4-turbo",
+                Aliases = new List<string> { "gpt-4t" },
+                Capabilities = AICapability.Text2Text,
+            });
+
+            var caps = registry.GetCapabilities("openai", "gpt-4t");
+
+            Assert.NotNull(caps);
+            Assert.Equal("gpt-4-turbo", caps.Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "GetCapabilities_UnknownModel_ReturnsNull [Windows]")]
+#else
+        [Fact(DisplayName = "GetCapabilities_UnknownModel_ReturnsNull [Core]")]
+#endif
+        public void GetCapabilities_UnknownModel_ReturnsNull()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            var caps = registry.GetCapabilities("unknown", "unknown");
+
+            Assert.Null(caps);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "HasProviderCapabilities_DetectsProvider [Windows]")]
+#else
+        [Fact(DisplayName = "HasProviderCapabilities_DetectsProvider [Core]")]
+#endif
+        public void HasProviderCapabilities_DetectsProvider()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            Assert.True(registry.HasProviderCapabilities("openai"));
+            Assert.False(registry.HasProviderCapabilities("anthropic"));
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "GetProviderModels_ReturnsOnlySameProvider [Windows]")]
+#else
+        [Fact(DisplayName = "GetProviderModels_ReturnsOnlySameProvider [Core]")]
+#endif
+        public void GetProviderModels_ReturnsOnlySameProvider()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+            });
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "anthropic",
+                Model = "claude-3",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            var openAiModels = registry.GetProviderModels("openai");
+
+            Assert.Single(openAiModels);
+            Assert.Equal("gpt-4", openAiModels[0].Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "FindModelsWithCapabilities_FiltersByCapability [Windows]")]
+#else
+        [Fact(DisplayName = "FindModelsWithCapabilities_FiltersByCapability [Core]")]
+#endif
+        public void FindModelsWithCapabilities_FiltersByCapability()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "dall-e",
+                Capabilities = AICapability.Text2Image,
+            });
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            var textModels = registry.FindModelsWithCapabilities(AICapability.Text2Text);
+
+            Assert.Single(textModels);
+            Assert.Equal("gpt-4", textModels[0].Model);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SetDefault_Exclusive_RemovesDefaultFromOthers [Windows]")]
+#else
+        [Fact(DisplayName = "SetDefault_Exclusive_RemovesDefaultFromOthers [Core]")]
+#endif
+        public void SetDefault_Exclusive_RemovesDefaultFromOthers()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+                Default = AICapability.Text2Text,
+            });
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-3.5",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            registry.SetDefault("openai", "gpt-3.5", AICapability.Text2Text, exclusive: true);
+
+            var gpt4 = registry.GetCapabilities("openai", "gpt-4");
+            var gpt35 = registry.GetCapabilities("openai", "gpt-3.5");
+
+            Assert.False((gpt4.Default & AICapability.Text2Text) == AICapability.Text2Text);
+            Assert.True((gpt35.Default & AICapability.Text2Text) == AICapability.Text2Text);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "GetDefaultModel_ReturnsDefaultForCapability [Windows]")]
+#else
+        [Fact(DisplayName = "GetDefaultModel_ReturnsDefaultForCapability [Core]")]
+#endif
+        public void GetDefaultModel_ReturnsDefaultForCapability()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+                Default = AICapability.Text2Text,
+                Rank = 10,
+            });
+
+            var defaultModel = registry.GetDefaultModel("openai", AICapability.Text2Text);
+
+            Assert.Equal("gpt-4", defaultModel);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SelectBestModel_UnknownUserModel_Allowed [Windows]")]
+#else
+        [Fact(DisplayName = "SelectBestModel_UnknownUserModel_Allowed [Core]")]
+#endif
+        public void SelectBestModel_UnknownUserModel_Allowed()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+            });
+
+            var selected = registry.SelectBestModel("openai", "custom-model", AICapability.Text2Text);
+
+            Assert.Equal("custom-model", selected);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "SelectBestModel_ReturnsDefaultWhenNoUserModel [Windows]")]
+#else
+        [Fact(DisplayName = "SelectBestModel_ReturnsDefaultWhenNoUserModel [Core]")]
+#endif
+        public void SelectBestModel_ReturnsDefaultWhenNoUserModel()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                Capabilities = AICapability.Text2Text,
+                Default = AICapability.Text2Text,
+            });
+
+            var selected = registry.SelectBestModel("openai", string.Empty, AICapability.Text2Text);
+
+            Assert.Equal("gpt-4", selected);
+        }
+
+#if NET7_WINDOWS
+        [Fact(DisplayName = "ModelSupportsStreaming_TrueWhenSupported [Windows]")]
+#else
+        [Fact(DisplayName = "ModelSupportsStreaming_TrueWhenSupported [Core]")]
+#endif
+        public void ModelSupportsStreaming_TrueWhenSupported()
+        {
+            ProviderSdkTestHelper.ResetCapabilityRegistry();
+            var registry = AIModelCapabilityRegistry.Instance;
+
+            registry.SetCapabilities(new AIModelCapabilities
+            {
+                Provider = "openai",
+                Model = "gpt-4",
+                SupportsStreaming = true,
+            });
+
+            Assert.True(registry.ModelSupportsStreaming("openai", "gpt-4"));
+            Assert.False(registry.ModelSupportsStreaming("openai", "unknown"));
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/Diagnostics/SHRuntimeMessageTests.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/Diagnostics/SHRuntimeMessageTests.cs
@@ -1,0 +1,90 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.Diagnostics
+{
+    using SmartHopper.ProviderSdk.Diagnostics;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="SHRuntimeMessage"/>.
+    /// </summary>
+    [Collection("ProviderSdk")]
+    public class SHRuntimeMessageTests
+    {
+#if NET7_WINDOWS
+        private const string PlatformSuffix = " [Windows]";
+#else
+        private const string PlatformSuffix = " [Core]";
+#endif
+
+        [Fact(DisplayName = nameof(Constructor_StoresAllProperties) + PlatformSuffix)]
+        public void Constructor_StoresAllProperties()
+        {
+            var message = new SHRuntimeMessage(
+                SHRuntimeMessageSeverity.Warning,
+                SHRuntimeMessageOrigin.Tool,
+                SHMessageCode.ToolExecutionError,
+                "message text",
+                false);
+
+            Assert.Equal(SHRuntimeMessageSeverity.Warning, message.Severity);
+            Assert.Equal(SHRuntimeMessageOrigin.Tool, message.Origin);
+            Assert.Equal(SHMessageCode.ToolExecutionError, message.Code);
+            Assert.Equal("message text", message.Message);
+            Assert.False(message.Surfaceable);
+        }
+
+        [Fact(DisplayName = nameof(Constructor_NullMessageBecomesEmpty) + PlatformSuffix)]
+        public void Constructor_NullMessageBecomesEmpty()
+        {
+            var message = new SHRuntimeMessage(
+                SHRuntimeMessageSeverity.Info,
+                SHRuntimeMessageOrigin.Return,
+                SHMessageCode.Unknown,
+                null!);
+
+            Assert.Equal(string.Empty, message.Message);
+        }
+
+        [Fact(DisplayName = nameof(Constructor_SurfaceableDefaultsToTrue) + PlatformSuffix)]
+        public void Constructor_SurfaceableDefaultsToTrue()
+        {
+            var message = new SHRuntimeMessage(
+                SHRuntimeMessageSeverity.Info,
+                SHRuntimeMessageOrigin.Return,
+                SHMessageCode.Unknown,
+                "message text");
+
+            Assert.True(message.Surfaceable);
+        }
+
+        [Fact(DisplayName = nameof(Constructor_SurfaceableCanBeFalse) + PlatformSuffix)]
+        public void Constructor_SurfaceableCanBeFalse()
+        {
+            var message = new SHRuntimeMessage(
+                SHRuntimeMessageSeverity.Debug,
+                SHRuntimeMessageOrigin.Return,
+                SHMessageCode.Unknown,
+                "message text",
+                false);
+
+            Assert.False(message.Surfaceable);
+        }
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj
+++ b/src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj
@@ -1,0 +1,64 @@
+<!--
+  SmartHopper - AI-powered Grasshopper Plugin
+  Copyright (C) 2024-2026 Marc Roca Musach
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0-windows;net7.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SmartHopper.ProviderSdk\SmartHopper.ProviderSdk.csproj" />
+  </ItemGroup>
+
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
+    <UseWindowsForms>true</UseWindowsForms>
+    <DefineConstants>$(DefineConstants);WINDOWS;NET7_WINDOWS</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
+    <!-- Prevent transitive WindowsDesktop framework references from propagating to testhost -->
+    <FrameworkReference Remove="Microsoft.WindowsDesktop.App" />
+    <FrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />
+    <FrameworkReference Remove="Microsoft.WindowsDesktop.App.WPF" />
+  </ItemGroup>
+
+</Project>

--- a/src/SmartHopper.ProviderSdk.Tests/TestHelpers/ProviderSdkTestCollection.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/TestHelpers/ProviderSdkTestCollection.cs
@@ -1,0 +1,34 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.TestHelpers
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Xunit;
+
+    /// <summary>
+    /// XUnit collection that disables parallelization across all Provider SDK tests
+    /// so that global mutable state such as <see cref="AIModelCapabilityRegistry"/>
+    /// can be reset safely between tests.
+    /// </summary>
+    [CollectionDefinition("ProviderSdk", DisableParallelization = true)]
+    [SuppressMessage("Naming", "CA1711", Justification = "Type is an xUnit collection definition.")]
+    public class ProviderSdkTestCollection : ICollectionFixture<object>
+    {
+    }
+}

--- a/src/SmartHopper.ProviderSdk.Tests/TestHelpers/ProviderSdkTestHelper.cs
+++ b/src/SmartHopper.ProviderSdk.Tests/TestHelpers/ProviderSdkTestHelper.cs
@@ -1,0 +1,37 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+namespace SmartHopper.ProviderSdk.Tests.TestHelpers
+{
+    using SmartHopper.ProviderSdk.AIModels;
+
+    /// <summary>
+    /// Shared helpers for Provider SDK tests.
+    /// </summary>
+    public static class ProviderSdkTestHelper
+    {
+        /// <summary>
+        /// Clears the singleton <see cref="AIModelCapabilityRegistry.Instance"/> model dictionary.
+        /// Call this at the start of tests that register or inspect capabilities.
+        /// </summary>
+        public static void ResetCapabilityRegistry()
+        {
+            AIModelCapabilityRegistry.Instance.Models.Clear();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds `SmartHopper.ProviderSdk.Tests` and expands coverage across the Provider SDK contracts:

- `AICostCalculator`, `AIMetrics`, `AIModelCapabilityRegistry`
- `AIBody`, `AIBodyBuilder`, `AIRequestBase`, `AIRequestCall`, `AIReturn`
- `AIInteractionText`, `AIInteractionToolCall`, `AIInteractionToolResult`, `AIInteractionImage`, `AIInteractionRuntimeMessage`, `AIInteractionAudio`
- `AICallStatus`, `AIAgent`, `AIRequestKind`
- `AICapability`, `AIModelCapabilities`, `SHRuntimeMessage`

Also adds `AGENTS.md` with local build/test notes.

## Breaking Changes

None.

## Testing Done

```powershell
dotnet test src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj -p:SignAssembly=false