### PR TITLE
feat(context): add selection and viewport context providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ Many thanks to the following contributors to this release:
 - Added automatic `version:` labeling for pull requests and issues. `pr-milestone.yml` now delegates to the `milestone/assign-pr` action; `milestone/assign-pr`, `github-issue-label-version-from-template.yml`, and `create-version-label` all use the shared `versioning/normalize-version` action to produce a milestone-aligned `version:` label (e.g. `version: 2.0.0-alpha` for `2.0.0-dev.260901`), creating the label if it does not exist.
 - Added `TestProviderHttpClientFactory`, `FakeAIProvider`, `FakeProviderModels`, and `FakeProviderRegistryHost` to `SmartHopper.ProviderSdk.Tests/TestHelpers` to support deterministic, network-free provider contract/round-trip tests.
 - Added `AIProviderCallTests` in `SmartHopper.ProviderSdk.Tests/AIProviders` covering text and tool-call round-trips, authorization header propagation, request encoding, and provider error handling using an in-memory HTTP fake.
+- Added `SelectionContextProvider` and `ViewportContextProvider` in `SmartHopper.Core/AIContext`, registered by default through `AIContextBootstrapper`. WebChat now includes `selection` and `viewport` in its default context filter.
 
 ### Changed
 
+- `FileContextProvider` no longer reports selected object metadata. Use the new `SelectionContextProvider` for `selected-count`, `selected-objects`, `selected-topology`, and `selected-runtime-values`.
 - Removed redundant `new` modifiers on `provider` fields in first-party `*ProviderSettings` classes; the base `AIProviderSettings` does not expose a conflicting accessible member, so the modifier only produced compiler warnings.
 - Releases now come from a single `main` branch with on-demand stabilization lines: a release is prepared on demand, tagged when its pull request merges, and published as a draft release. Version tags are the source of truth for released versions.
 - Hotfixes now branch from the release tag they patch and are backported automatically to active release lines.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SmartHopper - AI-Powered Tools and Assistant for Grasshopper3D
 
-[![Version](https://img.shields.io/badge/version-2.0.0--dev.260905-brown?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
+[![Version](https://img.shields.io/badge/version-2.0.0--dev.260906-brown?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![Status](https://img.shields.io/badge/status-Unstable%20Development-brown?style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/releases)
 [![.NET CI](https://img.shields.io/github/actions/workflow/status/architects-toolkit/SmartHopper/.github/workflows/ci-dotnet-tests.yml?label=tests&logo=dotnet&style=for-the-badge)](https://github.com/architects-toolkit/SmartHopper/actions/workflows/ci-dotnet-tests.yml)
 [![Ready to use](https://img.shields.io/badge/ready_to_use-NO-brown?style=for-the-badge)](https://smarthopper.xyz/#installation)

--- a/Solution.props
+++ b/Solution.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SolutionVersion>2.0.0-dev.260905</SolutionVersion>
+    <SolutionVersion>2.0.0-dev.260906</SolutionVersion>
   </PropertyGroup>
 </Project>

--- a/docs/Context/index.md
+++ b/docs/Context/index.md
@@ -8,9 +8,9 @@ Context providers enrich AI requests with environment information (such as time)
 
 | Property | Value |
 | --- | --- |
-| **Source Code** | `src/SmartHopper.Core/Context/` |
-| **Since Version** | ? |
-| **Last Updated** | 2026-06-14 |
+| **Source Code** | `src/SmartHopper.Core/AIContext/` |
+| **Since Version** | 2.0.0-dev.260905 |
+| **Last Updated** | 2026-09-05 |
 | **Documentation Maintainer** | Devin AI |
 
 _Note: This documentation was written by AI on its own. It may contain some mistakes. If you would like to help, read this documentation and delete this comment if everything is okay._
@@ -45,13 +45,15 @@ Supply dynamic key-value context injected into `AIBody` so prompts and tools can
 
 - `time`: provides `time_current-datetime`, `time_current-timezone`
 - `environment`: provides `environment_operating-system`, `environment_rhino-version`, `environment_platform`
-- `current-file`: provides `current-file-file-name`, `current-file-selected-count`, `current-file-selected-component-count`, `current-file-selected-param-count`, `current-file-selected-objects`, `current-file-object-count`, `current-file-component-count`, `current-file-param-count`, `current-file-scribble-count`, `current-file-group-count`
+- `current-file`: provides `current-file-file-name`, `current-file-object-count`, `current-file-component-count`, `current-file-param-count`, `current-file-scribble-count`, `current-file-group-count`
+- `selection`: provides `selection_selected-count`, `selection_selected-component-count`, `selection_selected-param-count`, `selection_selected-objects`, `selection_selected-topology`, `selection_selected-runtime-values`
+- `viewport`: provides `viewport_viewport-bounds`, `viewport_viewport-center`, `viewport_viewport-zoom`, `viewport_viewport-visible-count`, `viewport_viewport-visible-objects`
 
 ### WebChat defaults
 
 WebChat (both the Canvas Button and the AIChatComponent dialog) enables a curated context set by default:
 
-- `time, environment, current-file`
+- `time, environment, current-file, selection, viewport`
 
 ---
 
@@ -64,6 +66,8 @@ WebChat (both the Canvas Button and the AIChatComponent dialog) enables a curate
   - `EnvironmentContextProvider` (ProviderId: `environment`)
   - `TimeContextProvider` (ProviderId: `time`)
   - `FileContextProvider` (ProviderId: `current-file`)
+  - `SelectionContextProvider` (ProviderId: `selection`)
+  - `ViewportContextProvider` (ProviderId: `viewport`)
 
 ### Bootstrapping
 
@@ -76,7 +80,9 @@ Context providers are registered at startup via `AIContextBootstrapper`, ensurin
 - **Registered providers**:
   - `TimeContextProvider` — provides current date/time and timezone
   - `EnvironmentContextProvider` — provides OS, Rhino version, and platform info
-  - `FileContextProvider` — provides current file and selection metadata
+  - `FileContextProvider` — provides current document-level counts and file name
+  - `SelectionContextProvider` — provides full metadata, topology, and runtime preview for selected objects
+  - `ViewportContextProvider` — provides the visible canvas bounds and the objects on screen
 - **Registration mechanism**: Uses `AIContextManager.RegisterProvider()` which is idempotent by ProviderId
 - **Error handling**: Initialization errors are logged to debug output but do not throw
 
@@ -85,7 +91,7 @@ Context providers are registered at startup via `AIContextBootstrapper`, ensurin
 1. Assembly loads → `[ModuleInitializer]` attribute triggers `Init()`
 2. `Init()` calls `EnsureInitialized()`
 3. Double-checked lock ensures single initialization
-4. All three default providers are registered with `AIContextManager`
+4. All five default providers are registered with `AIContextManager`
 5. Subsequent calls to `EnsureInitialized()` return early (no-op)
 
 ### Usage
@@ -128,7 +134,7 @@ The context system is intentionally minimal and privacy-aware:
 
 - **Minimal footprint**: Each provider returns a small, well-scoped dictionary. There are no large serialized objects or unbounded collections.
 - **Deterministic keys**: Provider keys follow a `providerid_key-name` convention so collisions are avoided and consumers can reliably check for specific values.
-- **Privacy by design**: Sensitive data is not collected. File context exposes counts and names, not full geometry or proprietary data.
+- **Privacy by design**: Sensitive data is not collected. File context exposes counts and names, not full geometry or proprietary data. `selection` and `viewport` expose richer metadata by default; users can exclude them with a context filter such as `time, environment, current-file, -selection, -viewport`.
 - **Whitelist-friendly**: Consumers can filter the full context map to only the keys they need, making it easy to audit what information is actually sent to an AI provider.
 
 Guidance for extending the system:

--- a/src/SmartHopper.Core/AIContext/AIContextBootstrapper.cs
+++ b/src/SmartHopper.Core/AIContext/AIContextBootstrapper.cs
@@ -19,7 +19,7 @@
 /*
  * AIContextBootstrapper
  * Purpose: Centralized, idempotent initializer for context providers that should be globally available.
- * Currently registers SelectionContextProvider so it can be used by both AIChat and CanvasButton scenarios.
+ * Registers time, environment, file, selection, and viewport providers so they are available to chat and AI components.
  */
 
 using System;
@@ -62,6 +62,8 @@ namespace SmartHopper.Core.AIContext
                     AIContextManager.RegisterProvider(new TimeContextProvider());
                     AIContextManager.RegisterProvider(new EnvironmentContextProvider());
                     AIContextManager.RegisterProvider(new FileContextProvider());
+                    AIContextManager.RegisterProvider(new SelectionContextProvider());
+                    AIContextManager.RegisterProvider(new ViewportContextProvider());
                     _initialized = true;
                     Debug.WriteLine("[AIContextBootstrapper] Context providers initialized");
                 }

--- a/src/SmartHopper.Core/AIContext/FileContextProvider.cs
+++ b/src/SmartHopper.Core/AIContext/FileContextProvider.cs
@@ -20,14 +20,19 @@
  * FileContextProvider
  * Purpose: Provides live-updating context about the current Grasshopper file.
  * Currently includes:
- *  - selected-count: number of selected Grasshopper objects
- *  - component-count: total number of components in the document
+ *  - file-name: the current document file name or "Untitled".
+ *  - object-count: total number of document objects.
+ *  - component-count: total number of components in the document.
+ *  - param-count: total number of parameters in the document.
+ *  - scribble-count: total number of scribbles/notes in the document.
+ *  - group-count: total number of groups in the document.
  * This provider computes values on demand (no event wiring), so values are always fresh
  * whenever AIContextManager.GetCurrentContext() is called.
  */
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -41,7 +46,7 @@ using SmartHopper.Infrastructure.AIContext;
 namespace SmartHopper.Core.AIContext
 {
     /// <summary>
-    /// Context provider that supplies the current number of selected Grasshopper objects.
+    /// Context provider that supplies document-level metadata about the current Grasshopper file.
     /// </summary>
     public class FileContextProvider : IAIContextProvider
     {
@@ -54,7 +59,6 @@ namespace SmartHopper.Core.AIContext
         /// Gets the current file context for AI queries.
         /// Returns the following keys:
         ///  - "file-name": the current document file name or "Untitled".
-        ///  - "selected-count": number of selected objects in the current document.
         ///  - "object-count": total number of document objects.
         ///  - "component-count": total number of components in the current document.
         ///  - "param-count": total number of parameters in the current document.
@@ -62,15 +66,12 @@ namespace SmartHopper.Core.AIContext
         ///  - "group-count": total number of groups in the current document.
         /// </summary>
         /// <returns>A dictionary containing the current file context values.</returns>
+        [SuppressMessage("Design", "CA1031", Justification = "Context providers must be resilient and never crash the AI request pipeline.")]
         public Dictionary<string, string> GetContext()
         {
             try
             {
                 string fileName = "Untitled";
-                int selectedCount = 0;
-                int selectedComponentCount = 0;
-                int selectedParamCount = 0;
-                string selectedObjects = string.Empty;
                 int componentCount = 0;
                 int objectCount = 0;
                 int paramCount = 0;
@@ -105,31 +106,6 @@ namespace SmartHopper.Core.AIContext
                                 {
                                     fileName = Path.GetFileName(path);
                                 }
-
-                                // Selected objects.
-                                // NOTE: When this context is queried from background worker threads, selection state can be stale.
-                                // To keep it reliable, we always read it on the Rhino UI thread.
-                                var selected = doc.SelectedObjects()?.OfType<IGH_DocumentObject>()?.ToList();
-                                if (selected == null || selected.Count == 0)
-                                {
-                                    selected = doc.Objects
-                                        ?.OfType<IGH_DocumentObject>()
-                                        ?.Where(o => o?.Attributes?.Selected == true)
-                                        ?.ToList();
-                                }
-
-                                selectedCount = selected?.Count ?? 0;
-                                selectedComponentCount = selected?.OfType<IGH_Component>()?.Count() ?? 0;
-                                selectedParamCount = selected?.OfType<IGH_Param>()?.Count() ?? 0;
-
-                                if (selected != null && selected.Count > 0)
-                                {
-                                    selectedObjects = string.Join(
-                                        "; ",
-                                        selected
-                                            .Take(10)
-                                            .Select(o => $"{(string.IsNullOrWhiteSpace(o.NickName) ? o.Name : o.NickName)} ({o.GetType().Name})"));
-                                }
                             }
                             finally
                             {
@@ -144,10 +120,6 @@ namespace SmartHopper.Core.AIContext
                 var result = new Dictionary<string, string>
                 {
                     { "file-name", fileName },
-                    { "selected-count", selectedCount.ToString(CultureInfo.InvariantCulture) },
-                    { "selected-component-count", selectedComponentCount.ToString(CultureInfo.InvariantCulture) },
-                    { "selected-param-count", selectedParamCount.ToString(CultureInfo.InvariantCulture) },
-                    { "selected-objects", selectedObjects },
                     { "object-count", objectCount.ToString(CultureInfo.InvariantCulture) },
                     { "component-count", componentCount.ToString(CultureInfo.InvariantCulture) },
                     { "param-count", paramCount.ToString(CultureInfo.InvariantCulture) },
@@ -180,10 +152,6 @@ namespace SmartHopper.Core.AIContext
                 var fallback = new Dictionary<string, string>
                 {
                     { "file-name", "Untitled" },
-                    { "selected-count", "0" },
-                    { "selected-component-count", "0" },
-                    { "selected-param-count", "0" },
-                    { "selected-objects", string.Empty },
                     { "object-count", "0" },
                     { "component-count", "0" },
                     { "param-count", "0" },

--- a/src/SmartHopper.Core/AIContext/SelectionContextProvider.cs
+++ b/src/SmartHopper.Core/AIContext/SelectionContextProvider.cs
@@ -1,0 +1,341 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Grasshopper;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Newtonsoft.Json;
+using Rhino;
+using SmartHopper.Infrastructure.AIContext;
+
+namespace SmartHopper.Core.AIContext
+{
+    /// <summary>
+    /// Context provider that supplies full metadata about the currently selected
+    /// Grasshopper objects, including their topology and a small runtime preview.
+    /// </summary>
+    public class SelectionContextProvider : IAIContextProvider
+    {
+        /// <summary>
+        /// Maximum number of selected objects to include in the detailed list.
+        /// </summary>
+        private const int MaxSelectedObjects = 25;
+
+        /// <summary>
+        /// Maximum number of output parameters sampled for runtime preview per component.
+        /// </summary>
+        private const int MaxOutputsPerComponent = 5;
+
+        /// <summary>
+        /// Maximum number of data-tree branches to sample per output parameter.
+        /// </summary>
+        private const int MaxBranchesPerOutput = 3;
+
+        /// <summary>
+        /// Maximum number of items to sample per branch.
+        /// </summary>
+        private const int MaxItemsPerBranch = 3;
+
+        /// <summary>
+        /// Maximum length of a single branch preview string.
+        /// </summary>
+        private const int MaxBranchPreviewLength = 50;
+
+        /// <summary>
+        /// Maximum total length of a runtime preview string.
+        /// </summary>
+        private const int MaxTotalPreviewLength = 200;
+
+        /// <summary>
+        /// Gets the provider identifier.
+        /// </summary>
+        public string ProviderId => "selection";
+
+        /// <summary>
+        /// Gets the current selection context for AI queries.
+        /// </summary>
+        /// <returns>A dictionary containing the current selection context values.</returns>
+        [SuppressMessage("Design", "CA1031", Justification = "Context providers must be resilient and never crash the AI request pipeline.")]
+        public Dictionary<string, string> GetContext()
+        {
+            try
+            {
+                int selectedCount = 0;
+                int selectedComponentCount = 0;
+                int selectedParamCount = 0;
+                string selectedObjectsJson = "[]";
+                string selectedTopologyJson = "[]";
+                string selectedRuntimeValuesJson = "[]";
+
+                using (var uiThreadComplete = new ManualResetEventSlim(false))
+                {
+                    RhinoApp.InvokeOnUiThread(
+                        (Action)(() =>
+                        {
+                            try
+                            {
+                                var canvas = Instances.ActiveCanvas;
+                                var doc = canvas?.Document;
+                                if (doc == null)
+                                {
+                                    return;
+                                }
+
+                                var selected = doc.Objects
+                                    ?.OfType<IGH_DocumentObject>()
+                                    ?.Where(o => o?.Attributes?.Selected == true)
+                                    ?.ToList();
+
+                                selectedCount = selected?.Count ?? 0;
+                                selectedComponentCount = selected?.OfType<IGH_Component>().Count() ?? 0;
+                                selectedParamCount = selected?.OfType<IGH_Param>().Count() ?? 0;
+
+                                if (selected != null && selected.Count > 0)
+                                {
+                                    var objectInfos = new List<object>();
+                                    var topology = new List<object>();
+                                    var runtimeValues = new List<object>();
+
+                                    var selectedGuids = new HashSet<Guid>(selected.Select(o => o.InstanceGuid));
+
+                                    foreach (var obj in selected.Take(MaxSelectedObjects))
+                                    {
+                                        objectInfos.Add(BuildObjectInfo(obj));
+                                        CollectTopology(obj, selectedGuids, topology);
+                                        CollectRuntimePreview(obj, runtimeValues);
+                                    }
+
+                                    selectedObjectsJson = JsonConvert.SerializeObject(objectInfos);
+                                    selectedTopologyJson = JsonConvert.SerializeObject(topology);
+                                    selectedRuntimeValuesJson = JsonConvert.SerializeObject(runtimeValues);
+                                }
+                            }
+                            finally
+                            {
+                                uiThreadComplete.Set();
+                            }
+                        }));
+
+                    uiThreadComplete.Wait(TimeSpan.FromSeconds(5));
+                }
+
+                return new Dictionary<string, string>
+                {
+                    { "selected-count", selectedCount.ToString(CultureInfo.InvariantCulture) },
+                    { "selected-component-count", selectedComponentCount.ToString(CultureInfo.InvariantCulture) },
+                    { "selected-param-count", selectedParamCount.ToString(CultureInfo.InvariantCulture) },
+                    { "selected-objects", selectedObjectsJson },
+                    { "selected-topology", selectedTopologyJson },
+                    { "selected-runtime-values", selectedRuntimeValuesJson },
+                };
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SelectionContextProvider] Error: {ex.Message}");
+                return GetFallback();
+            }
+        }
+
+        /// <summary>
+        /// Returns a fallback dictionary when the active canvas cannot be read.
+        /// </summary>
+        private static Dictionary<string, string> GetFallback()
+        {
+            return new Dictionary<string, string>
+            {
+                { "selected-count", "0" },
+                { "selected-component-count", "0" },
+                { "selected-param-count", "0" },
+                { "selected-objects", "[]" },
+                { "selected-topology", "[]" },
+                { "selected-runtime-values", "[]" },
+            };
+        }
+
+        /// <summary>
+        /// Builds a compact information object for a single selected document object.
+        /// </summary>
+        private static object BuildObjectInfo(IGH_DocumentObject obj)
+        {
+            return new
+            {
+                instanceGuid = obj.InstanceGuid,
+                name = obj.Name,
+                nickName = string.IsNullOrWhiteSpace(obj.NickName) ? obj.Name : obj.NickName,
+                type = obj.GetType().Name,
+                pivot = new
+                {
+                    x = obj.Attributes?.Pivot.X ?? 0f,
+                    y = obj.Attributes?.Pivot.Y ?? 0f,
+                },
+                selected = obj.Attributes?.Selected ?? false,
+                locked = (obj as IGH_ActiveObject)?.Locked ?? false,
+            };
+        }
+
+        /// <summary>
+        /// Collects wire connections whose source and target both belong to the selected set.
+        /// </summary>
+        private static void CollectTopology(IGH_DocumentObject obj, HashSet<Guid> selectedGuids, List<object> topology)
+        {
+            IList<IGH_Param>? outputs = null;
+
+            if (obj is IGH_Component component)
+            {
+                outputs = component.Params.Output;
+            }
+            else if (obj is IGH_Param param)
+            {
+                outputs = new[] { param };
+            }
+
+            if (outputs == null)
+            {
+                return;
+            }
+
+            foreach (var output in outputs)
+            {
+                foreach (var recipient in output.Recipients)
+                {
+                    var targetObj = recipient.Attributes?.GetTopLevel?.DocObject;
+                    if (targetObj != null && selectedGuids.Contains(targetObj.InstanceGuid))
+                    {
+                        topology.Add(new
+                        {
+                            sourceGuid = obj.InstanceGuid,
+                            sourceParam = string.IsNullOrWhiteSpace(output.NickName) ? output.Name : output.NickName,
+                            targetGuid = targetObj.InstanceGuid,
+                            targetParam = string.IsNullOrWhiteSpace(recipient.NickName) ? recipient.Name : recipient.NickName,
+                        });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Collects a short preview of the runtime values for a selected object.
+        /// </summary>
+        private static void CollectRuntimePreview(IGH_DocumentObject obj, List<object> runtimeValues)
+        {
+            if (obj is IGH_Component component)
+            {
+                var outputPreviews = new List<object>();
+
+                foreach (var output in component.Params.Output.Take(MaxOutputsPerComponent))
+                {
+                    var preview = BuildOutputPreview(output);
+                    if (!string.IsNullOrWhiteSpace(preview))
+                    {
+                        outputPreviews.Add(new { name = string.IsNullOrWhiteSpace(output.NickName) ? output.Name : output.NickName, preview });
+                    }
+                }
+
+                if (outputPreviews.Count > 0)
+                {
+                    runtimeValues.Add(new
+                    {
+                        instanceGuid = component.InstanceGuid,
+                        outputs = outputPreviews,
+                    });
+                }
+            }
+            else if (obj is IGH_Param param)
+            {
+                var preview = BuildOutputPreview(param);
+                if (!string.IsNullOrWhiteSpace(preview))
+                {
+                    runtimeValues.Add(new
+                    {
+                        instanceGuid = param.InstanceGuid,
+                        outputs = new[]
+                        {
+                            new { name = string.IsNullOrWhiteSpace(param.NickName) ? param.Name : param.NickName, preview },
+                        },
+                    });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds a short, human-readable preview of the data flowing through a parameter.
+        /// </summary>
+        [SuppressMessage("Design", "CA1031", Justification = "Best-effort preview; failures should return empty rather than bubble up.")]
+        private static string BuildOutputPreview(IGH_Param param)
+        {
+            try
+            {
+                var data = param.VolatileData;
+                if (data == null)
+                {
+                    return string.Empty;
+                }
+
+                var previews = new List<string>();
+
+                foreach (var path in data.Paths.Take(MaxBranchesPerOutput))
+                {
+                    var branch = data.get_Branch(path);
+                    if (branch == null)
+                    {
+                        continue;
+                    }
+
+                    var items = branch
+                        .OfType<IGH_Goo>()
+                        .Take(MaxItemsPerBranch)
+                        .Select(g => g?.ToString())
+                        .Where(s => !string.IsNullOrWhiteSpace(s));
+
+                    var previewText = string.Join(", ", items);
+
+                    if (previewText.Length > MaxBranchPreviewLength)
+                    {
+                        previewText = string.Concat(previewText.AsSpan(0, MaxBranchPreviewLength), "...");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(previewText))
+                    {
+                        previews.Add($"{path}: {previewText}");
+                    }
+                }
+
+                var result = string.Join("; ", previews);
+
+                if (result.Length > MaxTotalPreviewLength)
+                {
+                    result = string.Concat(result.AsSpan(0, MaxTotalPreviewLength), "...");
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SelectionContextProvider] BuildOutputPreview error: {ex.Message}");
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core/AIContext/ViewportContextProvider.cs
+++ b/src/SmartHopper.Core/AIContext/ViewportContextProvider.cs
@@ -1,0 +1,168 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Grasshopper;
+using Grasshopper.Kernel;
+using Newtonsoft.Json;
+using Rhino;
+using SmartHopper.Infrastructure.AIContext;
+
+namespace SmartHopper.Core.AIContext
+{
+    /// <summary>
+    /// Context provider that supplies information about the currently visible
+    /// Grasshopper canvas viewport.
+    /// </summary>
+    public class ViewportContextProvider : IAIContextProvider
+    {
+        /// <summary>
+        /// Maximum number of visible objects to include in the detailed list.
+        /// </summary>
+        private const int MaxVisibleObjects = 50;
+
+        /// <summary>
+        /// Gets the provider identifier.
+        /// </summary>
+        public string ProviderId => "viewport";
+
+        /// <summary>
+        /// Gets the current viewport context for AI queries.
+        /// </summary>
+        /// <returns>A dictionary containing the current viewport context values.</returns>
+        [SuppressMessage("Design", "CA1031", Justification = "Context providers must be resilient and never crash the AI request pipeline.")]
+        public Dictionary<string, string> GetContext()
+        {
+            try
+            {
+                string boundsJson = "{}";
+                string centerJson = "{}";
+                float zoom = 1f;
+                int visibleCount = 0;
+                string visibleObjectsJson = "[]";
+
+                using (var uiThreadComplete = new ManualResetEventSlim(false))
+                {
+                    RhinoApp.InvokeOnUiThread(
+                        (Action)(() =>
+                        {
+                            try
+                            {
+                                var canvas = Instances.ActiveCanvas;
+                                var doc = canvas?.Document;
+                                var viewport = canvas?.Viewport;
+
+                                if (viewport != null)
+                                {
+                                    var bounds = viewport.VisibleRegion;
+                                    boundsJson = JsonConvert.SerializeObject(new
+                                    {
+                                        x = bounds.X,
+                                        y = bounds.Y,
+                                        width = bounds.Width,
+                                        height = bounds.Height,
+                                    });
+
+                                    centerJson = JsonConvert.SerializeObject(new
+                                    {
+                                        x = viewport.MidPoint.X,
+                                        y = viewport.MidPoint.Y,
+                                    });
+
+                                    zoom = viewport.Zoom;
+                                }
+
+                                if (doc != null && viewport != null)
+                                {
+                                    var visibleRegion = viewport.VisibleRegion;
+                                    var allObjects = doc.Objects?.OfType<IGH_DocumentObject>()?.ToList();
+                                    var visibleObjects = new List<object>();
+
+                                    if (allObjects != null)
+                                    {
+                                        foreach (var obj in allObjects)
+                                        {
+                                            if (obj?.Attributes?.Bounds != null
+                                                && obj.Attributes.Bounds.IntersectsWith(visibleRegion))
+                                            {
+                                                visibleObjects.Add(new
+                                                {
+                                                    instanceGuid = obj.InstanceGuid,
+                                                    name = obj.Name,
+                                                    nickName = string.IsNullOrWhiteSpace(obj.NickName)
+                                                        ? obj.Name
+                                                        : obj.NickName,
+                                                    type = obj.GetType().Name,
+                                                    pivot = new
+                                                    {
+                                                        x = obj.Attributes.Pivot.X,
+                                                        y = obj.Attributes.Pivot.Y,
+                                                    },
+                                                });
+
+                                                if (visibleObjects.Count >= MaxVisibleObjects)
+                                                {
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    visibleCount = visibleObjects.Count;
+                                    visibleObjectsJson = JsonConvert.SerializeObject(visibleObjects);
+                                }
+                            }
+                            finally
+                            {
+                                uiThreadComplete.Set();
+                            }
+                        }));
+
+                    uiThreadComplete.Wait(TimeSpan.FromSeconds(5));
+                }
+
+                return new Dictionary<string, string>
+                {
+                    { "viewport-bounds", boundsJson },
+                    { "viewport-center", centerJson },
+                    { "viewport-zoom", zoom.ToString(CultureInfo.InvariantCulture) },
+                    { "viewport-visible-count", visibleCount.ToString(CultureInfo.InvariantCulture) },
+                    { "viewport-visible-objects", visibleObjectsJson },
+                };
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[ViewportContextProvider] Error: {ex.Message}");
+                return new Dictionary<string, string>
+                {
+                    { "viewport-bounds", "{}" },
+                    { "viewport-center", "{}" },
+                    { "viewport-zoom", "1" },
+                    { "viewport-visible-count", "0" },
+                    { "viewport-visible-objects", "[]" },
+                };
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core/UI/Chat/WebChatUtils.Helpers.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatUtils.Helpers.cs
@@ -31,7 +31,7 @@ namespace SmartHopper.Core.UI.Chat
     /// </summary>
     public static partial class WebChatUtils
     {
-        private const string DefaultWebChatContextFilter = "time, environment, current-file";
+        private const string DefaultWebChatContextFilter = "time, environment, current-file, selection, viewport";
 
         /// <summary>
         /// Ensures the Eto.Forms Application is initialized and attached.


### PR DESCRIPTION
## Description
Added `SelectionContextProvider` and `ViewportContextProvider` to supply detailed metadata about selected Grasshopper objects (including topology and runtime previews) and the visible canvas viewport. Both providers are registered by default via `AIContextBootstrapper`. WebChat now includes `selection` and `viewport` in its default context filter. `FileContextProvider` no longer reports selected object metadata; use `SelectionContextProvider` instead.

## Breaking Changes
Yes. `FileContextProvider` no longer provides `selected-count`, `selected-objects`, `selected-topology`, or `selected-runtime-values`. Consumers must switch to `SelectionContextProvider` for this data.

## Testing Done

_Not verified by automation — to be completed by the author._

## Checklist

- [x] This PR is focused on a single feature or bug fix
- [x] CHANGELOG.md has been updated with relevant information to end user