### PR TITLE
chore: centralize macOS/WinForms workaround and standardize project references

### DIFF
--- a/.github/workflows/pr-notes.yml
+++ b/.github/workflows/pr-notes.yml
@@ -210,8 +210,8 @@ jobs:
                   "--paginate",
                   "--jq",
                   'map(select(.body | contains("<!-- pr-notes:suggestion -->"))) | if length > 0 then last | {id, body} else null end',
-              )
-              data = json.loads(result)
+              ).strip()
+              data = json.loads(result) if result else None
               if data and data.get("body"):
                   previous_comment_id = str(data.get("id", ""))
                   previous_comment_body = data.get("body", "")
@@ -225,9 +225,6 @@ jobs:
                           previous_diff_hash = meta.get("diff_hash", "")
                       except Exception:
                           pass
-
-                  pathlib.Path(previous_title_file).write_text(previous_title, encoding="utf-8")
-                  pathlib.Path(previous_body_file).write_text(previous_body, encoding="utf-8")
 
                   first_run = "false"
                   if diff_hash == previous_diff_hash:
@@ -249,6 +246,9 @@ jobs:
               diff_changed = "true"
               needs_severity = "false"
               should_generate = "true"
+
+          pathlib.Path(previous_title_file).write_text(previous_title, encoding="utf-8")
+          pathlib.Path(previous_body_file).write_text(previous_body, encoding="utf-8")
 
           if needs_severity == "true":
               diff_text = pathlib.Path(diff_truncated_file).read_text(encoding="utf-8")
@@ -364,7 +364,10 @@ jobs:
           diff_hash = os.environ.get("DIFF_HASH", "")
 
           def _read_file_or_empty(path):
-              return pathlib.Path(path).read_text(encoding="utf-8") if path else ""
+              if not path:
+                  return ""
+              p = pathlib.Path(path)
+              return p.read_text(encoding="utf-8") if p.exists() else ""
 
           commits = _read_file_or_empty(os.environ.get("COMMITS_FILE", "")).splitlines()
           files = _read_file_or_empty(os.environ.get("FILES_FILE", "")).splitlines()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Many thanks to the following contributors to this release:
 - `pr-notes.yml` no longer posts fallback suggestions on subsequent runs, so only the first run uses the branch-based fallback.
 - The deterministic `## Testing Done` and `## Checklist` body sections have been moved from `pr-notes.yml` to `.github/prompts/pr-notes-static.md` so they can be edited independently.
 - Hardened `ComponentStateManager` debounce logic so stale timer callbacks are ignored after `StartDebounce`/`CancelDebounce`, preventing a race where an old or cancelled debounce could still trigger a state transition.
+- Fixed `pr-notes.yml` crash when the previous-suggestion lookup fails or returns unparsable output by always writing `previous-title.txt` and `previous-body.txt`, and by making the post-processing `_read_file_or_empty` helper tolerate missing files.
 
 ## [2.0.0-dev.260821] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Many thanks to the following contributors to this release:
 - ProviderTrustPolicy unknown-provider diagnostic now only suggests switching to `Hard` or `Strict` integrity mode when the current mode is `Soft`, avoiding misleading guidance when the provider is already blocked.
 - `pr-notes.yml` now updates the PR title automatically and posts description suggestions as PR comments (first suggestion in code blocks, later updates inside a `<details>` block with a reason), instead of editing the PR description directly.
 - `pr-validation.yml` now runs on `pull_request` again instead of being dispatched by `pr-notes.yml`, since title validation is handled by `pr-notes.yml`.
+- Centralized the macOS/WinForms `net48` reference-assembly workaround in `Directory.Build.props` and removed the duplicated workaround blocks from all affected `.csproj` files. `SmartHopper.Components` now conditions its `System.Drawing.Common` reference on the Windows TFM, and `SmartHopper.Core.Grasshopper` now uses a simple `ProjectReference` without explicit GUID metadata.
 
 ### Removed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,4 +36,12 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <!-- macOS workaround for .NET 7.0 projects that use WinForms types without the WindowsDesktop SDK. -->
+  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
+  </ItemGroup>
 </Project>

--- a/docs/Reviews/260828 SmartHopper Conceptual Quality Review.md
+++ b/docs/Reviews/260828 SmartHopper Conceptual Quality Review.md
@@ -51,12 +51,11 @@ The following review suggestions have been implemented since the review was writ
 | --- | --- | --- |
 | 1 | `ProviderTrustPolicy` enforcement before provider calls | `ProviderTrustPolicy` in `src/SmartHopper.ProviderSdk/AICall/Validation/ProviderTrustPolicy.cs` now decides block/warn/allow; `AIRequestCall.IsValid()` and `AIRequestCall.Exec()` enforce it |
 | 2 | `SmartHopper.Components.Test` Release build mapping | `SmartHopper.sln` still has `Release\|*` build entries for `{B932CFFA-0C82-4A1F-92F2-003CDE1C94AE}` (Components.Test) |
-| 3 | Centralize macOS/WinForms `net48` reference-assembly workaround | The workaround is still duplicated in ~18 `.csproj` files, including `SmartHopper.Components.Test.csproj` |
-| 4 | Use `IProviderHttpClientFactory` in `AIProvider.CallApi` / streaming / batch | `IProviderHttpClientFactory` exists and is registered in `SmartHopperInitializer`, but `AIProvider.CallApi` and `AIProviderStreamingAdapter.CreateHttpClient` still call `new HttpClient()` |
-| 5 | Provider contract / round-trip `Encode/Decode` tests | No round-trip contract tests for text/tool/image/audio interactions across providers |
-| 6 | Structured logging/tracing and metrics export | `IProviderLogger` exists and is registered, but provider code still uses ad-hoc `Debug.WriteLine`; `AIMetrics` are not exported to an external sink |
-| 7 | Hardcoded model capability lists | Each provider still returns a large `List<AIModelCapabilities>` from `*ProviderModels.cs` |
-| 8 | OpenAI-compatible role mapping consolidation | OpenAI, Mistral, LocalAI, and Ollama still contain identical `switch` role mappings in their `EncodeToJToken` paths |
+| 3 | Use `IProviderHttpClientFactory` in `AIProvider.CallApi` / streaming / batch | `IProviderHttpClientFactory` exists and is registered in `SmartHopperInitializer`, but `AIProvider.CallApi` and `AIProviderStreamingAdapter.CreateHttpClient` still call `new HttpClient()` |
+| 4 | Provider contract / round-trip `Encode/Decode` tests | No round-trip contract tests for text/tool/image/audio interactions across providers |
+| 5 | Structured logging/tracing and metrics export | `IProviderLogger` exists and is registered, but provider code still uses ad-hoc `Debug.WriteLine`; `AIMetrics` are not exported to an external sink |
+| 6 | Hardcoded model capability lists | Each provider still returns a large `List<AIModelCapabilities>` from `*ProviderModels.cs` |
+| 7 | OpenAI-compatible role mapping consolidation | OpenAI, Mistral, LocalAI, and Ollama still contain identical `switch` role mappings in their `EncodeToJToken` paths |
 
 ### Partially implemented
 
@@ -199,7 +198,7 @@ The following review suggestions have been implemented since the review was writ
 | OpenAI-compatible role mapping | `OpenAIProvider`, `MistralAIProvider`, `LocalAIProvider`, `OllamaProvider` | `StandardRoleMapper` in Provider SDK | Medium |
 | Per-provider test runner components | 43 files in `src/SmartHopper.Components.Test/Providers/` | Keep as independent provider test runners; extract a shared test-harness base for setup/teardown | Intentional (not duplication) — **Harness added** |
 | Hardcoded model capability lists | Every `*ProviderModels.cs` | JSON/fluent builder or external model manifest loaded by `AIProviderModels` | Medium |
-| WinForms/macOS reference workaround | ~20 `.csproj` files | Centralized in `Directory.Build.props` | High |
+| WinForms/macOS reference workaround | ~20 `.csproj` files | Centralized in `Directory.Build.props` | High — **Remediated** |
 
 ---
 
@@ -227,8 +226,10 @@ The following review suggestions have been implemented since the review was writ
 | 5 | **Fix `AIBody` immutability and `AIInteractionBase` mutability.** Make `AIBody.InteractionsNew` immutable, remove `ResetNew()` if unused, and use init-only setters or a builder for `AIInteractionBase`. | Small | Medium. Aligns the domain model with the documented immutability goal. **Done.** |
 | 6 | **Introduce a `ProviderTrustPolicy` that enforces integrity checks before the provider call.** In `Soft`/`Hard`/`Strict` modes, decide whether to block, warn, or allow; do not rely only on `IsValid` messages. | Small | High. Closes the security enforcement gap without changing the contract. **Done.** |
 | 7 | **Fix the `SmartHopper.Components.Test` Release build mapping.** Add `DisableBuild` condition or remove Release solution configurations for the project. | Small | Medium. Aligns build behavior with documented intent. **Done.** |
-| 8 | **Centralize macOS/WinForms workaround and standardize project references.** Move the `net48` reference-assembly logic to `Directory.Build.props` and remove explicit GUIDs from `ProjectReference`. | Small–Medium | Medium. Reduces csproj duplication and build maintenance. |
+| 8 | **Centralize macOS/WinForms workaround and standardize project references.** Move the `net48` reference-assembly logic to `Directory.Build.props` and remove explicit GUIDs from `ProjectReference`. | Small–Medium | Medium. Reduces csproj duplication and build maintenance. **Done.** |
 | 9 | **Add provider contract / round-trip tests and HTTP fakes.** Use `IProviderHttpClientFactory` in `AIProvider.CallApi` and provide a mock message handler. | Medium | Medium. Improves testability and catches provider drift. |
 | 10 | **Introduce structured logging/tracing and metrics export.** Replace ad-hoc `Debug.WriteLine` with an `IProviderLogger` implementation that supports scopes/correlation; export `AIMetrics` to a sink. | Large | Medium. Needed for production observability but can follow the other items. |
 
 *Implementation status updated to reflect the `ProviderTrustPolicy` work on branch `feature/2.0.0-provider-trust-policy`.*
+
+*Implementation status for the macOS/WinForms workaround updated to reflect the work on branch `chore/2.0.0-dev.260901-centralize-winforms`.*

--- a/src/SmartHopper.Components.Test/SmartHopper.Components.Test.csproj
+++ b/src/SmartHopper.Components.Test/SmartHopper.Components.Test.csproj
@@ -63,16 +63,7 @@
     <ProjectReference Include="..\SmartHopper.Providers.OpenRouter\SmartHopper.Providers.OpenRouter.csproj" />
   </ItemGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Components/SmartHopper.Components.csproj
+++ b/src/SmartHopper.Components/SmartHopper.Components.csproj
@@ -44,7 +44,7 @@
       <Source>https://mcneel.jfrog.io/artifactory/api/nuget/rhino-packages</Source>
     </PackageReference>
     <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.11" Condition="$(TargetFramework.Contains('-windows'))" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,16 +58,7 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <!-- <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" /> -->  <!-- Already referenced above -->
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Core.Grasshopper/SmartHopper.Core.Grasshopper.csproj
+++ b/src/SmartHopper.Core.Grasshopper/SmartHopper.Core.Grasshopper.csproj
@@ -59,10 +59,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SmartHopper.Infrastructure\SmartHopper.Infrastructure.csproj" />
-    <ProjectReference Include="..\SmartHopper.Core\SmartHopper.Core.csproj">
-      <Project>{D4C6D3D5-2B3A-4B6C-8C3D-57B2D0D3C1E1}</Project>
-      <Name>SmartHopper.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\SmartHopper.Core\SmartHopper.Core.csproj" />
     <ProjectReference Include="..\..\..\ghjson-dotnet\src\GhJSON.Core\GhJSON.Core.csproj" Condition="'$(UseLocalGhJsonSource)' == 'true' AND Exists('..\..\..\ghjson-dotnet\src\GhJSON.Core\GhJSON.Core.csproj')" />
     <ProjectReference Include="..\..\..\ghjson-dotnet\src\GhJSON.Grasshopper\GhJSON.Grasshopper.csproj" Condition="'$(UseLocalGhJsonSource)' == 'true' AND Exists('..\..\..\ghjson-dotnet\src\GhJSON.Grasshopper\GhJSON.Grasshopper.csproj')" />
     <PackageReference Include="GhJSON.Core" Version="1.1.1" Condition="'$(UseLocalGhJsonSource)' != 'true' OR !Exists('..\..\..\ghjson-dotnet\src\GhJSON.Core\GhJSON.Core.csproj')" />
@@ -74,16 +71,7 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <!-- Embed GhJSON specification markdown documents for the smarthopper_ghjson_reference tool.
        The committed snapshot under Resources/GhJsonSpec/v1.0 is authoritative at build time.

--- a/src/SmartHopper.Core.Tests/SmartHopper.Core.Tests.csproj
+++ b/src/SmartHopper.Core.Tests/SmartHopper.Core.Tests.csproj
@@ -50,11 +50,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS;NET7_WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
   <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
     <!-- Prevent transitive WindowsDesktop framework references from propagating to testhost -->
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App" />
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />

--- a/src/SmartHopper.Core/SmartHopper.Core.csproj
+++ b/src/SmartHopper.Core/SmartHopper.Core.csproj
@@ -70,16 +70,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Infrastructure.Tests/SmartHopper.Infrastructure.Tests.csproj
+++ b/src/SmartHopper.Infrastructure.Tests/SmartHopper.Infrastructure.Tests.csproj
@@ -53,15 +53,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS;NET7_WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
   <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
-
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
     <!-- Prevent transitive WindowsDesktop framework references from propagating to testhost -->
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App" />
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />

--- a/src/SmartHopper.Infrastructure/SmartHopper.Infrastructure.csproj
+++ b/src/SmartHopper.Infrastructure/SmartHopper.Infrastructure.csproj
@@ -49,15 +49,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
+
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />
   </ItemGroup>

--- a/src/SmartHopper.Menu/SmartHopper.Menu.csproj
+++ b/src/SmartHopper.Menu/SmartHopper.Menu.csproj
@@ -58,16 +58,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj
+++ b/src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj
@@ -51,11 +51,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS;NET7_WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
   <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
     <!-- Prevent transitive WindowsDesktop framework references from propagating to testhost -->
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App" />
     <FrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />

--- a/src/SmartHopper.ProviderSdk/SmartHopper.ProviderSdk.csproj
+++ b/src/SmartHopper.ProviderSdk/SmartHopper.ProviderSdk.csproj
@@ -52,11 +52,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
+
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\..\.editorconfig" />

--- a/src/SmartHopper.Providers.Anthropic/SmartHopper.Providers.Anthropic.csproj
+++ b/src/SmartHopper.Providers.Anthropic/SmartHopper.Providers.Anthropic.csproj
@@ -50,16 +50,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.DeepSeek/SmartHopper.Providers.DeepSeek.csproj
+++ b/src/SmartHopper.Providers.DeepSeek/SmartHopper.Providers.DeepSeek.csproj
@@ -45,16 +45,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.Gemini/SmartHopper.Providers.Gemini.csproj
+++ b/src/SmartHopper.Providers.Gemini/SmartHopper.Providers.Gemini.csproj
@@ -51,16 +51,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.LocalAI/SmartHopper.Providers.LocalAI.csproj
+++ b/src/SmartHopper.Providers.LocalAI/SmartHopper.Providers.LocalAI.csproj
@@ -45,16 +45,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.MistralAI/SmartHopper.Providers.MistralAI.csproj
+++ b/src/SmartHopper.Providers.MistralAI/SmartHopper.Providers.MistralAI.csproj
@@ -49,16 +49,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.Ollama/SmartHopper.Providers.Ollama.csproj
+++ b/src/SmartHopper.Providers.Ollama/SmartHopper.Providers.Ollama.csproj
@@ -45,16 +45,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.OpenAI/SmartHopper.Providers.OpenAI.csproj
+++ b/src/SmartHopper.Providers.OpenAI/SmartHopper.Providers.OpenAI.csproj
@@ -45,16 +45,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- Reference WinForms for .NET 7.0 on macOS -->
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <!-- Rhino 8.11 and later you can use this -->
-    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
 
-    <!-- Rhino 8.10 and earlier -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />

--- a/src/SmartHopper.Providers.OpenRouter/SmartHopper.Providers.OpenRouter.csproj
+++ b/src/SmartHopper.Providers.OpenRouter/SmartHopper.Providers.OpenRouter.csproj
@@ -43,11 +43,7 @@
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.11" ExcludeAssets="runtime" />
-  </ItemGroup>
+
 
   <ItemGroup>
     <EditorConfigFiles Remove="..\.editorconfig" />


### PR DESCRIPTION
## Description
Centralized the macOS/WinForms `net48` reference-assembly workaround in `Directory.Build.props` and removed duplicated blocks from all affected `.csproj` files. `SmartHopper.Components` now conditions its `System.Drawing.Common` reference on the Windows TFM, and `SmartHopper.Core.Grasshopper` uses a simplified `ProjectReference` without explicit GUID metadata. Fixed `pr-notes.yml` crash when the previous-suggestion lookup fails or returns unparsable output by always writing `previous-title.txt` and `previous-body.txt`, and by making the post-processing `_read_file_or_empty` helper tolerate missing files.

## Breaking Changes
No

## Testing Done

_Not verified by automation — to be completed by the author._

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] CHANGELOG.md has been updated with relevant information to end user