### PR TITLE
ci: workflow versioning and branch management fixes

### DIFF
--- a/.github/workflows/chore-cleanup-stale-branches.yml
+++ b/.github/workflows/chore-cleanup-stale-branches.yml
@@ -1,10 +1,11 @@
-name: 🧹 Cleanup stale chore branches
+name: 🧹 Cleanup stale chore/cascade/devin branches
 
-# Description: Scheduled weekly cleanup that removes chore/* branches with no
+# Description: Scheduled weekly cleanup that removes stale branches with no
 # open pull requests.  A branch is deleted only when ALL of these are true:
-#   1. Its name starts with "chore/".
+#   1. Its name starts with one of the watched prefixes (chore/, cascade/, devin/).
 #   2. It has zero open PRs (merged/closed PRs are fine).
 #   3. It is not a base (protected) branch.
+#   4. Its last commit is older than the configured age threshold.
 #
 # Triggers:
 #   - schedule: every Monday 4:00 UTC
@@ -12,30 +13,48 @@ name: 🧹 Cleanup stale chore branches
 #
 # Permissions:
 #   - contents: write  - Required to delete branches
+#   - pull-requests: read - Required to check for open PRs
 
 on:
   schedule:
     - cron: '0 4 * * 1'
   workflow_dispatch:
+    inputs:
+      max-age-days:
+        description: 'Delete branches whose last commit is older than this many days'
+        required: false
+        type: string
+        default: '7'
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   cleanup:
-    name: Delete orphaned chore branches
+    name: Delete orphaned chore/cascade/devin branches
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Find and delete stale chore branches
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find and delete stale branches
         uses: actions/github-script@v7
+        env:
+          MAX_AGE_DAYS: ${{ github.event.inputs.max-age-days || '7' }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prefix = 'chore/';
-            let deleted = 0;
-            let skipped = 0;
+            const maxAgeDays = parseInt(process.env.MAX_AGE_DAYS, 10);
+            const prefixes = ['chore/', 'cascade/', 'devin/'];
+            const protectedBranches = new Set(['main', 'dev']);
+
+            const now = new Date();
+            const cutoff = new Date(now.getTime() - maxAgeDays * 24 * 60 * 60 * 1000);
 
             // Paginate through all branches
             const branches = await github.paginate(
@@ -43,10 +62,15 @@ jobs:
               { owner, repo, per_page: 100 },
             );
 
-            const choreBranches = branches.filter(b => b.name.startsWith(prefix));
-            core.info(`Found ${choreBranches.length} chore/* branch(es).`);
+            const watchedBranches = branches.filter(b =>
+              prefixes.some(p => b.name.startsWith(p)) && !protectedBranches.has(b.name)
+            );
 
-            for (const branch of choreBranches) {
+            let deleted = 0;
+            let skipped = 0;
+            let tooNew = 0;
+
+            for (const branch of watchedBranches) {
               // Check for open PRs from this branch
               const { data: openPrs } = await github.rest.pulls.list({
                 owner,
@@ -62,7 +86,21 @@ jobs:
                 continue;
               }
 
-              // No open PRs — safe to delete
+              // Get the commit date for the branch tip
+              const { data: commit } = await github.rest.git.getCommit({
+                owner,
+                repo,
+                commit_sha: branch.commit.sha,
+              });
+
+              const commitDate = new Date(commit.committer.date);
+              if (commitDate > cutoff) {
+                core.info(`⏭️  ${branch.name} — last commit ${commitDate.toISOString()} is newer than ${maxAgeDays} days, skipping.`);
+                tooNew++;
+                continue;
+              }
+
+              // No open PRs and old enough — safe to delete
               try {
                 await github.rest.git.deleteRef({
                   owner,
@@ -77,13 +115,14 @@ jobs:
             }
 
             core.summary
-              .addHeading('Stale chore branch cleanup', 3)
+              .addHeading('Stale branch cleanup', 3)
               .addTable([
                 [{ data: 'Metric', header: true }, { data: 'Count', header: true }],
-                ['Chore branches found', `${choreBranches.length}`],
+                ['Watched branches found', `${watchedBranches.length}`],
                 ['Deleted', `${deleted}`],
                 ['Skipped (open PRs)', `${skipped}`],
+                ['Skipped (too new)', `${tooNew}`],
               ])
               .write();
 
-            core.info(`Done. Deleted ${deleted}, skipped ${skipped}.`);
+            core.info(`Done. Deleted ${deleted}, skipped ${skipped}, too new ${tooNew}.`);

--- a/.github/workflows/hotfix-backport.yml
+++ b/.github/workflows/hotfix-backport.yml
@@ -1,0 +1,187 @@
+name: Hotfix Backport to Dev
+
+# Description: After a hotfix release PR merges to main, this workflow
+# automatically backports the actual fix (without the release version/changelog
+# changes) to dev.
+#
+# It uses the merged PR diff, excludes the version-specific files
+# (Solution.props, CHANGELOG.md, README.md, yak-package/manifest.yml), and
+# opens a backport/hotfix-X.Y.Z-description PR to dev.
+#
+# Related workflows:
+#   - hotfix-0-new-branch.yml (creates the hotfix branch)
+#   - hotfix-1-release-hotfix.yml (prepares the release PR to main)
+#   - release-3-pr-to-main-closed.yml (creates the GitHub release)
+#   - sync-dev-from-main.yml (brings other main changes to dev)
+#
+# Triggers:
+# - pull_request.closed on main/main-* where the head ref is a hotfix release branch
+#
+# Permissions:
+# - contents: write  - Required to create and push the backport branch
+# - pull-requests: write - Required to create the PR and enable auto-merge
+# - actions: write - Required to dispatch required PR checks
+# - issues: read - Required to assign the PR to the current milestone
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - 'main-*'
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  issues: read
+
+concurrency:
+  group: hotfix-backport-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  backport-to-dev:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      contains(github.event.pull_request.head.ref, '-hotfix-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ vars.SMARTHOPPER_BOT_NAME }}"
+          git config user.email "${{ vars.SMARTHOPPER_BOT_EMAIL }}"
+
+      - name: Resolve hotfix version and description
+        id: parse
+        shell: bash
+        run: |
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          # release/X.Y.Z-hotfix-description -> X.Y.Z and description
+          if [[ "$HEAD_REF" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)-hotfix-(.*)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            DESCRIPTION="${BASH_REMATCH[2]}"
+          else
+            echo "::error::Could not parse hotfix version/description from $HEAD_REF"
+            exit 1
+          fi
+          BACKPORT_BRANCH="backport/hotfix-${VERSION}-${DESCRIPTION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "description=$DESCRIPTION" >> "$GITHUB_OUTPUT"
+          echo "backport_branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create backport branch from dev
+        id: branch
+        run: |
+          BACKPORT_BRANCH="${{ steps.parse.outputs.backport_branch }}"
+          git checkout -b "$BACKPORT_BRANCH"
+
+      - name: Apply hotfix diff to dev
+        id: apply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BACKPORT_BRANCH="${{ steps.parse.outputs.backport_branch }}"
+
+          # Download the merged PR diff.  The --exclude options below drop the
+          # version/changelog/manifest/README changes so dev keeps its own version.
+          gh pr diff "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            > /tmp/hotfix.patch
+
+          if [ ! -s /tmp/hotfix.patch ]; then
+            echo "No diff found for PR #$PR_NUMBER. Nothing to backport."
+            echo "applied=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git apply \
+            --exclude='Solution.props' \
+            --exclude='CHANGELOG.md' \
+            --exclude='README.md' \
+            --exclude='yak-package/manifest.yml' \
+            /tmp/hotfix.patch; then
+            git add -A
+            if git diff --cached --quiet; then
+              echo "The hotfix changes are already present on dev. Nothing to backport."
+              echo "applied=false" >> "$GITHUB_OUTPUT"
+            else
+              VERSION="${{ steps.parse.outputs.version }}"
+              ORIGINAL="${{ github.event.pull_request.html_url }}"
+              git commit -m "chore: backport hotfix ${VERSION} to dev" -m "Original: ${ORIGINAL}"
+              git push origin "$BACKPORT_BRANCH"
+              echo "applied=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::error::The hotfix could not be applied cleanly to dev."
+            echo "This usually means the code has diverged and the fix must be backported manually."
+            exit 1
+          fi
+
+      - name: Create Pull Request
+        if: steps.apply.outputs.applied == 'true'
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BACKPORT_BRANCH="${{ steps.parse.outputs.backport_branch }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          BODY=$'This PR backports hotfix **'"${VERSION}"$'** to `dev`.\n\n'
+          BODY+="Original PR: ${{ github.event.pull_request.html_url }}"
+
+          gh pr create \
+            --repo ${{ github.repository }} \
+            --base dev \
+            --head "$BACKPORT_BRANCH" \
+            --title "chore: backport hotfix ${VERSION} to dev" \
+            --body "$BODY" 2>&1 || true
+
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --base dev --head "$BACKPORT_BRANCH" --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Failed to create or find backport PR"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Add automated label
+        if: steps.create-pr.outputs.pr_number != ''
+        run: |
+          gh pr edit "${{ steps.create-pr.outputs.pr_number }}" --add-label "automated"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assign PR to Milestone
+        if: steps.create-pr.outputs.pr_number != ''
+        uses: ./.github/actions/milestone/assign-pr
+        with:
+          pr-number: ${{ steps.create-pr.outputs.pr_number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch required PR checks
+        if: steps.create-pr.outputs.pr_number != ''
+        uses: ./.github/actions/dispatch-required-pr-checks
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ steps.parse.outputs.backport_branch }}
+          pr-number: ${{ steps.create-pr.outputs.pr_number }}
+          base-ref: dev
+          pr-title: "chore: backport hotfix ${{ steps.parse.outputs.version }} to dev"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pr_number != ''
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_number }}" --auto --merge \
+            || echo "::warning::Could not enable auto-merge. Please merge manually once approved."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-delete-auto-branches.yml
+++ b/.github/workflows/pr-delete-auto-branches.yml
@@ -16,6 +16,7 @@ name: pr-delete-auto-branches
 # - fix/*
 # - hash-update/*
 # - patch/*
+# - cascade/*
 # - devin/*
 # - backport/*
 #
@@ -53,6 +54,7 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'fix/') ||
       startsWith(github.event.pull_request.head.ref, 'hash-update/') ||
       startsWith(github.event.pull_request.head.ref, 'patch/') ||
+      startsWith(github.event.pull_request.head.ref, 'cascade/') ||
       startsWith(github.event.pull_request.head.ref, 'devin/') ||
       startsWith(github.event.pull_request.head.ref, 'backport/')
     runs-on: ubuntu-latest

--- a/.github/workflows/release-2-pr-to-dev-closed.yml
+++ b/.github/workflows/release-2-pr-to-dev-closed.yml
@@ -11,10 +11,12 @@ name: 🏁 2 PR Release to Main from Dev
 # Description: This workflow automatically creates a PR to merge a release branch into main (or main-X.Y.Z for stabilization paths).
 # When the release/* branch is merged to dev or dev-X.Y.Z.
 #
-# Before creating the release PR, it verifies that dev is rebased onto main.
-# If dev is behind main, it rebases and force-pushes dev. If the rebase fails
-# (e.g. due to conflicts), the workflow run fails so the problem surfaces in
-# GitHub Actions.
+# Before creating the release PR, it verifies that the source dev branch
+# (dev or dev-X.Y.Z) is rebased onto its matching main branch (main or main-X.Y.Z).
+# If the dev branch is behind, it rebases and force-pushes the matching dev branch.
+# The global `dev` branch is never touched during a stabilization release.
+# If the rebase fails (e.g. due to conflicts), the workflow run fails so the
+# problem surfaces in GitHub Actions.
 #
 # Triggers:
 # - Automatically when a PR to dev or dev-* is closed
@@ -44,7 +46,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: dev-rebase-onto-main
+  group: release-2-${{ github.event.pull_request.base.ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -58,36 +60,56 @@ jobs:
       issues: read
       pull-requests: write
     steps:
-      - name: Checkout dev
+      - name: Resolve target branches
+        if: ${{ github.event_name == 'pull_request' }}
+        id: resolve-targets
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEV_BRANCH="${{ github.event.pull_request.base.ref }}"
+          if [[ "$DEV_BRANCH" == dev-* ]]; then
+            SUFFIX="${DEV_BRANCH#dev-}"
+            TARGET_MAIN="main-${SUFFIX}"
+          else
+            TARGET_MAIN="main"
+          fi
+          echo "dev_branch=$DEV_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target_main=$TARGET_MAIN" >> "$GITHUB_OUTPUT"
+          echo "Source dev branch: $DEV_BRANCH"
+          echo "Target main branch: $TARGET_MAIN"
+
+      - name: Checkout dev branch
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: ${{ steps.resolve-targets.outputs.dev_branch }}
           fetch-depth: 0
 
-      - name: Ensure dev is rebased onto main
+      - name: Ensure dev branch is rebased onto its matching main
         if: ${{ github.event_name == 'pull_request' }}
         id: sync-check
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin main
+          DEV_BRANCH="${{ steps.resolve-targets.outputs.dev_branch }}"
+          TARGET_MAIN="${{ steps.resolve-targets.outputs.target_main }}"
+          git fetch origin "$TARGET_MAIN"
 
-          if git merge-base --is-ancestor origin/main HEAD; then
-            echo "dev is up to date with main"
+          if git merge-base --is-ancestor "origin/$TARGET_MAIN" HEAD; then
+            echo "$DEV_BRANCH is up to date with $TARGET_MAIN"
             echo "sync_needed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::dev is not a descendant of origin/main. A release PR cannot be created until dev is rebased onto main."
+            echo "::warning::$DEV_BRANCH is not a descendant of origin/$TARGET_MAIN. A release PR cannot be created until it is rebased."
             echo "sync_needed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Rebase and force-push dev onto main
+      - name: Rebase and force-push matching dev branch onto its main
         if: ${{ github.event_name == 'pull_request' && steps.sync-check.outputs.sync_needed == 'true' }}
         id: rebase
         uses: ./.github/actions/utils/rebase-onto-base
         with:
-          head-ref: dev
-          base-ref: main
+          head-ref: ${{ steps.resolve-targets.outputs.dev_branch }}
+          base-ref: ${{ steps.resolve-targets.outputs.target_main }}
           push: true
           token: ${{ secrets.GITHUB_TOKEN }}
           bot-name: ${{ vars.SMARTHOPPER_BOT_NAME }}
@@ -101,20 +123,13 @@ jobs:
           SOURCE_PR_TITLE: ${{ github.event.pull_request.head.ref }}
           SOURCE_PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          DEV_BRANCH="${{ github.event.pull_request.base.ref }}"
-          # If merging into dev-X.Y.Z, target main-X.Y.Z; otherwise target main
-          if [[ "$DEV_BRANCH" == dev-* ]]; then
-            SUFFIX="${DEV_BRANCH#dev-}"
-            TARGET_BRANCH="main-${SUFFIX}"
-          else
-            TARGET_BRANCH="main"
-          fi
-          MAIN_HEAD="$DEV_BRANCH"
+          DEV_BRANCH="${{ steps.resolve-targets.outputs.dev_branch }}"
+          TARGET_BRANCH="${{ steps.resolve-targets.outputs.target_main }}"
           echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
           gh pr create \
             --repo ${{ github.repository }} \
             --base "$TARGET_BRANCH" \
-            --head "$MAIN_HEAD" \
+            --head "$DEV_BRANCH" \
             --title "$SOURCE_PR_TITLE" \
             --body "$SOURCE_PR_BODY" 2>&1 || true
 

--- a/.github/workflows/release-3-pr-to-main-closed.yml
+++ b/.github/workflows/release-3-pr-to-main-closed.yml
@@ -151,6 +151,36 @@ jobs:
           suffix: ${{ steps.release_info.outputs.suffix }}
           mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
 
+      - name: Configure git
+        if: steps.dev_check.outputs.skip != 'true'
+        run: |
+          git config user.name "${{ vars.SMARTHOPPER_BOT_NAME }}"
+          git config user.email "${{ vars.SMARTHOPPER_BOT_EMAIL }}"
+
+      - name: Create annotated release tag
+        if: steps.dev_check.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.release_info.outputs.version }}"
+
+          # Fetch existing tags so we can tell whether the tag already exists.
+          git fetch --tags
+
+          if git ls-remote --tags origin "$VERSION" | grep -q "refs/tags/$VERSION"; then
+            echo "Tag $VERSION already exists on origin. Skipping tag creation."
+            exit 0
+          fi
+
+          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          if [ -n "$MERGE_SHA" ]; then
+            git tag -a "$VERSION" -m "Release $VERSION" "$MERGE_SHA"
+          else
+            git tag -a "$VERSION" -m "Release $VERSION"
+          fi
+          git push origin "$VERSION"
+          echo "Created annotated tag $VERSION."
+
       - name: Create Release
         if: steps.dev_check.outputs.skip != 'true'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/sync-dev-from-main.yml
+++ b/.github/workflows/sync-dev-from-main.yml
@@ -1,19 +1,27 @@
 name: Sync dev from main
 
-# Description: When `main` moves ahead of `dev`, this workflow rebases `dev` onto
-# `origin/main` and force-pushes the result. `dev` is configured for squash merges
-# only, so a merge commit cannot be used to bring `main` into `dev`.
+# Description: When `main` moves ahead of `dev`, this workflow creates a PR that
+# brings the non-version-specific changes from `main` back into `dev`.
 #
-# The force-push must be allowed for the workflow token. If it is not, the rebase
-# step fails and the whole workflow run fails, surfacing the problem in GitHub
-# Actions instead of opening an issue.
+# Version/changelog/manifest/README files are intentionally kept on the `dev`
+# side so `dev` does not lose its development version.  The resulting PR is
+# opened to `dev` and auto-merge is enabled; a codeowner still has to approve
+# before it merges.
+#
+# Related workflows:
+#   - release-2-pr-to-dev-closed.yml (creates the release PR from dev to main)
+#   - hotfix-backport.yml (backports a hotfix to dev after it merges to main)
+#   - pr-delete-auto-branches.yml (deletes the sync branch after the PR closes)
 #
 # Triggers:
 # - push to main
 # - workflow_dispatch
 #
 # Permissions:
-# - contents: write (to push the rebased dev branch)
+# - contents: write  - Required to create and push the sync branch
+# - pull-requests: write - Required to create the PR and enable auto-merge
+# - actions: write - Required to dispatch required PR checks
+# - issues: read - Required to assign the PR to the current milestone
 
 on:
   push:
@@ -23,43 +31,229 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+  actions: write
+  issues: read
 
 concurrency:
-  group: "dev-rebase-onto-main"
+  group: sync-dev-from-main
   cancel-in-progress: true
 
 jobs:
-  rebase-dev:
-    name: Rebase dev onto main
+  sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout dev
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: dev
+          fetch-depth: 0
 
-      - name: Fetch main and check sync status
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ vars.SMARTHOPPER_BOT_NAME }}"
+          git config user.email "${{ vars.SMARTHOPPER_BOT_EMAIL }}"
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Check if sync is needed
         id: check
         shell: bash
         run: |
-          git fetch origin main
           if git merge-base --is-ancestor origin/main HEAD; then
-            echo "dev is up to date with main"
-            echo "behind=false" >> "$GITHUB_OUTPUT"
+            echo "dev is already up to date with main"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "dev is behind main and will be rebased"
-            echo "behind=true" >> "$GITHUB_OUTPUT"
+            echo "main is ahead of dev; sync needed"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Rebase and force-push dev onto main
-        if: steps.check.outputs.behind == 'true'
-        uses: ./.github/actions/utils/rebase-onto-base
+      - name: Determine sync branch name
+        if: steps.check.outputs.needed == 'true'
+        id: branch
+        run: |
+          echo "sync_branch=chore/sync-dev-from-main-$(date +%Y%m%d-%H%M%S)" >> "$GITHUB_OUTPUT"
+
+      - name: Backport main changes to dev
+        if: steps.check.outputs.needed == 'true'
+        id: backport
+        shell: bash
+        run: |
+          set -euo pipefail
+          SYNC_BRANCH="${{ steps.branch.outputs.sync_branch }}"
+          git checkout -b "$SYNC_BRANCH"
+
+          # Files that carry a released version and should be kept on the dev side.
+          SKIP_FILES=(
+            "Solution.props"
+            "CHANGELOG.md"
+            "README.md"
+            "yak-package/manifest.yml"
+          )
+
+          # Commits on main that are not already in dev, in chronological order.
+          mapfile -t DELTA < <(git log --no-merges --cherry-pick --right-only --reverse \
+            --format=%H "origin/dev...origin/main")
+
+          APPLIED=()
+          SKIPPED=()
+          CONFLICTED=()
+
+          for sha in "${DELTA[@]}"; do
+            readarray -t files < <(git diff-tree --no-commit-id --name-only -r "$sha")
+
+            # Skip commits that only touch version/changelog/manifest/readme files.
+            all_skip=true
+            for f in "${files[@]}"; do
+              if [[ ! " ${SKIP_FILES[*]} " =~ " $f " ]]; then
+                all_skip=false
+                break
+              fi
+            done
+
+            if [ "$all_skip" = true ]; then
+              SKIPPED+=("$sha")
+              continue
+            fi
+
+            # Build a patch that omits the version-specific files.
+            patch_file="$(mktemp)"
+            git diff --binary "$sha"^.."$sha" -- . \
+              ':!Solution.props' \
+              ':!CHANGELOG.md' \
+              ':!README.md' \
+              ':!yak-package/manifest.yml' > "$patch_file"
+
+            # Skip if there are no non-version changes (e.g. a release prep on a squashed branch).
+            if [ ! -s "$patch_file" ]; then
+              SKIPPED+=("$sha")
+              rm "$patch_file"
+              continue
+            fi
+
+            if git apply --check "$patch_file" >/dev/null 2>&1; then
+              git apply "$patch_file"
+              git add -A
+
+              # Only commit if there are staged changes.
+              if git diff --cached --quiet; then
+                SKIPPED+=("$sha")
+              else
+                msg_file="$(mktemp)"
+                git log -1 --format='%B' "$sha" > "$msg_file"
+                author="$(git log -1 --format='%an <%ae>' "$sha")"
+                git commit -F "$msg_file" --author "$author"
+                APPLIED+=("$sha")
+                rm "$msg_file"
+              fi
+            else
+              CONFLICTED+=("$sha")
+            fi
+
+            rm "$patch_file"
+          done
+
+          {
+            echo "applied_count=${#APPLIED[@]}"
+            echo "skipped_count=${#SKIPPED[@]}"
+            echo "conflicted_count=${#CONFLICTED[@]}"
+            echo "applied=${APPLIED[*]}"
+            echo "skipped=${SKIPPED[*]}"
+            echo "conflicted=${CONFLICTED[*]}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "${#APPLIED[@]}" -eq 0 ]; then
+            if [ "${#CONFLICTED[@]}" -gt 0 ]; then
+              echo "::error::All candidate commits conflict with dev."
+              exit 1
+            fi
+            echo "No source changes to sync."
+            exit 0
+          fi
+
+          git push origin "$SYNC_BRANCH"
+
+      - name: Create Pull Request
+        if: steps.check.outputs.needed == 'true' && steps.backport.outputs.applied_count != '0'
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SYNC_BRANCH="${{ steps.branch.outputs.sync_branch }}"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "This PR syncs source changes from \`main\` back into \`dev\`."
+            echo
+            echo "Version, changelog, manifest and README changes are intentionally kept on the \`dev\` side."
+            echo
+            if [ "${{ steps.backport.outputs.applied_count }}" -gt 0 ]; then
+              echo "### Commits applied (${{ steps.backport.outputs.applied_count }})"
+              for sha in ${{ steps.backport.outputs.applied }}; do
+                git log -1 --format='- %h %s' "$sha"
+              done
+            fi
+            if [ "${{ steps.backport.outputs.skipped_count }}" -gt 0 ]; then
+              echo
+              echo "### Skipped (${{ steps.backport.outputs.skipped_count }})"
+              echo "Version/changelog/manifest/README-only commits:"
+              for sha in ${{ steps.backport.outputs.skipped }}; do
+                git log -1 --format='- %h %s' "$sha"
+              done
+            fi
+            if [ "${{ steps.backport.outputs.conflicted_count }}" -gt 0 ]; then
+              echo
+              echo "### ⚠️ Conflicts (${{ steps.backport.outputs.conflicted_count }})"
+              echo "These commits could not be applied automatically and must be handled manually if still relevant:"
+              for sha in ${{ steps.backport.outputs.conflicted }}; do
+                git log -1 --format='- %h %s' "$sha"
+              done
+            fi
+          } > "$BODY_FILE"
+
+          gh pr create \
+            --repo ${{ github.repository }} \
+            --base dev \
+            --head "$SYNC_BRANCH" \
+            --title "chore: sync dev from main" \
+            --body-file "$BODY_FILE" 2>&1 || true
+
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --base dev --head "$SYNC_BRANCH" --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::Failed to create or find sync PR"
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Add automated label
+        if: steps.create-pr.outputs.pr_number != ''
+        run: |
+          gh pr edit "${{ steps.create-pr.outputs.pr_number }}" --add-label "automated"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assign PR to Milestone
+        if: steps.create-pr.outputs.pr_number != ''
+        uses: ./.github/actions/milestone/assign-pr
         with:
-          head-ref: dev
-          base-ref: main
-          push: true
+          pr-number: ${{ steps.create-pr.outputs.pr_number }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          bot-name: ${{ vars.SMARTHOPPER_BOT_NAME }}
-          bot-email: ${{ vars.SMARTHOPPER_BOT_EMAIL }}
+
+      - name: Dispatch required PR checks
+        if: steps.create-pr.outputs.pr_number != ''
+        uses: ./.github/actions/dispatch-required-pr-checks
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ steps.branch.outputs.sync_branch }}
+          pr-number: ${{ steps.create-pr.outputs.pr_number }}
+          base-ref: dev
+          pr-title: "chore: sync dev from main"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pr_number != ''
+        run: |
+          gh pr merge "${{ steps.create-pr.outputs.pr_number }}" --auto --merge \
+            || echo "::warning::Could not enable auto-merge. Please merge manually once approved."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates the CI/release workflows to fix several versioning and branch-management issues:

- `release-2-pr-to-dev-closed.yml` now resolves the matching `dev-X.Y.Z`/`main-X.Y.Z` pair for stabilization paths and no longer checks or force-pushes the global `dev` branch during a stabilization release.
- `sync-dev-from-main.yml` is replaced with a PR-based sync: it opens a `chore/sync-dev-from-main-...` PR to `dev` that cherry-picks non-version changes from `main`, while keeping `Solution.props`, `CHANGELOG.md`, `README.md`, and `yak-package/manifest.yml` on the `dev` side. Auto-merge is enabled.
- New `hotfix-backport.yml` automatically backports hotfix PR diffs to `dev` (excluding version/changelog/manifest/README changes) and opens a `backport/hotfix-...` PR.
- `pr-delete-auto-branches.yml` now also deletes `cascade/*` branches on PR close.
- `chore-cleanup-stale-branches.yml` now also cleans `cascade/*` and `devin/*` branches older than 7 days (configurable) and with no open PRs.
- `release-3-pr-to-main-closed.yml` now creates an annotated `git tag -a` for each release before the GitHub release is created.

## Breaking Changes

None.

## Testing Done

- All 49 workflow YAML files parsed successfully.
- The `ci/workflow-fixes` branch is clean and only contains workflow changes.
- Branch pushed to `public`.

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [ ] Version in Solution.props was updated, if necessary, and follows semantic versioning
- [ ] CHANGELOG.md has been updated (skipped because this is a `ci` change; the changelog check in `pr-validation` will be skipped for `ci:` PRs)
- [x] PR title follows Conventional Commits format
- [x] PR description follows Pull Request Description Template