### PR TITLE
feat(aitools): add visual review for structural AI canvas changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Many thanks to the following contributors to this release:
 
 ### Added
 
+- Added document-staged visual review for structural AI canvas changes. `gh_put`, `gh_remove`, `gh_clear`, `gh_connect`, `gh_disconnect`, `gh_move`, `gh_group`, and `gh_group_selected` now paint proposed additions, modifications, removals, wires, target positions, and groups over the actual Grasshopper canvas and apply only user-accepted changes.
+- Added reusable `CanvasChangeReviewSession`, `CanvasChangeReviewService`, `CanvasChangePreviewOverlay`, and Eto review dialog infrastructure in `SmartHopper.Core.Grasshopper`.
 - Pull request descriptions and titles are now drafted automatically, with a deterministic fallback when AI is unavailable and no overwriting of descriptions written by a person.
 - Added `AIBody.WithReplaced` extension for replacing a specific interaction by reference in an immutable body.
 - Added `AITool.GetRequiredParameters()` helper to parse required parameter names from a tool's JSON schema.

--- a/docs/UI/ai-change-review.md
+++ b/docs/UI/ai-change-review.md
@@ -1,0 +1,195 @@
+# AI Canvas Change Review
+
+Structural AI canvas changes are staged as a visual proposal on the actual Grasshopper canvas and applied only after explicit user acceptance.
+
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| **Since Version** | 2.1.0 |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+_Note: This documentation was written by AI on its own. It may contain some mistakes. If you would like to help, read this documentation and delete this comment if everything is okay._
+
+---
+
+## Why Read This?
+
+AI tools can add, modify, move, connect, group, and delete Grasshopper objects. Without a review step, every proposed mutation becomes part of the document immediately. This feature stages structural changes first, paints them over the live canvas, and applies only what the user accepts.
+
+**You should read this if you:**
+
+- Want to review or partially accept AI-proposed canvas changes
+- Are integrating a canvas-mutating AI tool with the shared review flow
+- Need to understand how SmartHopper splits responsibilities with `ghjson-dotnet`
+- Are debugging overlay rendering, proposal filtering, or undo behavior
+
+---
+
+## End-User Guide
+
+### What Is This?
+
+When an AI tool wants to change the canvas, SmartHopper shows a review dialog next to the Grasshopper window and paints the proposal directly on the canvas. Nothing is added to or removed from the document until the user clicks **Apply**.
+
+### Overlay Color Legend
+
+| Color | Meaning |
+| --- | --- |
+| Green | Component additions |
+| Amber | Modifications and proposed move targets |
+| Red | Removals and disconnections |
+| Blue | New connections |
+| Purple | Groups |
+
+### Step-by-Step
+
+1. Run an AI request that mutates the canvas (for example `gh_put`, `gh_move`, or `gh_disconnect`).
+2. Inspect the painted proposal on the canvas and the matching rows in the review dialog.
+3. Uncheck any change you do not want, or cancel to apply nothing.
+4. Click **Apply** to execute only the effectively accepted changes.
+5. The tool reports accepted and rejected counts back to the AI so it can continue without assuming rejected changes were applied.
+
+### Common Questions
+
+**Q: Does the preview create temporary components on the canvas?**
+A: No. The preview is painted during `CanvasPostPaintOverlay`. It never creates a duplicate `GH_Document` or temporary `IGH_DocumentObject` instances.
+
+**Q: What happens when I cancel the dialog?**
+A: The proposal is discarded and the document is left untouched.
+
+**Q: Can protected components be changed by the AI?**
+A: No. Protected canvas objects are filtered out before review and cannot be accepted indirectly through dependent changes.
+
+---
+
+## Developer Reference
+
+### API Overview
+
+```csharp
+// Review entry point: shows the dialog and overlay, returns true when applied.
+public static class CanvasChangeReviewService
+{
+    public static Task<bool> ReviewAsync(CanvasChangeReviewSession session);
+    public static CanvasChangeReviewSession CreateRemovalSession(string source, IEnumerable<Guid> instanceGuids);
+    public static CanvasChangeReviewSession CreateMoveSession(string source, IReadOnlyDictionary<Guid, PointF> targets, bool relative);
+    public static CanvasChangeReviewSession CreateConnectionSession(string source, IReadOnlyList<CanvasConnectionReviewProposal> proposals, CanvasChangeKind kind);
+    public static IReadOnlySet<Guid> GetAcceptedComponentGuids(CanvasChangeReviewSession session);
+    public static IReadOnlyList<Guid> GetAcceptedRemovalGuids(CanvasChangeReviewSession session);
+    public static IReadOnlySet<int> GetAcceptedConnectionProposalIndexes(CanvasChangeReviewSession session);
+}
+```
+
+### Key Types
+
+| Type | Purpose |
+| --- | --- |
+| `CanvasChangeReviewItem` | One independently selectable structural change, with optional dependencies via `RequiredItemKeys` |
+| `CanvasChangeReviewSession` | Immutable proposal (`GhJsonDocument`) plus mutable user selections |
+| `CanvasChangeReviewService` | UI-thread review entry point and proposal factories for removals, moves, and connections |
+| `CanvasChangePreviewOverlay` | Actual-canvas renderer hooked on `CanvasPostPaintOverlay`; never mutates `GH_Document` |
+| `CanvasChangeReviewDialog` | Eto dialog with per-change accept/reject checkboxes, positioned beside the canvas |
+| `GhPutChangePlan` | Compares an incoming GhJSON fragment with serialized live components and filters rejected components, connections, and groups |
+| `CanvasChangeKind` | Visual category: `ComponentAdded`, `ComponentModified`, `ComponentRemoved`, `ConnectionAdded`, `ConnectionRemoved`, `GroupAdded`, `GroupModified`, `GroupRemoved` |
+
+### Code Examples
+
+#### Building and Reviewing a Proposal
+
+```csharp
+// A tool builds review items, shows the session, and applies only accepted changes.
+var session = new CanvasChangeReviewSession(
+    "Review AI changes",
+    "gh_put",
+    proposedDocument,
+    items);
+
+var applied = await CanvasChangeReviewService.ReviewAsync(session);
+if (!applied)
+{
+    // Cancelled: apply nothing.
+}
+```
+
+#### Declaring Item Dependencies
+
+```csharp
+// A connection item can require its endpoint component items to be accepted.
+var wire = new CanvasChangeReviewItem(
+    "connection:0",
+    CanvasChangeKind.ConnectionAdded,
+    "Connect Number Slider -> Panel",
+    "New wire");
+wire.RequiredItemKeys.Add("component:42");
+```
+
+### Error Handling
+
+| Error | Cause | Solution |
+| --- | --- | --- |
+| Proposal appears empty | All items were filtered as protected or invalid | Check the tool result; rejected/protected items are reported to the AI |
+| Overlay not visible | Canvas was recreated or the session was cleared | Re-run the tool; overlays detach automatically on session end |
+| Rejected dependency still applied | Item keys were not declared in `RequiredItemKeys` | Add dependency keys so dependent changes are rejected together |
+
+---
+
+## Architecture & Design
+
+### Design Rationale
+
+**Problem**: AI canvas mutations were applied immediately, giving the user no chance to inspect or partially accept them before they became persistent document changes.
+
+**Approach**: Document staging. Tools build a proposed `GhJsonDocument` off-canvas, the overlay paints the proposal on the live canvas, and the final mutation runs only after user acceptance — ideally as a single undoable action.
+
+**Trade-offs**:
+
+- True staging (safe, honest preview) vs approximated ghost bounds for not-yet-instantiated components
+- Shared review contracts (consistent UX across tools) vs a small per-tool adapter to describe proposals
+
+### Ownership
+
+- **GhJSON.Core** owns portable GhJSON/GhPatch models, diffing, patching, checksums, and conflict handling.
+- **GhJSON.Grasshopper** owns generic canvas serialization, placement, connection, deletion, and undo integration.
+- **SmartHopper.Core.Grasshopper** owns AI proposal policy, user acceptance, Eto UI, and canvas overlays.
+
+This keeps GhJSON reusable by non-AI clients while avoiding SmartHopper-specific approval concepts in the format libraries.
+
+### Data Flow
+
+```text
+AI tool → build proposal (GhJsonDocument + review items)
+        → CanvasChangeReviewService.ReviewAsync
+        → CanvasChangePreviewOverlay paints on live canvas
+        → CanvasChangeReviewDialog collects accept/reject
+        → apply accepted subset only → tool result reports rejected items
+```
+
+### Tool Coverage
+
+The shared review flow currently gates:
+
+- `gh_put` additions, replacements, connections, and groups
+- `gh_remove` and `gh_clear` removals
+- `gh_connect` and `gh_disconnect` wire changes
+- `gh_move` target positions
+- `gh_group` and `gh_group_selected` group creation
+
+Runtime actions such as button clicks and script execution are not represented as structural diffs. They retain their existing execution semantics.
+
+### Gotchas
+
+- Added-component ghosts approximate component bounds because exact attributes are only available after Grasshopper instantiation.
+- Proposals without pivots use GhJSON dependency-graph layout for preview; Grasshopper-aware final layout may differ slightly.
+- Non-edit `gh_put` can auto-offset the accepted network to avoid live objects, so its final global offset can differ from the proposal coordinates.
+- Specialized structural tools (`gh_tidy_up`, `gh_smart_connect`, preview/lock changes, parameter modifiers) still use their existing execution paths and can adopt the same contracts later.
+
+### Related Documentation
+
+- [User Interface](./index.md)
+- [Chat UI](./Chat/index.md)
+- [Tools](../Tools/index.md)

--- a/docs/UI/icon-set-brief.md
+++ b/docs/UI/icon-set-brief.md
@@ -2,7 +2,66 @@
 
 Brief for generating a new, coherent icon set (e.g. with an AI icon-set generator such as mew.design) covering the Grasshopper component icons and app identity assets of SmartHopper.
 
-## 1. Technical constraints
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Components/Resources/` |
+| **Since Version** | ? |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+---
+
+## Why Read This?
+
+Component icons are the primary visual language of SmartHopper on the Grasshopper canvas. This brief defines the badge grammar, color system, and per-icon design specs so a regenerated icon set stays coherent.
+
+**You should read this if you:**
+
+- Are generating or redrawing component or brand icons
+- Need to understand the badge grammar (direction, source, and AI markers)
+- Are adding a new component and need a consistent icon spec
+
+---
+
+## End-User Guide
+
+### What users see
+
+Every component icon is a main central glyph plus one or two small corner badges that encode semantics: direction (data into AI vs out of AI), source/type, and whether the component calls an AI provider. The numbered sections below describe this grammar in detail.
+
+---
+
+## Developer Reference
+
+### Icon assets and assignment
+
+Component icons are 24×24 PNGs embedded as `Bitmap` resources and exposed through each component's `Icon` override:
+
+```csharp
+// Each component surfaces its icon from embedded resources.
+protected override Bitmap Icon => Properties.Resources.aichat;
+```
+
+The Grasshopper category tab icon is registered once at assembly load:
+
+```csharp
+// SmartHopperAssemblyPriority registers the category identity.
+Instances.ComponentServer.AddCategoryIcon("SmartHopper", Resources.smarthopper);
+```
+
+---
+
+## Architecture & Design
+
+### Design brief
+
+The numbered sections below are the full generation brief: technical constraints, the current icon system, the proposed badge grammar, the per-icon inventory, and the color system.
+
+### 1. Technical constraints
 
 | Constraint | Value | Why |
 | --- | --- | --- |
@@ -13,7 +72,7 @@ Brief for generating a new, coherent icon set (e.g. with an AI icon-set generato
 | Theme | Must work on light **and** dark Grasshopper themes | Avoid pure black or pure white-only silhouettes; prefer mid-tone fills + outlines |
 | Legibility rule | Max **2 badges** per icon, badges ≥ 8 px | At 24 px, anything finer turns to noise |
 
-## 2. Current system
+### 2. Current system
 
 Every component icon is a **main central glyph** plus **one or two small badges** at the bottom corners that encode semantics. The codebase already reveals a consistent grammar:
 
@@ -23,7 +82,7 @@ Every component icon is a **main central glyph** plus **one or two small badges*
 - GhJSON icons = document glyph + operation badge (get / put / merge / diff / patch).
 - "Side" icons (settings, context, models, metrics) have no direction badge.
 
-## 3. Proposed badge grammar
+### 3. Proposed badge grammar
 
 Fixed positions so badges are predictable:
 
@@ -38,7 +97,7 @@ Fixed positions so badges are predictable:
 
 Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 badges as standalone assets, then ask the generator to compose each icon. That guarantees consistency that one-shot generation won't.
 
-## 4. Similarity groups found in the codebase
+### 4. Similarity groups found in the codebase
 
 1. **Direction pairs** — the largest pattern: `toai-*` (B. Input) vs `aito*` (C. Output). Same type glyph, mirrored direction badge.
 2. **Data-type family** — text, text list, boolean, integer, number, JSON, list, image, audio, speech, file, web, GhJSON, context, prompt.
@@ -48,9 +107,9 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 6. **Side/config icons** — settings, extra settings, models, context providers, file metadata, metrics: no direction badge; these live next to the AI pipeline.
 7. **Viewers/captures** — image viewer, audio viewer, canvas/viewport capture: "display/capture" family, no AI badge.
 
-## 5. Full icon inventory and per-icon design spec
+### 5. Full icon inventory and per-icon design spec
 
-### 5.1 Brand / app identity
+#### 5.1 Brand / app identity
 
 | Asset | Used by | Design spec |
 | --- | --- | --- |
@@ -59,7 +118,7 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 | `img/smarthopper.png` | Repo/README logo | Large-format variant of the mascot. |
 | Provider logos (8) | `SmartHopper.Providers.*`: anthropic, deepseek, gemini, localai, mistralai, ollama, openai, openrouter | **Do not AI-generate** — third-party trademarks. Keep official brand marks, normalized to a consistent square frame. |
 
-### 5.2 "A. AI" category — assistant & configuration
+#### 5.2 "A. AI" category — assistant & configuration
 
 | Component | Icon resource | Design spec |
 | --- | --- | --- |
@@ -70,7 +129,7 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 | File Metadata (`AIFileMetadataComponent`) | `context` | Document with a tag/label line — represents file-level metadata context. |
 | AI Models (`AIModelsComponent`) | `aimodels` | Stacked/layered nodes or a list with a spark — "catalog of models". |
 
-### 5.3 "B. Input" category — data → AI (`toai-*`)
+#### 5.3 "B. Input" category — data → AI (`toai-*`)
 
 Shared spec: **type glyph center + "arrow into AI spark" badge bottom-right**. List variants add a bottom-left `≡`/`[]` badge.
 
@@ -99,7 +158,7 @@ Shared spec: **type glyph center + "arrow into AI spark" badge bottom-right**. L
 | Ladybug Post to AI | **missing** | Post card | to-AI + Ladybug mark |
 | Ladybug Topic to AI | **missing** | Topic stack | to-AI + Ladybug mark |
 
-### 5.4 "C. Output" category — AI → data (`aito*`)
+#### 5.4 "C. Output" category — AI → data (`aito*`)
 
 Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right**. Mirror of 5.3.
 
@@ -120,7 +179,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI to Script | `aitoscript` | `</>` code glyph |
 | AI to GhJSON | `aitogh` | GH document |
 
-### 5.5 "Text" category — AI text ops
+#### 5.5 "Text" category — AI text ops
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -128,14 +187,14 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI Text To Text List | `textlistgenerate` | "T" + list lines + AI spark |
 | AI Text To Boolean | `textevaluate` | "T" + check/?-evaluate badge — reads as "question → true/false" |
 
-### 5.6 "List" category
+#### 5.6 "List" category
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
 | AI List Filter | `listfilter` | List `≡` + funnel badge + AI spark |
 | AI List To Boolean | `listevaluate` | List `≡` + check/evaluate badge + AI spark |
 
-### 5.7 "JSON" category — pure data toolkit (no AI)
+#### 5.7 "JSON" category — pure data toolkit (no AI)
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -152,7 +211,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | JSON Schema Prop | `jsonschemaprop` | Schema badge + single key glyph |
 | AI Text → JSON | `jsonai` | `{ }` + AI spark (only AI-powered member of the family) |
 
-### 5.8 "Knowledge" category — research sources
+#### 5.8 "Knowledge" category — research sources
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -169,7 +228,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | McNeel × (search / post get / post open / post summarize / topic summarize) | `mcneel*` | Same action badges, source glyph = McNeel mark (rhino/"M") |
 | Ladybug × same 5 actions | `ladybug*` | Same action badges, source glyph = ladybug beetle |
 
-### 5.9 "Grasshopper" category — GhJSON document ops
+#### 5.9 "Grasshopper" category — GhJSON document ops
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -189,7 +248,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI Smart Connect | **missing** | Two component nodes + wire/plug + AI spark |
 | AI Canvas Report | **missing** | Clipboard/report + canvas grid + AI spark |
 
-### 5.10 "Img" / "Audio" categories
+#### 5.10 "Img" / "Audio" categories
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -200,14 +259,14 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | Viewport To Image | **new:** `viewportcapture` (replaces shared `aitoimg`) | Perspective viewport frame + capture/camera badge; blue non-AI helper |
 | Audio Viewer | `audio` | Speaker/waveform in a display frame — no AI badge |
 
-### 5.11 "Script" category
+#### 5.11 "Script" category
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
 | AI Script Generate | `scriptgenerate` | `</>` code glyph + AI spark |
 | AI Script Review | `scriptreview` | `</>` + magnifier/check badge + AI spark |
 
-### 5.12 "Utils" / "MCP"
+#### 5.12 "Utils" / "MCP"
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -215,7 +274,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | Combine Metrics | **missing** | Chart bars + merge badge |
 | SmartHopper MCP Server | **missing** (no `Icon` override) | Server/plug node + SmartHopper spark — represents the loopback MCP endpoint |
 
-## 6. New composed icons required because of missing or shared assets
+### 6. New composed icons required because of missing or shared assets
 
 The new set must include the following **22 distinct 24×24 component icons** in addition to replacing the icons already listed above. Fourteen fill current gaps; eight separate components that currently reuse an icon with different semantics. Resource names below are proposed identifiers and can be adjusted during integration.
 
@@ -244,7 +303,7 @@ The new set must include the following **22 distinct 24×24 component icons** in
 | Combine Metrics | `metricscombine` | Current `Icon => null` | Metrics-chart full glyph + merge badge |
 | SmartHopper MCP Server | `mcpserver` | No `Icon` override | Server-node full glyph + MCP/connection badge |
 
-## 7. Color system
+### 7. Color system
 
 Color should accelerate recognition, but **never carry meaning alone**: each role also has a unique full glyph or badge silhouette. Use color on the principal glyph and the semantically important badge, with dark slate outlines and off-white cutouts for contrast.
 
@@ -260,7 +319,7 @@ Color should accelerate recognition, but **never carry meaning alone**: each rol
 | Knockout / highlight | Off-white | `#F4F6F8` | Interior cutouts, badge symbols, separation keylines | Remains readable on dark canvas themes |
 | Error/status only | Red | `#C0392B` | Existing invalid-model runtime badge only | Reserve red for actual errors; never use it as a component-category color |
 
-### 7.1 Color application rules
+#### 7.1 Color application rules
 
 1. Use at most **two semantic colors** in one icon, plus slate and off-white neutrals.
 2. The **main glyph color identifies the domain**: gray configuration, pink knowledge, teal canvas/GhJSON, blue deterministic data/media, or green AI-first components.
@@ -271,11 +330,11 @@ Color should accelerate recognition, but **never carry meaning alone**: each rol
 7. Do not use gradients, shadows, semitransparent hairlines, or red/green color contrast as the only distinction.
 8. Third-party source marks may keep recognizable brand shapes, but recolor them raspberry pink where trademark guidance permits. If recoloring is not permitted, use the official mark inside a consistent pink source-badge frame.
 
-## 8. Deduplicated drawing inventory
+### 8. Deduplicated drawing inventory
 
 Generate these drawings as reusable masters before composing the 24×24 icons. A drawing appears **once** in this list even when dozens of icons reuse it.
 
-### 8.1 Full-size drawings
+#### 8.1 Full-size drawings
 
 Full-size drawings occupy approximately **14–18 px** of the 24×24 artboard and provide the icon's primary silhouette.
 
@@ -315,7 +374,7 @@ Full-size drawings occupy approximately **14–18 px** of the 24×24 artboard an
 | F32 | MCP server | Gray | Compact server stack with one network port/node | SmartHopper MCP Server |
 | F33 | Scattered components | Teal | Three displaced component rectangles | Tidy Up before-state |
 
-### 8.2 Badge-size drawings
+#### 8.2 Badge-size drawings
 
 Badge drawings occupy approximately **7–9 px**, use filled geometric silhouettes, and normally sit bottom-right. Source/type modifiers sit bottom-left. Draw every badge on the same nominal 9×9 artboard with at least a 1 px clear zone.
 
@@ -363,7 +422,7 @@ Badge drawings occupy approximately **7–9 px**, use filled geometric silhouett
 | B40 | Providers / registry | Gray | Three short rows with connection dots | Context Providers / AI Models |
 | B41 | MCP connection | Gray | Two linked nodes with a central port | MCP Server |
 
-### 8.3 Runtime badges drawn by code
+#### 8.3 Runtime badges drawn by code
 
 These are not PNG assets but should be included in the visual design handoff because they appear next to the generated icons. Keep their existing semantics and colors:
 
@@ -376,7 +435,7 @@ These are not PNG assets but should be included in the visual design handoff bec
 | Replaced model | Runtime 16×16 | Blue `#3498DB` | Filled circle + white refresh arrow |
 | Provider identity | Runtime 16×16 | Provider brand | Official provider logo in the bottom strip; do not regenerate |
 
-## 9. Gaps and cleanup notes
+### 9. Gaps and cleanup notes
 
 - **14 components currently ship without icons** (`Icon => null` or no override): the 4 forum `*2AI` inputs, 4 GhJSON/GhPatch file operations, `GhValidate`, `GhPatchApplyToCanvas`, `AIGhConnect`, `AIGhReport`, `CombineMetrics`, and `SmartHopperMcpServer`.
 - **Eight additional components require new dedicated compositions** because they currently reuse an icon with different semantics: Boolean/Integer/Number List to AI, JSON Get Value, JSON Set Value, AI Web To Markdown, Canvas To Image, and Viewport To Image.
@@ -385,7 +444,7 @@ These are not PNG assets but should be included in the visual design handoff bec
 - Template/junk entries `Bitmap1`, `Color1`, `Icon1`, and `Name1` should not be recreated.
 - Chat UI uses an inline chart emoji for metrics; it is outside the Grasshopper component icon set but should eventually use the same F29 metrics drawing for product consistency.
 
-## 10. Suggested generation prompts
+### 10. Suggested generation prompts
 
 Use one style preamble for every full-size drawing:
 

--- a/docs/UI/index.md
+++ b/docs/UI/index.md
@@ -1,0 +1,99 @@
+# User Interface
+
+Documentation for SmartHopper's user-facing UI: the WebView chat, canvas overlays and review dialogs, and the icon set design brief.
+
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Core/UI/` and `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| **Since Version** | ? |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+_Note: This documentation was written by AI on its own. It may contain some mistakes. If you would like to help, read this documentation and delete this comment if everything is okay._
+
+---
+
+## Why Read This?
+
+SmartHopper surfaces AI capabilities through two main UI layers: the WebView-based chat and canvas-integrated overlays/dialogs. This index links the detailed pages and explains how they relate.
+
+**You should read this if you:**
+
+- Are working on the chat dialog, canvas overlays, or Eto dialogs
+- Need to find where a UI surface is implemented
+- Want to add a new user-facing review or visualization feature
+
+---
+
+## End-User Guide
+
+### UI Surfaces
+
+| Surface | Description | Documentation |
+| --- | --- | --- |
+| Chat UI | Full WebView chat interface bridged to the Rhino host | [Chat UI](Chat/index.md) |
+| AI Canvas Change Review | Staged visual review of AI-proposed canvas changes | [AI Canvas Change Review](ai-change-review.md) |
+| Icon Set | Component and brand asset design brief | [Icon Set Brief](icon-set-brief.md) |
+
+### Common Questions
+
+**Q: Where does the chat window live?**
+A: The WebView chat is hosted in `SmartHopper.Core` under `UI/Chat/`, with conversation state in `SmartHopper.Infrastructure`.
+
+**Q: Where are canvas overlays implemented?**
+A: Overlays live in `SmartHopper.Core.Grasshopper` under `Utils/Canvas/` and render via `GH_Canvas` paint callbacks.
+
+---
+
+## Developer Reference
+
+### Entry Points
+
+| Concern | Location |
+| --- | --- |
+| Chat dialog and renderer | `src/SmartHopper.Core/UI/Chat/` |
+| Canvas overlays and review | `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| Assembly-level canvas registration | `src/SmartHopper.Components/SmartHopperAssemblyPriority.cs` |
+
+### Code Examples
+
+#### Registering a Canvas Overlay
+
+```csharp
+// Overlays are initialized once from the assembly priority load hook.
+public override GH_LoadingInstruction PriorityLoad()
+{
+    CanvasProtectionOverlay.Initialize();
+    CanvasChangePreviewOverlay.Initialize();
+    return GH_LoadingInstruction.Proceed;
+}
+```
+
+#### Showing a Staged Review
+
+```csharp
+// Tools hand a prepared session to the shared review service.
+var session = CanvasChangeReviewService.CreateMoveSession("gh_move", targets, relative: false);
+var applied = await CanvasChangeReviewService.ReviewAsync(session);
+```
+
+---
+
+## Architecture & Design
+
+### Design Rationale
+
+**Problem**: SmartHopper needs both a rich conversational UI and lightweight, in-context canvas feedback without duplicating UI frameworks.
+
+**Approach**: The chat uses a WebView hosted in Eto for rich HTML rendering; canvas feedback uses `GH_Canvas` paint callbacks plus small Eto dialogs. Both are owned by `SmartHopper.Core`/`SmartHopper.Core.Grasshopper` so provider and component projects stay UI-free.
+
+### Related Documentation
+
+- [Chat UI](Chat/index.md)
+- [AI Canvas Change Review](ai-change-review.md)
+- [Icon Set Brief](icon-set-brief.md)
+- [Documentation Hub](../index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ This is the root documentation hub for SmartHopper. It organizes all guides, ref
 
 #### UI
 
-- [Chat UI](UI/Chat/index.md) -- web chat interface and host bridge
+- [User Interface](UI/index.md) -- chat UI, canvas overlays, and AI change review
 
 #### Usage Guides
 

--- a/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
+++ b/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
@@ -43,6 +43,8 @@ namespace SmartHopper.Components
                 DialogCanvasLink.RegisterLink(dialog, guid, color);
             };
 
+            CanvasChangePreviewOverlay.EnsureInitialized();
+
             // Initialize the visual overlay that marks protected components on the canvas.
             CanvasProtectionOverlay.EnsureInitialized();
 

--- a/src/SmartHopper.Core.Grasshopper.Tests/AITools/GhPutChangePlanTests.cs
+++ b/src/SmartHopper.Core.Grasshopper.Tests/AITools/GhPutChangePlanTests.cs
@@ -1,0 +1,153 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+using SmartHopper.Core.Grasshopper.AITools;
+using SmartHopper.Core.Grasshopper.Utils.Canvas;
+using Xunit;
+
+namespace SmartHopper.Core.Grasshopper.Tests.AITools
+{
+    /// <summary>
+    /// Tests document-only planning and selection without requiring a Rhino runtime.
+    /// </summary>
+    public sealed class GhPutChangePlanTests
+    {
+        /// <summary>
+        /// Verifies that unchanged, modified, and added components are classified correctly.
+        /// </summary>
+        [Fact]
+        public void Create_ClassifiesComponentChanges()
+        {
+            var modifiedGuid = Guid.NewGuid();
+            var unchangedGuid = Guid.NewGuid();
+            var existing = CreateDocument(
+                new[]
+                {
+                    CreateComponent(1, modifiedGuid, "Slider", "Old"),
+                    CreateComponent(2, unchangedGuid, "Panel", "Same"),
+                });
+            var proposed = CreateDocument(
+                new[]
+                {
+                    CreateComponent(1, modifiedGuid, "Slider", "New"),
+                    CreateComponent(2, unchangedGuid, "Panel", "Same"),
+                    CreateComponent(3, null, "Addition", "Add"),
+                });
+
+            var plan = GhPutChangePlan.Create(proposed, existing);
+
+            Assert.Equal(2, plan.Session.Items.Count);
+            Assert.Contains(plan.Session.Items, item => item.Kind == CanvasChangeKind.ComponentModified && item.ComponentId == 1);
+            Assert.Contains(plan.Session.Items, item => item.Kind == CanvasChangeKind.ComponentAdded && item.ComponentId == 3);
+        }
+
+        /// <summary>
+        /// Verifies that dependent wires and groups are omitted when a required component is rejected.
+        /// </summary>
+        [Fact]
+        public void BuildAcceptedDocument_RemovesRejectedDependencies()
+        {
+            var modifiedGuid = Guid.NewGuid();
+            var existing = CreateDocument(new[] { CreateComponent(1, modifiedGuid, "Slider", "Old") });
+            var components = new[]
+            {
+                CreateComponent(1, modifiedGuid, "Slider", "New"),
+                CreateComponent(2, null, "Addition", "Add"),
+            };
+            var connection = new GhJsonConnection
+            {
+                From = new GhJsonConnectionEndpoint { Id = 1, ParamName = "R" },
+                To = new GhJsonConnectionEndpoint { Id = 2, ParamName = "A" },
+            };
+            var group = new GhJsonGroup
+            {
+                Id = 3,
+                Name = "Generated",
+                Members = new List<int> { 1, 2 },
+            };
+            var proposed = CreateDocument(components, new[] { connection }, new[] { group });
+            var plan = GhPutChangePlan.Create(proposed, existing);
+            var added = plan.Session.Items.Single(item => item.Kind == CanvasChangeKind.ComponentAdded);
+
+            plan.Session.SetAccepted(added.Key, false);
+            var accepted = plan.BuildAcceptedDocument();
+
+            Assert.Single(accepted.Components);
+            Assert.Equal(1, accepted.Components[0].Id);
+            Assert.Null(accepted.Connections);
+            Assert.Single(accepted.Groups!);
+            Assert.Equal(new[] { 1 }, accepted.Groups![0].Members);
+            Assert.Equal(2, plan.Session.AcceptedCount);
+        }
+
+        /// <summary>
+        /// Verifies that accepted wires to unchanged live components are retained for post-placement connection.
+        /// </summary>
+        [Fact]
+        public void GetAcceptedExternalConnections_ReturnsConnectionsToUnchangedComponents()
+        {
+            var existingGuid = Guid.NewGuid();
+            var unchanged = CreateComponent(1, existingGuid, "Slider", "Same");
+            var added = CreateComponent(2, null, "Addition", "Add");
+            var connection = new GhJsonConnection
+            {
+                From = new GhJsonConnectionEndpoint { Id = 1, ParamName = "R" },
+                To = new GhJsonConnectionEndpoint { Id = 2, ParamName = "A" },
+            };
+            var plan = GhPutChangePlan.Create(
+                CreateDocument(new[] { unchanged, added }, new[] { connection }),
+                CreateDocument(new[] { unchanged }));
+
+            var accepted = plan.BuildAcceptedDocument();
+            var externalConnections = plan.GetAcceptedExternalConnections(accepted);
+
+            Assert.Single(accepted.Components);
+            Assert.Single(externalConnections);
+            Assert.Equal(existingGuid, plan.GetExistingInstanceGuid(1));
+        }
+
+        private static GhJsonDocument CreateDocument(
+            IEnumerable<GhJsonComponent> components,
+            IEnumerable<GhJsonConnection>? connections = null,
+            IEnumerable<GhJsonGroup>? groups = null)
+        {
+            return new GhJsonDocument("1.0", null, components, connections, groups);
+        }
+
+        private static GhJsonComponent CreateComponent(
+            int id,
+            Guid? instanceGuid,
+            string name,
+            string nickName)
+        {
+            return new GhJsonComponent
+            {
+                Id = id,
+                InstanceGuid = instanceGuid,
+                ComponentGuid = Guid.Parse("3e8f5f24-8e8c-4f11-a538-4dcd67e3590f"),
+                Name = name,
+                NickName = nickName,
+                Pivot = new GhJsonPivot(id * 100, 100),
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/AITools/GhPutChangePlan.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/GhPutChangePlan.cs
@@ -1,0 +1,337 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core;
+using GhJSON.Core.SchemaModels;
+using Newtonsoft.Json.Linq;
+using SmartHopper.Core.Grasshopper.Utils.Canvas;
+
+namespace SmartHopper.Core.Grasshopper.AITools
+{
+    /// <summary>
+    /// Builds a selectable, non-mutating review plan for a <c>gh_put</c> proposal.
+    /// </summary>
+    public sealed class GhPutChangePlan
+    {
+        private GhPutChangePlan(
+            GhJsonDocument proposedDocument,
+            CanvasChangeReviewSession session)
+        {
+            this.ProposedDocument = proposedDocument;
+            this.Session = session;
+        }
+
+        /// <summary>Gets the original proposed document.</summary>
+        public GhJsonDocument ProposedDocument { get; }
+
+        /// <summary>Gets the user-review session.</summary>
+        public CanvasChangeReviewSession Session { get; }
+
+        /// <summary>
+        /// Creates a review plan by comparing proposed components with their live serialized state.
+        /// </summary>
+        /// <param name="proposedDocument">Incoming GhJSON proposal.</param>
+        /// <param name="existingDocument">Serialized live components matched by instance GUID.</param>
+        /// <returns>The review plan.</returns>
+        public static GhPutChangePlan Create(GhJsonDocument proposedDocument, GhJsonDocument existingDocument)
+        {
+            if (proposedDocument == null)
+            {
+                throw new ArgumentNullException(nameof(proposedDocument));
+            }
+
+            var existingByGuid = (existingDocument?.Components ?? Array.Empty<GhJsonComponent>())
+                .Where(component => component.InstanceGuid.HasValue)
+                .ToDictionary(component => component.InstanceGuid!.Value);
+            var items = new List<CanvasChangeReviewItem>();
+            var componentKeysById = new Dictionary<int, string>();
+            var unchangedIds = new HashSet<int>();
+
+            foreach (var component in proposedDocument.Components)
+            {
+                var key = $"component:{component.Id?.ToString() ?? component.InstanceGuid?.ToString() ?? items.Count.ToString()}";
+                if (component.Id.HasValue)
+                {
+                    componentKeysById[component.Id.Value] = key;
+                }
+
+                if (component.InstanceGuid.HasValue &&
+                    existingByGuid.TryGetValue(component.InstanceGuid.Value, out var existing))
+                {
+                    if (ComponentsAreEqual(component, existing))
+                    {
+                        if (component.Id.HasValue)
+                        {
+                            unchangedIds.Add(component.Id.Value);
+                        }
+
+                        continue;
+                    }
+
+                    items.Add(new CanvasChangeReviewItem(
+                        key,
+                        CanvasChangeKind.ComponentModified,
+                        DisplayName(component),
+                        DescribeChangedFields(component, existing))
+                    {
+                        ComponentId = component.Id,
+                        ExistingInstanceGuid = component.InstanceGuid,
+                    });
+                    continue;
+                }
+
+                items.Add(new CanvasChangeReviewItem(
+                    key,
+                    CanvasChangeKind.ComponentAdded,
+                    DisplayName(component),
+                    component.Library ?? "New component")
+                {
+                    ComponentId = component.Id,
+                });
+            }
+
+            if (proposedDocument.Connections != null)
+            {
+                for (var index = 0; index < proposedDocument.Connections.Count; index++)
+                {
+                    var connection = proposedDocument.Connections[index];
+                    var item = new CanvasChangeReviewItem(
+                        $"connection:{index}",
+                        CanvasChangeKind.ConnectionAdded,
+                        DescribeConnection(connection, proposedDocument),
+                        DescribeConnectionParameters(connection))
+                    {
+                        ConnectionIndex = index,
+                    };
+                    AddDependency(item, connection.From.Id, componentKeysById, unchangedIds);
+                    AddDependency(item, connection.To.Id, componentKeysById, unchangedIds);
+                    items.Add(item);
+                }
+            }
+
+            if (proposedDocument.Groups != null)
+            {
+                for (var index = 0; index < proposedDocument.Groups.Count; index++)
+                {
+                    var group = proposedDocument.Groups[index];
+                    var item = new CanvasChangeReviewItem(
+                        $"group:{index}",
+                        CanvasChangeKind.GroupAdded,
+                        string.IsNullOrWhiteSpace(group.Name) ? "Group" : group.Name!,
+                        $"{group.Members.Count} member(s)")
+                    {
+                        GroupIndex = index,
+                    };
+                    items.Add(item);
+                }
+            }
+
+            var previewDocument = proposedDocument.Components.Any(component => component.Pivot != null)
+                ? proposedDocument
+                : GhJson.ReorganizePivots(proposedDocument);
+            var session = new CanvasChangeReviewSession(
+                "Review AI canvas changes",
+                "gh_put",
+                previewDocument,
+                items);
+            return new GhPutChangePlan(proposedDocument, session);
+        }
+
+        /// <summary>
+        /// Gets accepted connections that cannot be created by placing the filtered fragment because at least one endpoint is an unchanged live component.
+        /// </summary>
+        /// <param name="acceptedDocument">Filtered document returned by <see cref="BuildAcceptedDocument"/>.</param>
+        /// <returns>Accepted connections requiring post-placement connection.</returns>
+        public IReadOnlyList<GhJsonConnection> GetAcceptedExternalConnections(GhJsonDocument acceptedDocument)
+        {
+            var placedIds = acceptedDocument.Components
+                .Where(component => component.Id.HasValue)
+                .Select(component => component.Id!.Value)
+                .ToHashSet();
+            var acceptedIndexes = this.Session.Items
+                .Where(item => item.ConnectionIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ConnectionIndex!.Value)
+                .ToHashSet();
+            return this.ProposedDocument.Connections?
+                .Select((connection, index) => new { Connection = connection, Index = index })
+                .Where(entry =>
+                    acceptedIndexes.Contains(entry.Index) &&
+                    (!placedIds.Contains(entry.Connection.From.Id) || !placedIds.Contains(entry.Connection.To.Id)))
+                .Select(entry => entry.Connection)
+                .ToList() ?? new List<GhJsonConnection>();
+        }
+
+        /// <summary>
+        /// Resolves a proposed component ID to its instance GUID when the proposal references a live component.
+        /// </summary>
+        /// <param name="componentId">Proposed component ID.</param>
+        /// <returns>The live instance GUID, or <c>null</c>.</returns>
+        public Guid? GetExistingInstanceGuid(int componentId)
+        {
+            return this.ProposedDocument.Components.FirstOrDefault(component => component.Id == componentId)?.InstanceGuid;
+        }
+
+        /// <summary>
+        /// Builds the GhJSON fragment containing only effectively accepted changes.
+        /// </summary>
+        /// <returns>A filtered GhJSON document.</returns>
+        public GhJsonDocument BuildAcceptedDocument()
+        {
+            var acceptedComponents = this.Session.Items
+                .Where(item => item.ComponentId.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ComponentId!.Value)
+                .ToHashSet();
+            var acceptedConnections = this.Session.Items
+                .Where(item => item.ConnectionIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ConnectionIndex!.Value)
+                .ToHashSet();
+            var acceptedGroups = this.Session.Items
+                .Where(item => item.GroupIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.GroupIndex!.Value)
+                .ToHashSet();
+
+            var components = this.ProposedDocument.Components
+                .Where(component => component.Id.HasValue && acceptedComponents.Contains(component.Id.Value))
+                .ToList();
+            var retainedIds = components
+                .Where(component => component.Id.HasValue)
+                .Select(component => component.Id!.Value)
+                .ToHashSet();
+            var connections = this.ProposedDocument.Connections?
+                .Select((connection, index) => new { Connection = connection, Index = index })
+                .Where(entry =>
+                    acceptedConnections.Contains(entry.Index) &&
+                    retainedIds.Contains(entry.Connection.From.Id) &&
+                    retainedIds.Contains(entry.Connection.To.Id))
+                .Select(entry => entry.Connection)
+                .ToList();
+            var groups = this.ProposedDocument.Groups?
+                .Select((group, index) => new { Group = group, Index = index })
+                .Where(entry => acceptedGroups.Contains(entry.Index))
+                .Select(entry => CopyGroup(entry.Group, retainedIds))
+                .Where(group => group.Members.Count > 0)
+                .ToList();
+
+            return new GhJsonDocument(
+                this.ProposedDocument.Schema,
+                this.ProposedDocument.Metadata,
+                components,
+                connections,
+                groups);
+        }
+
+        private static void AddDependency(
+            CanvasChangeReviewItem item,
+            int componentId,
+            IReadOnlyDictionary<int, string> componentKeysById,
+            ISet<int> unchangedIds)
+        {
+            if (!unchangedIds.Contains(componentId) &&
+                componentKeysById.TryGetValue(componentId, out var key) &&
+                !item.RequiredItemKeys.Contains(key))
+            {
+                item.RequiredItemKeys.Add(key);
+            }
+        }
+
+        private static GhJsonGroup CopyGroup(GhJsonGroup group, ISet<int> retainedIds)
+        {
+            return new GhJsonGroup
+            {
+                Id = group.Id,
+                InstanceGuid = group.InstanceGuid,
+                Name = group.Name,
+                Color = group.Color,
+                Members = group.Members.Where(retainedIds.Contains).ToList(),
+            };
+        }
+
+        private static string DescribeChangedFields(GhJsonComponent proposed, GhJsonComponent existing)
+        {
+            var proposedObject = Normalize(proposed);
+            var existingObject = Normalize(existing);
+            var changed = proposedObject.Properties()
+                .Select(property => property.Name)
+                .Union(existingObject.Properties().Select(property => property.Name))
+                .Where(name => !JToken.DeepEquals(proposedObject[name], existingObject[name]))
+                .ToList();
+            return changed.Count == 0 ? "Component state will change" : $"Changed: {string.Join(", ", changed)}";
+        }
+
+        private static string DescribeConnection(GhJsonConnection connection, GhJsonDocument document)
+        {
+            var from = document.Components.FirstOrDefault(component => component.Id == connection.From.Id);
+            var to = document.Components.FirstOrDefault(component => component.Id == connection.To.Id);
+            return $"{DisplayName(from)} → {DisplayName(to)}";
+        }
+
+        private static string DescribeConnectionParameters(GhJsonConnection connection)
+        {
+            var from = connection.From.ParamName ?? connection.From.ParamIndex?.ToString() ?? "output";
+            var to = connection.To.ParamName ?? connection.To.ParamIndex?.ToString() ?? "input";
+            return $"{from} → {to}";
+        }
+
+        private static string DisplayName(GhJsonComponent? component)
+        {
+            if (component == null)
+            {
+                return "Unknown component";
+            }
+
+            return !string.IsNullOrWhiteSpace(component.NickName) ? component.NickName! : component.Name ?? "Component";
+        }
+
+        private static bool ComponentsAreEqual(GhJsonComponent proposed, GhJsonComponent existing)
+        {
+            return JToken.DeepEquals(Normalize(proposed), Normalize(existing));
+        }
+
+        private static JObject Normalize(GhJsonComponent component)
+        {
+            var value = JObject.FromObject(component);
+            value.Remove("id");
+            value.Remove("errors");
+            value.Remove("warnings");
+            value.Remove("remarks");
+
+            if (value["componentState"] is JObject state)
+            {
+                state.Remove("selected");
+            }
+
+            foreach (var settingsKey in new[] { "inputSettings", "outputSettings" })
+            {
+                if (value[settingsKey] is not JArray settings)
+                {
+                    continue;
+                }
+
+                foreach (var setting in settings.OfType<JObject>())
+                {
+                    setting.Remove("runtimeData");
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Clear all components from the Grasshopper canvas. Optionally keep locked components. Protected components (and their direct neighbors) are always preserved. This is a destructive operation - use with caution. Supports undo (Ctrl+Z).",
+                description: "Stage removal of all components from the Grasshopper canvas and let the user visually review and select removals before applying them. Optionally keep locked components. Protected components (and their direct neighbors) are always preserved. Supports undo (Ctrl+Z).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -65,11 +65,11 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.ClearCanvasAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete", "destructive" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""deletedCount"": { ""type"": ""integer"" }, ""deleted"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""skippedLockedCount"": { ""type"": ""integer"" }, ""protectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""deletedCount"": { ""type"": ""integer"" }, ""deleted"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedCount"": { ""type"": ""integer"" }, ""skippedLockedCount"": { ""type"": ""integer"" }, ""protectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
         }
 
-        private Task<AIReturn> ClearCanvasAsync(AIToolCall toolCall)
+        private async Task<AIReturn> ClearCanvasAsync(AIToolCall toolCall)
         {
             var output = new AIReturn { Request = toolCall };
 
@@ -85,7 +85,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (doc == null)
                 {
                     output.CreateError("No active Grasshopper document found.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 // Collect all canvas object GUIDs
@@ -136,17 +136,26 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         .Build();
 
                     output.CreateSuccess(body, toolCall);
-                    return Task.FromResult(output);
+                    return output;
                 }
+
+                var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                IReadOnlyList<Guid> acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
+                    : Array.Empty<Guid>();
+                var rejectedCount = reviewSession.Items.Count - acceptedGuids.Count;
 
                 // Delete via GhJsonGrasshopper (handles UI thread + undo)
                 var deleteOptions = new DeleteOptions { Redraw = true };
-                var deleteResult = GhJsonGrasshopper.Delete(allowedGuids, deleteOptions);
+                var deleteResult = GhJsonGrasshopper.Delete(acceptedGuids, deleteOptions);
 
                 var result = new JObject
                 {
                     ["deletedCount"] = deleteResult.DeletedCount,
                     ["deleted"] = JArray.FromObject(deleteResult.Deleted.Select(g => g.ToString())),
+                    ["rejectedCount"] = rejectedCount,
                     ["skippedLockedCount"] = skippedLockedCount,
                     ["protectedGuids"] = JArray.FromObject(protectedGuids.Select(g => g.ToString())),
                 };
@@ -162,20 +171,22 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }
 
                 result["message"] = deleteResult.DeletedCount > 0
-                    ? $"Successfully cleared canvas. Deleted {deleteResult.DeletedCount} component(s)."
-                    : "No components were deleted.";
+                    ? $"Deleted {deleteResult.DeletedCount} component(s); the user rejected {rejectedCount} staged removal(s)."
+                    : rejectedCount > 0
+                        ? "The user rejected all staged removals."
+                        : "No components were deleted.";
 
                 var outBody = AIBodyBuilder.Create()
                     .AddToolResult(result)
                     .Build();
 
                 output.CreateSuccess(outBody, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error clearing canvas: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Connect Grasshopper components together by creating wires between outputs and inputs. Use this to establish data flow between existing components on the canvas. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
+                description: "Stage wires between Grasshopper outputs and inputs, show the user an in-canvas visual review, and create only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -121,85 +121,108 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     return output;
                 }
 
-                var connectTcs = new TaskCompletionSource<(List<JObject> successful, List<JObject> failed)>();
+                var proposals = new List<CanvasConnectionReviewProposal>();
+                var failedConnections = new List<JObject>();
+                var protectedGuids = CanvasProtection.GetProtectedInstanceGuids();
+                foreach (var connSpec in connectionsArray)
+                {
+                    var sourceGuidString = connSpec["sourceGuid"]?.ToString();
+                    var targetGuidString = connSpec["targetGuid"]?.ToString();
+                    if (!Guid.TryParse(sourceGuidString, out var sourceGuid) ||
+                        !Guid.TryParse(targetGuidString, out var targetGuid))
+                    {
+                        failedConnections.Add(new JObject
+                        {
+                            ["error"] = "Missing or invalid sourceGuid or targetGuid",
+                            ["spec"] = connSpec,
+                        });
+                        continue;
+                    }
+
+                    if (protectedGuids.Contains(sourceGuid) || protectedGuids.Contains(targetGuid))
+                    {
+                        failedConnections.Add(new JObject
+                        {
+                            ["error"] = "Connection rejected because it involves a protected component.",
+                            ["sourceGuid"] = sourceGuidString,
+                            ["targetGuid"] = targetGuidString,
+                        });
+                        continue;
+                    }
+
+                    proposals.Add(new CanvasConnectionReviewProposal
+                    {
+                        SourceGuid = sourceGuid,
+                        TargetGuid = targetGuid,
+                        SourceParameter = connSpec["sourceParam"]?.ToString(),
+                        TargetParameter = connSpec["targetParam"]?.ToString(),
+                    });
+                }
+
+                var reviewSession = CanvasChangeReviewService.CreateConnectionSession(
+                    this.toolName,
+                    proposals,
+                    CanvasChangeKind.ConnectionAdded);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedIndexes = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
+                    : new HashSet<int>();
+                var representedIndexes = reviewSession.Items
+                    .Where(item => item.ComponentId.HasValue)
+                    .Select(item => item.ComponentId!.Value)
+                    .ToHashSet();
+                var connectTcs = new TaskCompletionSource<List<JObject>>();
                 Rhino.RhinoApp.InvokeOnUiThread(() =>
                 {
                     try
                     {
                         var successfulConnections = new List<JObject>();
-                        var failedConnections = new List<JObject>();
-                        var protectedGuids = CanvasProtection.GetProtectedInstanceGuids();
-
-                        foreach (var connSpec in connectionsArray)
+                        for (var index = 0; index < proposals.Count; index++)
                         {
-                            var sourceGuidStr = connSpec["sourceGuid"]?.ToString();
-                            var targetGuidStr = connSpec["targetGuid"]?.ToString();
-                            var sourceParamName = connSpec["sourceParam"]?.ToString();
-                            var targetParamName = connSpec["targetParam"]?.ToString();
-
-                            if (string.IsNullOrEmpty(sourceGuidStr) || string.IsNullOrEmpty(targetGuidStr))
+                            var proposal = proposals[index];
+                            if (!acceptedIndexes.Contains(index))
                             {
                                 failedConnections.Add(new JObject
                                 {
-                                    ["error"] = "Missing sourceGuid or targetGuid",
-                                    ["spec"] = connSpec
+                                    ["error"] = representedIndexes.Contains(index) ? "Connection rejected by the user." : "Source or target component was not found.",
+                                    ["sourceGuid"] = proposal.SourceGuid.ToString(),
+                                    ["targetGuid"] = proposal.TargetGuid.ToString(),
                                 });
                                 continue;
                             }
 
-                            if (!Guid.TryParse(sourceGuidStr, out var sourceGuid) || !Guid.TryParse(targetGuidStr, out var targetGuid))
+                            var success = GhJsonGrasshopper.Connect(
+                                proposal.SourceGuid,
+                                proposal.TargetGuid,
+                                proposal.SourceParameter,
+                                proposal.TargetParameter);
+                            var result = new JObject
                             {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Invalid GUID format",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
-                                continue;
-                            }
-
-                            if (protectedGuids.Contains(sourceGuid) || protectedGuids.Contains(targetGuid))
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection rejected because it involves a protected component.",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
-                                continue;
-                            }
-
-                            bool success = GhJsonGrasshopper.Connect(sourceGuid, targetGuid, sourceParamName, targetParamName);
-
+                                ["sourceGuid"] = proposal.SourceGuid.ToString(),
+                                ["targetGuid"] = proposal.TargetGuid.ToString(),
+                                ["sourceParam"] = proposal.SourceParameter ?? "(first output)",
+                                ["targetParam"] = proposal.TargetParameter ?? "(first input)",
+                            };
                             if (success)
                             {
-                                successfulConnections.Add(new JObject
-                                {
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                    ["sourceParam"] = sourceParamName ?? "(first output)",
-                                    ["targetParam"] = targetParamName ?? "(first input)",
-                                    ["status"] = "connected"
-                                });
+                                result["status"] = "connected";
+                                successfulConnections.Add(result);
                             }
                             else
                             {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection failed - check component GUIDs and parameter names",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
+                                result["error"] = "Connection failed - check component GUIDs and parameter names";
+                                failedConnections.Add(result);
                             }
                         }
 
-                        if (successfulConnections.Any())
+                        if (successfulConnections.Count > 0)
                         {
                             doc.NewSolution(false);
                             Instances.RedrawCanvas();
                         }
 
-                        connectTcs.SetResult((successfulConnections, failedConnections));
+                        connectTcs.SetResult(successfulConnections);
                     }
                     catch (Exception ex)
                     {
@@ -207,7 +230,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 });
 
-                var (successfulConnections, failedConnections) = await connectTcs.Task.ConfigureAwait(false);
+                var successfulConnections = await connectTcs.Task.ConfigureAwait(false);
 
                 var toolResult = new JObject
                 {

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Disconnect Grasshopper components by removing wires between outputs and inputs. Use this to break data flow between existing components on the canvas. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
+                description: "Stage Grasshopper wire removals, show the user an in-canvas visual review, and remove only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -123,6 +123,37 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 var successfulDisconnections = new List<JObject>();
                 var failedDisconnections = new List<JObject>();
+                var proposals = connectionsArray
+                    .Select(connSpec => new
+                    {
+                        Source = connSpec["sourceGuid"]?.ToString(),
+                        Target = connSpec["targetGuid"]?.ToString(),
+                        SourceParameter = connSpec["sourceParam"]?.ToString(),
+                        TargetParameter = connSpec["targetParam"]?.ToString(),
+                    })
+                    .Where(value =>
+                        Guid.TryParse(value.Source, out var sourceGuid) &&
+                        Guid.TryParse(value.Target, out var targetGuid) &&
+                        !CanvasProtection.IsProtected(sourceGuid) &&
+                        !CanvasProtection.IsProtected(targetGuid))
+                    .Select(value => new CanvasConnectionReviewProposal
+                    {
+                        SourceGuid = Guid.Parse(value.Source!),
+                        TargetGuid = Guid.Parse(value.Target!),
+                        SourceParameter = value.SourceParameter,
+                        TargetParameter = value.TargetParameter,
+                    })
+                    .ToList();
+                var reviewSession = CanvasChangeReviewService.CreateConnectionSession(
+                    this.toolName,
+                    proposals,
+                    CanvasChangeKind.ConnectionRemoved);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedIndexes = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
+                    : new HashSet<int>();
+                var proposalIndex = 0;
 
                 foreach (var connSpec in connectionsArray)
                 {
@@ -159,6 +190,17 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             ["sourceGuid"] = sourceGuidStr,
                             ["targetGuid"] = targetGuidStr,
                             ["error"] = "Disconnection rejected because it involves a protected component.",
+                        });
+                        continue;
+                    }
+
+                    if (!acceptedIndexes.Contains(proposalIndex++))
+                    {
+                        failedDisconnections.Add(new JObject
+                        {
+                            ["sourceGuid"] = sourceGuidStr,
+                            ["targetGuid"] = targetGuidStr,
+                            ["error"] = "Disconnection rejected by the user or an endpoint was not found.",
                         });
                         continue;
                     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
@@ -21,6 +21,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using GhJSON.Core.SchemaModels;
+using GhJSON.Grasshopper;
 using Grasshopper;
 using Grasshopper.Kernel.Special;
 using Newtonsoft.Json.Linq;
@@ -50,7 +52,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Create a visual group container around components to organize and annotate them. Use this to highlight related components, mark areas of interest, or add notes to the canvas. Requires component GUIDs from gh_get.",
+                description: "Stage a visual group around components, show the user an in-canvas review, and create it only after acceptance. Use this to organize or annotate related components. Requires component GUIDs from gh_get.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -80,7 +82,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
             // Specialized wrapper: gh_group_selected
             yield return new AITool(
                 name: "gh_group_selected",
-                description: "Create a group around currently selected components. Quick way to organize selected items without needing to specify GUIDs manually.",
+                description: "Stage a group around currently selected components and show the user an in-canvas review before creation. Quick way to organize selected items without specifying GUIDs manually.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -137,6 +139,52 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     return output;
                 }
 
+                var reviewDocument = GhJsonGrasshopper.GetByGuids(validGuids);
+                var memberIds = reviewDocument.Components
+                    .Where(component =>
+                        component.Id.HasValue &&
+                        component.InstanceGuid.HasValue &&
+                        validGuids.Contains(component.InstanceGuid.Value))
+                    .Select(component => component.Id!.Value)
+                    .ToList();
+                var proposedGroup = new GhJsonGroup
+                {
+                    Id = 1,
+                    Name = groupName,
+                    Members = memberIds,
+                };
+                var proposedDocument = new GhJsonDocument(
+                    reviewDocument.Schema,
+                    reviewDocument.Metadata,
+                    reviewDocument.Components,
+                    reviewDocument.Connections,
+                    new[] { proposedGroup });
+                var reviewItem = new CanvasChangeReviewItem(
+                    "group:0",
+                    CanvasChangeKind.GroupAdded,
+                    groupName ?? "Group",
+                    $"{memberIds.Count} member(s)")
+                {
+                    GroupIndex = 0,
+                };
+                var reviewSession = new CanvasChangeReviewSession(
+                    "Review AI group",
+                    this.toolName,
+                    proposedDocument,
+                    new[] { reviewItem });
+                if (!await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false) ||
+                    !reviewSession.IsEffectivelyAccepted(reviewItem))
+                {
+                    var rejectedResult = new JObject
+                    {
+                        ["group"] = null,
+                        ["grouped"] = new JArray(),
+                        ["rejected"] = true,
+                    };
+                    output.CreateSuccess(AIBodyBuilder.Create().AddToolResult(rejectedResult).Build(), toolCall);
+                    return output;
+                }
+
                 GH_Group group = null;
 
                 // Combine UI operations and result resolution in a single UI thread callback.
@@ -183,6 +231,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         if (canvas?.Document != null)
                         {
                             canvas.Document.AddObject(group, false);
+                            canvas.Document.UndoUtil.RecordAddObjectEvent("[SH] Add reviewed group", group);
                         }
 
                         // Update UI

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
@@ -49,7 +49,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Reposition components on the canvas by specifying target coordinates. Use absolute coordinates (canvas position) or relative offsets (move by delta). Useful for organizing layouts or separating component groups. Requires component GUIDs from gh_get.",
+                description: "Stage component moves at absolute coordinates or relative offsets, show target positions on the live canvas, and move only components accepted by the user. Useful for organizing layouts. Requires component GUIDs from gh_get.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -123,7 +123,16 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }
 
-                var movedList = CanvasAccess.MoveInstance(dict, relative);
+                var reviewSession = CanvasChangeReviewService.CreateMoveSession(this.toolName, dict, relative);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(reviewSession)
+                    : new HashSet<Guid>();
+                var acceptedTargets = dict
+                    .Where(entry => acceptedGuids.Contains(entry.Key))
+                    .ToDictionary(entry => entry.Key, entry => entry.Value);
+                var movedList = CanvasAccess.MoveInstance(acceptedTargets, relative);
 
                 var toolResult = new JObject
                 {

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,7 +34,6 @@ using Newtonsoft.Json.Linq;
 using SmartHopper.Core.Grasshopper.Utils.Canvas;
 using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.Infrastructure.AITools;
-using SmartHopper.Infrastructure.Dialogs;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
 using SmartHopper.ProviderSdk.AICall.Core.Returns;
 using SmartHopper.ProviderSdk.Diagnostics;
@@ -60,13 +58,13 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Add new components to the canvas from GhJSON format. Use this to create component networks, add missing components, or build parametric definitions. The GhJSON must include component types, positions, and connections. Component-specific state (e.g. Number Slider values under componentState.extensions['gh.numberslider'].value using the format 'current<min~max>', Panel text under componentState.extensions['gh.panel'].text) is preserved. Example: gh_put({ ghjson: '...' }) or gh_put({ ghjson: 'C:/path/to/file.ghjson' }). See also: gh_get, script_generate_and_place_on_canvas.",
+                description: "Stage components from GhJSON, show the user an in-canvas visual diff, and place only accepted changes. Use this to create component networks, add missing components, or build parametric definitions. The GhJSON must include component types, positions, and connections. Component-specific state (e.g. Number Slider values under componentState.extensions['gh.numberslider'].value using the format 'current<min~max>', Panel text under componentState.extensions['gh.panel'].text) is preserved. Example: gh_put({ ghjson: '...' }) or gh_put({ ghjson: 'C:/path/to/file.ghjson' }). See also: gh_get, script_generate_and_place_on_canvas.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
                     ""properties"": {
                         ""ghjson"": { ""type"": ""string"", ""description"": ""GhJSON document string, or an absolute file path to a .ghjson file containing the document."" },
-                        ""editMode"": { ""type"": ""boolean"", ""description"": ""When true, existing components on canvas will be replaced. User will be prompted for confirmation."" },
+                        ""editMode"": { ""type"": ""boolean"", ""description"": ""When true, proposed components with matching instance GUIDs are reviewed as modifications instead of additions."" },
                         ""autoOffset"": { ""type"": ""boolean"", ""default"": true, ""description"": ""When true, newly placed components are offset on the canvas so they do not overlap existing objects. In edit mode this defaults to false."" }
                     },
                     ""required"": [""ghjson""]
@@ -74,7 +72,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.GhPutToolAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "ghjson" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Names of the placed or replaced components."" }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the placed or replaced components."" }, ""analysis"": { ""type"": [""string"", ""null""], ""description"": ""Validation, error, or warning summary. Null when nothing notable happened."" } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Names of the placed or replaced components."" }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the placed or replaced components."" }, ""acceptedChanges"": { ""type"": ""integer"" }, ""rejectedChanges"": { ""type"": ""integer"" }, ""analysis"": { ""type"": [""string"", ""null""], ""description"": ""Validation, review, error, or warning summary. Null when nothing notable happened."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
         }
 
@@ -147,188 +145,74 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }
 
-                // In edit mode, check for existing components that match instanceGuids
                 var existingComponents = new Dictionary<Guid, IGH_DocumentObject>();
-                var existingPositions = new Dictionary<Guid, PointF>();
                 var componentsToReplace = new List<Guid>();
-                HashSet<Guid> unchangedGuids = null;
-
-                // Captured external connections: source/target component + parameter names
                 var capturedConnections = new List<ConnectionInfo>();
+                var existingDocument = new GhJsonDocument();
 
-                if (editMode && document?.Components != null)
+                if (editMode)
                 {
-                    // Step 1: Pre-compare components with canvas.
-                    // Collect all incoming components with an instanceGuid that exists on canvas,
-                    // then batch-serialize via GhJsonGrasshopper.GetByGuids for efficiency.
-                    var incomingWithGuid = document.Components
-                        .Where(c => c.InstanceGuid.HasValue && c.InstanceGuid.Value != Guid.Empty)
-                        .ToList();
-
-                    foreach (var compProps in incomingWithGuid)
+                    foreach (var component in document.Components.Where(component =>
+                                 component.InstanceGuid.HasValue && component.InstanceGuid.Value != Guid.Empty))
                     {
-                        var guid = compProps.InstanceGuid.Value;
+                        var guid = component.InstanceGuid!.Value;
                         var existing = CanvasAccess.FindInstance(guid);
                         if (existing != null)
                         {
                             existingComponents[guid] = existing;
-                            existingPositions[guid] = existing.Attributes.Pivot;
                         }
                     }
 
                     if (existingComponents.Count > 0)
                     {
-                        var guidsToCompare = existingComponents.Keys.ToList();
-                        var existingDoc = GhJsonGrasshopper.GetByGuids(guidsToCompare);
-
-                        foreach (var compProps in incomingWithGuid)
-                        {
-                            var guid = compProps.InstanceGuid.Value;
-                            if (!existingComponents.ContainsKey(guid))
-                            {
-                                continue;
-                            }
-
-                            var existingComp = existingDoc.Components
-                                .FirstOrDefault(c => c.InstanceGuid == guid);
-
-                            if (existingComp != null && ComponentsAreEqual(compProps, existingComp))
-                            {
-                                Debug.WriteLine($"[gh_put] Component '{existingComponents[guid].Name}' ({guid}) is unchanged, skipping replacement");
-                            }
-                            else
-                            {
-                                componentsToReplace.Add(guid);
-                                Debug.WriteLine($"[gh_put] Component '{existingComponents[guid].Name}' ({guid}) has changes, will prompt for replacement");
-                            }
-                        }
-                    }
-
-                    // Step 2: Prompt user for confirmation for each modified component
-                    if (componentsToReplace.Count > 0)
-                    {
-                        var confirmedReplacements = new List<Guid>();
-
-                        foreach (var guid in componentsToReplace)
-                        {
-                            var confirmTcs = new TaskCompletionSource<bool>();
-                            var componentName = existingComponents.TryGetValue(guid, out var comp) ? comp.Name : "Unknown";
-
-                            Rhino.RhinoApp.InvokeOnUiThread(() =>
-                            {
-                                try
-                                {
-                                    var message = $"Do you want to replace component '{componentName}' with the new definition'?\n\n" +
-                                                  "Click 'Yes' to replace this component.\n" +
-                                                  "Click 'No' to create a new component instead.";
-                                    var result = StyledMessageDialog.ShowConfirmation(message, "Replace", guid);
-                                    confirmTcs.SetResult(result);
-                                }
-                                catch (Exception ex)
-                                {
-                                    Debug.WriteLine($"[gh_put] Error showing confirmation dialog: {ex.Message}");
-                                    confirmTcs.SetResult(false);
-                                }
-                            });
-
-                            var shouldReplace = await confirmTcs.Task.ConfigureAwait(false);
-
-                            if (shouldReplace)
-                            {
-                                confirmedReplacements.Add(guid);
-                                Debug.WriteLine($"[gh_put] User confirmed replacement of component '{componentName}' ({guid})");
-                            }
-                            else
-                            {
-                                Debug.WriteLine($"[gh_put] User chose to create new component instead of replacing '{componentName}' ({guid})");
-                            }
-                        }
-
-                        // Update the lists to only include confirmed replacements
-                        componentsToReplace.Clear();
-                        componentsToReplace.AddRange(confirmedReplacements);
-
-                        // Capture unchanged GUIDs BEFORE mutating existingComponents so Step 3
-                        // can still filter out unchanged components correctly.
-                        unchangedGuids = existingComponents.Keys.Except(confirmedReplacements).ToHashSet();
-
-                        // Remove non-confirmed components from tracking dictionaries
-                        foreach (var guid in unchangedGuids)
-                        {
-                            existingComponents.Remove(guid);
-                            existingPositions.Remove(guid);
-                        }
-
-                        Debug.WriteLine($"[gh_put] Final replacement count: {componentsToReplace.Count}");
-
-                        // If no replacements were needed, all existing components are unchanged.
-                        // Ensure unchangedGuids is populated so Step 3 filters them out.
-                        if (unchangedGuids == null && existingComponents.Count > 0)
-                        {
-                            unchangedGuids = existingComponents.Keys.ToHashSet();
-                        }
-
-                        // Capture external connections for replaced components before removal
-                        if (componentsToReplace.Count > 0)
-                        {
-                            capturedConnections = GhJsonGrasshopper.CaptureExternalConnections(componentsToReplace).ToList();
-                            Debug.WriteLine($"[gh_put] Captured {capturedConnections.Count} external connections");
-                        }
-                    }
-
-                    // Step 3: Filter the document to only include components that need placement.
-                    // Unchanged existing components are stripped out so they are not duplicated.
-                    if (document.Components != null)
-                    {
-                        var filteredComponents = new List<GhJsonComponent>();
-                        var skippedGuids = new HashSet<Guid>();
-
-                        foreach (var comp in document.Components)
-                        {
-                            if (comp.InstanceGuid.HasValue && comp.InstanceGuid.Value != Guid.Empty)
-                            {
-                                var guid = comp.InstanceGuid.Value;
-                                if (unchangedGuids != null && unchangedGuids.Contains(guid))
-                                {
-                                    // This is an unchanged existing component — skip it
-                                    skippedGuids.Add(guid);
-                                    continue;
-                                }
-                            }
-
-                            filteredComponents.Add(comp);
-                        }
-
-                        if (skippedGuids.Count > 0)
-                        {
-                            Debug.WriteLine($"[gh_put] Filtered out {skippedGuids.Count} unchanged component(s) from document");
-
-                            // Build a set of remaining component IDs for connection filtering
-                            var remainingIds = new HashSet<int>(filteredComponents.Where(c => c.Id.HasValue).Select(c => c.Id.Value));
-
-                            // Filter connections to only those between remaining components
-                            var filteredConnections = document.Connections?.Where(conn =>
-                                remainingIds.Contains(conn.From.Id) && remainingIds.Contains(conn.To.Id)).ToList();
-
-                            // Filter groups to only those with at least one remaining member
-                            var filteredGroups = document.Groups?.Where(g =>
-                                g.Members?.Any(m => remainingIds.Contains(m)) == true).ToList();
-
-                            document = new GhJsonDocument(
-                                document.Schema,
-                                document.Metadata,
-                                filteredComponents,
-                                filteredConnections,
-                                filteredGroups);
-                        }
+                        existingDocument = GhJsonGrasshopper.GetByGuids(existingComponents.Keys);
                     }
                 }
 
-                if (document?.Components == null || !document.Components.Any())
+                var changePlan = GhPutChangePlan.Create(document, existingDocument);
+                if (changePlan.Session.Items.Count > 0)
                 {
-                    var msg = analysisMsg ?? "JSON must contain a non-empty components array";
-                    output.CreateError(msg);
-                    return output;
+                    if (!await CanvasChangeReviewService.ReviewAsync(changePlan.Session).ConfigureAwait(false))
+                    {
+                        return CreateNoPlacementResult(output, toolCall, "The user cancelled the staged canvas changes.", changePlan.Session.Items.Count);
+                    }
+                }
+
+                document = changePlan.BuildAcceptedDocument();
+                var acceptedExternalConnections = changePlan.GetAcceptedExternalConnections(document);
+                componentsToReplace.AddRange(document.Components
+                    .Where(component =>
+                        component.InstanceGuid.HasValue &&
+                        existingComponents.ContainsKey(component.InstanceGuid.Value))
+                    .Select(component => component.InstanceGuid!.Value));
+
+                foreach (var guid in existingComponents.Keys.Except(componentsToReplace).ToList())
+                {
+                    existingComponents.Remove(guid);
+                }
+
+                if (componentsToReplace.Count > 0)
+                {
+                    var invalidReplacements = document.Components
+                        .Where(component =>
+                            component.InstanceGuid.HasValue &&
+                            componentsToReplace.Contains(component.InstanceGuid.Value) &&
+                            !GhJsonGrasshopper.CanInstantiate(component))
+                        .Select(component => component.NickName ?? component.Name ?? component.InstanceGuid!.Value.ToString())
+                        .ToList();
+                    if (invalidReplacements.Count > 0)
+                    {
+                        output.CreateError($"Cannot apply staged replacement(s) because these components are unavailable: {string.Join(", ", invalidReplacements)}");
+                        return output;
+                    }
+
+                    capturedConnections = GhJsonGrasshopper.CaptureExternalConnections(componentsToReplace).ToList();
+                    Debug.WriteLine($"[gh_put] Captured {capturedConnections.Count} external connections");
+                }
+
+                if (document.Components.Count == 0)
+                {
+                    return CreateNoPlacementResult(output, toolCall, "No staged canvas changes were selected.", changePlan.Session.Items.Count);
                 }
 
                 // Put operation must run on UI thread.
@@ -379,6 +263,41 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             throw new InvalidOperationException($"Put failed: {putResult.ErrorMessage}");
                         }
 
+                        var externalConnectionsCreated = 0;
+                        if (acceptedExternalConnections.Count > 0)
+                        {
+                            var resolvedGuids = new Dictionary<int, Guid>(putResult.IdToGuidMapping);
+                            foreach (var connection in acceptedExternalConnections)
+                            {
+                                if (!resolvedGuids.ContainsKey(connection.From.Id) &&
+                                    changePlan.GetExistingInstanceGuid(connection.From.Id) is Guid sourceGuid)
+                                {
+                                    resolvedGuids[connection.From.Id] = sourceGuid;
+                                }
+
+                                if (!resolvedGuids.ContainsKey(connection.To.Id) &&
+                                    changePlan.GetExistingInstanceGuid(connection.To.Id) is Guid targetGuid)
+                                {
+                                    resolvedGuids[connection.To.Id] = targetGuid;
+                                }
+
+                                if (resolvedGuids.TryGetValue(connection.From.Id, out var resolvedSource) &&
+                                    resolvedGuids.TryGetValue(connection.To.Id, out var resolvedTarget) &&
+                                    !protectedGuids.Contains(resolvedSource) &&
+                                    !protectedGuids.Contains(resolvedTarget))
+                                {
+                                    if (GhJsonGrasshopper.Connect(
+                                        resolvedSource,
+                                        resolvedTarget,
+                                        connection.From.ParamName,
+                                        connection.To.ParamName))
+                                    {
+                                        externalConnectionsCreated++;
+                                    }
+                                }
+                            }
+                        }
+
                         // Restore captured external connections
                         if (capturedConnections.Count > 0)
                         {
@@ -420,6 +339,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             }
                         }
 
+                        if (externalConnectionsCreated > 0)
+                        {
+                            ghDoc?.NewSolution(false);
+                            Instances.RedrawCanvas();
+                        }
+
                         placeTcs.SetResult(true);
                     }
                     catch (Exception ex)
@@ -455,6 +380,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     analysisSections.Add(CanvasProtection.FormatProtectionMessage(protectedPutGuids));
                 }
 
+                var rejectedChanges = changePlan.Session.Items.Count - changePlan.Session.AcceptedCount;
+                if (rejectedChanges > 0)
+                {
+                    analysisSections.Add($"The user rejected {rejectedChanges} of {changePlan.Session.Items.Count} staged change(s).");
+                }
+
                 if (putResult.FailedComponents != null && putResult.FailedComponents.Count > 0)
                 {
                     var lines = new List<string> { "Errors:" };
@@ -485,6 +416,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 {
                     ["components"] = JArray.FromObject(placedNames),
                     ["instanceGuids"] = JArray.FromObject(placedGuids),
+                    ["acceptedChanges"] = changePlan.Session.AcceptedCount,
+                    ["rejectedChanges"] = rejectedChanges,
                     ["analysis"] = combinedAnalysis,
                 };
 
@@ -565,57 +498,23 @@ namespace SmartHopper.Core.Grasshopper.AITools
         }
 
         /// <summary>
-        /// Compares two GhJSON component representations for structural equality,
-        /// ignoring volatile fields such as runtime messages, IDs, and selection state.
+        /// Creates a successful tool result when a staged proposal is cancelled or contains no selected changes.
         /// </summary>
-        private static bool ComponentsAreEqual(GhJsonComponent incoming, GhJsonComponent existing)
+        private static AIReturn CreateNoPlacementResult(AIReturn output, AIToolCall toolCall, string message, int rejectedChanges)
         {
-            var incomingJObj = JObject.FromObject(incoming);
-            var existingJObj = JObject.FromObject(existing);
-
-            // Remove volatile fields that should not affect equality
-            incomingJObj.Remove("id");
-            incomingJObj.Remove("errors");
-            incomingJObj.Remove("warnings");
-            incomingJObj.Remove("remarks");
-
-            existingJObj.Remove("id");
-            existingJObj.Remove("errors");
-            existingJObj.Remove("warnings");
-            existingJObj.Remove("remarks");
-
-            // Remove selection state from componentState if present
-            if (incomingJObj["componentState"] is JObject incomingState)
+            var toolResult = new JObject
             {
-                incomingState.Remove("selected");
-            }
-
-            if (existingJObj["componentState"] is JObject existingState)
-            {
-                existingState.Remove("selected");
-            }
-
-            // Remove runtime data from parameter settings. Runtime data is computed by the
-            // canvas and is not part of the component's structural definition, so including
-            // it makes every existing component look different from an incoming definition.
-            static void RemoveRuntimeData(JObject jObj)
-            {
-                foreach (var settingsKey in new[] { "inputSettings", "outputSettings" })
-                {
-                    if (jObj[settingsKey] is JArray settingsArray)
-                    {
-                        foreach (var itemObj in settingsArray.OfType<JObject>())
-                        {
-                            itemObj.Remove("runtimeData");
-                        }
-                    }
-                }
-            }
-
-            RemoveRuntimeData(incomingJObj);
-            RemoveRuntimeData(existingJObj);
-
-            return JToken.DeepEquals(incomingJObj, existingJObj);
+                ["components"] = new JArray(),
+                ["instanceGuids"] = new JArray(),
+                ["acceptedChanges"] = 0,
+                ["rejectedChanges"] = rejectedChanges,
+                ["analysis"] = message,
+            };
+            var body = AIBodyBuilder.Create()
+                .AddToolResult(toolResult)
+                .Build();
+            output.CreateSuccess(body, toolCall);
+            return output;
         }
 
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
@@ -48,7 +48,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Remove components from the Grasshopper canvas by their instance GUIDs. The operation records an undo event so the user can reverse it with Ctrl+Z. Use GUIDs from gh_get or similar tools.",
+                description: "Stage component removals by instance GUID, show the user an in-canvas visual review, and remove only accepted objects. The operation records an undo event so the user can reverse it with Ctrl+Z. Use GUIDs from gh_get or similar tools.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -64,11 +64,11 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.GhRemoveToolAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""removedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""removedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
         }
 
-        private Task<AIReturn> GhRemoveToolAsync(AIToolCall toolCall)
+        private async Task<AIReturn> GhRemoveToolAsync(AIToolCall toolCall)
         {
             var output = new AIReturn { Request = toolCall };
 
@@ -83,7 +83,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (guidArray == null || guidArray.Count == 0)
                 {
                     output.CreateError("Missing or empty 'instanceGuids' parameter.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var requestedGuids = guidArray
@@ -95,7 +95,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (requestedGuids.Count == 0)
                 {
                     output.CreateError("No valid GUIDs provided in 'instanceGuids'.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var (allowedGuids, protectedGuids) = CanvasProtection.FilterProtectedGuids(requestedGuids);
@@ -108,13 +108,24 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         CanvasProtection.FormatProtectionMessage(protectedGuids));
                 }
 
-                var removedGuids = CanvasAccess.RemoveInstances(allowedGuids);
+                var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                IReadOnlyList<Guid> acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
+                    : Array.Empty<Guid>();
+                var rejectedGuids = reviewSession.Items
+                    .Where(item => item.ExistingInstanceGuid.HasValue &&
+                        (!applyReview || !reviewSession.IsEffectivelyAccepted(item)))
+                    .Select(item => item.ExistingInstanceGuid!.Value)
+                    .ToList();
+                var removedGuids = CanvasAccess.RemoveInstances(acceptedGuids);
                 var notFoundGuids = allowedGuids
-                    .Except(removedGuids)
+                    .Except(reviewSession.Items.Where(item => item.ExistingInstanceGuid.HasValue).Select(item => item.ExistingInstanceGuid!.Value))
                     .Select(g => g.ToString())
                     .ToList();
 
-                if (removedGuids.Count == 0 && protectedGuids.Count == 0)
+                if (removedGuids.Count == 0 && protectedGuids.Count == 0 && rejectedGuids.Count == 0)
                 {
                     output.AddRuntimeMessage(
                         SHRuntimeMessageSeverity.Warning,
@@ -125,6 +136,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 var toolResult = new JObject
                 {
                     ["removedGuids"] = JArray.FromObject(removedGuids.Select(g => g.ToString())),
+                    ["rejectedGuids"] = JArray.FromObject(rejectedGuids.Select(g => g.ToString())),
                     ["notFoundGuids"] = JArray.FromObject(notFoundGuids),
                     ["protectedGuids"] = JArray.FromObject(protectedGuids.Select(g => g.ToString())),
                 };
@@ -134,12 +146,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     .Build();
 
                 output.CreateSuccess(body, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
@@ -1,0 +1,462 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+using Grasshopper;
+using Grasshopper.GUI.Canvas;
+using Grasshopper.Kernel;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Paints a non-mutating visual representation of staged changes over the actual Grasshopper canvas.
+    /// </summary>
+    public static class CanvasChangePreviewOverlay
+    {
+        private static readonly Color AddedColor = Color.FromArgb(230, 45, 164, 78);
+        private static readonly Color ModifiedColor = Color.FromArgb(230, 191, 135, 0);
+        private static readonly Color RemovedColor = Color.FromArgb(230, 207, 34, 46);
+        private static readonly Color GroupColor = Color.FromArgb(230, 130, 80, 223);
+        private static readonly Color WireColor = Color.FromArgb(230, 9, 105, 218);
+        private static bool initialized;
+        private static CanvasChangeReviewSession? activeSession;
+        private static string? highlightedKey;
+
+        /// <summary>
+        /// Hooks Grasshopper canvas paint events. Safe to call multiple times.
+        /// </summary>
+        public static void EnsureInitialized()
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            AttachToCanvas(Instances.ActiveCanvas);
+            Instances.CanvasCreated += AttachToCanvas;
+            initialized = true;
+        }
+
+        /// <summary>
+        /// Starts displaying a staged review session.
+        /// </summary>
+        /// <param name="session">Session to display.</param>
+        public static void Begin(CanvasChangeReviewSession session)
+        {
+            EnsureInitialized();
+            End();
+            activeSession = session ?? throw new ArgumentNullException(nameof(session));
+            activeSession.SelectionChanged += OnSelectionChanged;
+            RefreshCanvas();
+        }
+
+        /// <summary>
+        /// Stops displaying the current staged review session.
+        /// </summary>
+        public static void End()
+        {
+            if (activeSession != null)
+            {
+                activeSession.SelectionChanged -= OnSelectionChanged;
+            }
+
+            activeSession = null;
+            highlightedKey = null;
+            RefreshCanvas();
+        }
+
+        /// <summary>
+        /// Highlights one review item on the canvas.
+        /// </summary>
+        /// <param name="key">Item key, or <c>null</c> to clear the highlight.</param>
+        public static void Highlight(string? key)
+        {
+            highlightedKey = key;
+            RefreshCanvas();
+        }
+
+        private static void AttachToCanvas(GH_Canvas? canvas)
+        {
+            if (canvas == null)
+            {
+                return;
+            }
+
+            canvas.CanvasPostPaintOverlay -= OnCanvasPostPaintOverlay;
+            canvas.CanvasPostPaintOverlay += OnCanvasPostPaintOverlay;
+        }
+
+        private static void OnSelectionChanged(object? sender, EventArgs e)
+        {
+            RefreshCanvas();
+        }
+
+        private static void RefreshCanvas()
+        {
+            try
+            {
+                Instances.ActiveCanvas?.Refresh();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"[CanvasChangePreviewOverlay] Canvas refresh skipped: {ex.Message}");
+            }
+        }
+
+        private static void OnCanvasPostPaintOverlay(GH_Canvas canvas)
+        {
+            var session = activeSession;
+            if (session == null || canvas?.Document == null || canvas.Graphics == null)
+            {
+                return;
+            }
+
+            var graphics = canvas.Graphics;
+            var oldTransform = graphics.Transform;
+            graphics.ResetTransform();
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+            try
+            {
+                foreach (var item in session.Items.OrderBy(GetPaintOrder))
+                {
+                    DrawItem(graphics, canvas, session, item);
+                }
+            }
+            finally
+            {
+                graphics.Transform = oldTransform;
+                oldTransform.Dispose();
+            }
+        }
+
+        private static int GetPaintOrder(CanvasChangeReviewItem item)
+        {
+            return item.Kind switch
+            {
+                CanvasChangeKind.GroupAdded or CanvasChangeKind.GroupModified or CanvasChangeKind.GroupRemoved => 0,
+                CanvasChangeKind.ConnectionAdded or CanvasChangeKind.ConnectionRemoved => 1,
+                _ => 2,
+            };
+        }
+
+        private static void DrawItem(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item)
+        {
+            var effective = session.IsEffectivelyAccepted(item);
+            var highlighted = string.Equals(highlightedKey, item.Key, StringComparison.Ordinal);
+            var alpha = effective ? 230 : 55;
+            var color = Color.FromArgb(alpha, GetColor(item.Kind));
+            var width = highlighted ? 4f : 2.2f;
+
+            switch (item.Kind)
+            {
+                case CanvasChangeKind.ComponentAdded:
+                    DrawAddedComponent(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.ComponentModified:
+                case CanvasChangeKind.ComponentRemoved:
+                    DrawExistingComponent(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.ConnectionAdded:
+                case CanvasChangeKind.ConnectionRemoved:
+                    DrawConnection(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.GroupAdded:
+                case CanvasChangeKind.GroupModified:
+                case CanvasChangeKind.GroupRemoved:
+                    DrawGroup(graphics, canvas, session, item, color, width);
+                    break;
+            }
+        }
+
+        private static void DrawAddedComponent(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            var component = FindComponent(session, item.ComponentId);
+            if (component?.Pivot == null)
+            {
+                return;
+            }
+
+            var bounds = ProjectProposedBounds(canvas.Viewport, component);
+            using var fill = new SolidBrush(Color.FromArgb(Math.Min((int)color.A, 45), color));
+            using var pen = CreatePen(color, width);
+            graphics.FillRoundedRectangle(fill, bounds, 6f);
+            graphics.DrawRoundedRectangle(pen, bounds, 6f);
+            DrawLabel(graphics, bounds, component.NickName ?? component.Name ?? "Component", color);
+        }
+
+        private static void DrawExistingComponent(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (!item.ExistingInstanceGuid.HasValue)
+            {
+                return;
+            }
+
+            var obj = canvas.Document.FindObject(item.ExistingInstanceGuid.Value, false);
+            if (obj?.Attributes == null)
+            {
+                return;
+            }
+
+            var bounds = ProjectBounds(canvas.Viewport, obj.Attributes.Bounds);
+            bounds.Inflate(4f, 4f);
+            using var fill = new SolidBrush(Color.FromArgb(Math.Min((int)color.A, 35), color));
+            using var pen = CreatePen(color, width);
+            graphics.FillRoundedRectangle(fill, bounds, 6f);
+            graphics.DrawRoundedRectangle(pen, bounds, 6f);
+
+            var proposed = FindComponent(session, item.ComponentId);
+            if (item.Kind == CanvasChangeKind.ComponentModified && proposed?.Pivot != null)
+            {
+                var targetBounds = ProjectProposedBounds(canvas.Viewport, proposed);
+                var currentCenter = new PointF(bounds.Left + (bounds.Width / 2f), bounds.Top + (bounds.Height / 2f));
+                var targetCenter = new PointF(targetBounds.Left + (targetBounds.Width / 2f), targetBounds.Top + (targetBounds.Height / 2f));
+                if (Math.Abs(currentCenter.X - targetCenter.X) > 4f || Math.Abs(currentCenter.Y - targetCenter.Y) > 4f)
+                {
+                    graphics.DrawRoundedRectangle(pen, targetBounds, 6f);
+                    graphics.DrawLine(pen, currentCenter, targetCenter);
+                    DrawLabel(graphics, targetBounds, "Proposed position", color);
+                }
+            }
+
+            if (item.Kind == CanvasChangeKind.ComponentRemoved)
+            {
+                graphics.DrawLine(pen, bounds.Left, bounds.Top, bounds.Right, bounds.Bottom);
+                graphics.DrawLine(pen, bounds.Right, bounds.Top, bounds.Left, bounds.Bottom);
+            }
+
+            DrawLabel(graphics, bounds, item.Kind == CanvasChangeKind.ComponentModified ? "Modified" : "Removed", color);
+        }
+
+        private static void DrawConnection(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (!item.ConnectionIndex.HasValue || session.ProposedDocument.Connections == null ||
+                item.ConnectionIndex.Value >= session.ProposedDocument.Connections.Count)
+            {
+                return;
+            }
+
+            var connection = session.ProposedDocument.Connections[item.ConnectionIndex.Value];
+            if (!TryGetAnchor(canvas, session, connection.From.Id, true, out var from) ||
+                !TryGetAnchor(canvas, session, connection.To.Id, false, out var to))
+            {
+                return;
+            }
+
+            var offset = Math.Max(30f, Math.Abs(to.X - from.X) * 0.45f);
+            using var path = new GraphicsPath();
+            path.AddBezier(from, new PointF(from.X + offset, from.Y), new PointF(to.X - offset, to.Y), to);
+            using var pen = CreatePen(color, width);
+            graphics.DrawPath(pen, path);
+        }
+
+        private static void DrawGroup(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (item.ExistingInstanceGuid.HasValue &&
+                canvas.Document.FindObject(item.ExistingInstanceGuid.Value, false)?.Attributes is IGH_Attributes existingAttributes)
+            {
+                var existingBounds = ProjectBounds(canvas.Viewport, existingAttributes.Bounds);
+                existingBounds.Inflate(4f, 4f);
+                using var existingPen = CreatePen(color, width);
+                graphics.DrawRoundedRectangle(existingPen, existingBounds, 8f);
+                DrawLabel(graphics, existingBounds, item.Title, color);
+                return;
+            }
+
+            if (!item.GroupIndex.HasValue || session.ProposedDocument.Groups == null ||
+                item.GroupIndex.Value >= session.ProposedDocument.Groups.Count)
+            {
+                return;
+            }
+
+            var group = session.ProposedDocument.Groups[item.GroupIndex.Value];
+            RectangleF? groupBounds = null;
+            foreach (var memberId in group.Members)
+            {
+                var component = session.ProposedDocument.Components.FirstOrDefault(candidate => candidate.Id == memberId);
+                if (component == null)
+                {
+                    continue;
+                }
+
+                RectangleF bounds;
+                if (component.InstanceGuid.HasValue &&
+                    canvas.Document.FindObject(component.InstanceGuid.Value, false)?.Attributes is IGH_Attributes attributes)
+                {
+                    bounds = ProjectBounds(canvas.Viewport, attributes.Bounds);
+                }
+                else if (component.Pivot != null)
+                {
+                    bounds = ProjectProposedBounds(canvas.Viewport, component);
+                }
+                else
+                {
+                    continue;
+                }
+
+                groupBounds = groupBounds.HasValue ? RectangleF.Union(groupBounds.Value, bounds) : bounds;
+            }
+
+            if (!groupBounds.HasValue)
+            {
+                return;
+            }
+
+            var result = groupBounds.Value;
+            result.Inflate(16f, 18f);
+            using var pen = CreatePen(color, width);
+            graphics.DrawRoundedRectangle(pen, result, 8f);
+            DrawLabel(graphics, result, group.Name ?? "Group", color);
+        }
+
+        private static bool TryGetAnchor(
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            int componentId,
+            bool output,
+            out PointF anchor)
+        {
+            var component = session.ProposedDocument.Components.FirstOrDefault(candidate => candidate.Id == componentId);
+            if (component?.InstanceGuid.HasValue == true &&
+                canvas.Document.FindObject(component.InstanceGuid.Value, false)?.Attributes is IGH_Attributes attributes)
+            {
+                var bounds = ProjectBounds(canvas.Viewport, attributes.Bounds);
+                anchor = new PointF(output ? bounds.Right : bounds.Left, bounds.Top + (bounds.Height / 2f));
+                return true;
+            }
+
+            if (component?.Pivot != null)
+            {
+                var bounds = ProjectProposedBounds(canvas.Viewport, component);
+                anchor = new PointF(output ? bounds.Right : bounds.Left, bounds.Top + (bounds.Height / 2f));
+                return true;
+            }
+
+            anchor = PointF.Empty;
+            return false;
+        }
+
+        private static GhJsonComponent? FindComponent(CanvasChangeReviewSession session, int? componentId)
+        {
+            return componentId.HasValue
+                ? session.ProposedDocument.Components.FirstOrDefault(component => component.Id == componentId.Value)
+                : null;
+        }
+
+        private static RectangleF ProjectProposedBounds(GH_Viewport viewport, GhJsonComponent component)
+        {
+            var worldBounds = new RectangleF(
+                (float)component.Pivot!.X,
+                (float)component.Pivot.Y,
+                140f,
+                52f);
+            return ProjectBounds(viewport, worldBounds);
+        }
+
+        private static RectangleF ProjectBounds(GH_Viewport viewport, RectangleF bounds)
+        {
+            var topLeft = new PointF(bounds.Left, bounds.Top);
+            var bottomRight = new PointF(bounds.Right, bounds.Bottom);
+            viewport.Project(ref topLeft);
+            viewport.Project(ref bottomRight);
+            return RectangleF.FromLTRB(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
+        }
+
+        private static Pen CreatePen(Color color, float width)
+        {
+            return new Pen(color, width)
+            {
+                DashStyle = DashStyle.Dash,
+            };
+        }
+
+        private static Color GetColor(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => AddedColor,
+                CanvasChangeKind.ComponentModified => ModifiedColor,
+                CanvasChangeKind.ComponentRemoved => RemovedColor,
+                CanvasChangeKind.ConnectionAdded => WireColor,
+                CanvasChangeKind.ConnectionRemoved => RemovedColor,
+                _ => GroupColor,
+            };
+        }
+
+        private static void DrawLabel(Graphics graphics, RectangleF bounds, string text, Color color)
+        {
+            using var font = new Font("Segoe UI", 8.5f, FontStyle.Bold);
+            var size = graphics.MeasureString(text, font);
+            var labelBounds = new RectangleF(bounds.Left, bounds.Top - size.Height - 3f, size.Width + 10f, size.Height + 2f);
+            using var brush = new SolidBrush(color);
+            using var textBrush = new SolidBrush(Color.White);
+            graphics.FillRoundedRectangle(brush, labelBounds, 5f);
+            graphics.DrawString(text, font, textBrush, labelBounds.Left + 5f, labelBounds.Top + 1f);
+        }
+
+        private static void FillRoundedRectangle(this Graphics graphics, Brush brush, RectangleF bounds, float radius)
+        {
+            using var path = CreateRoundedRectangle(bounds, radius);
+            graphics.FillPath(brush, path);
+        }
+
+        private static void DrawRoundedRectangle(this Graphics graphics, Pen pen, RectangleF bounds, float radius)
+        {
+            using var path = CreateRoundedRectangle(bounds, radius);
+            graphics.DrawPath(pen, path);
+        }
+
+        private static GraphicsPath CreateRoundedRectangle(RectangleF bounds, float radius)
+        {
+            var diameter = radius * 2f;
+            var path = new GraphicsPath();
+            path.AddArc(bounds.Left, bounds.Top, diameter, diameter, 180f, 90f);
+            path.AddArc(bounds.Right - diameter, bounds.Top, diameter, diameter, 270f, 90f);
+            path.AddArc(bounds.Right - diameter, bounds.Bottom - diameter, diameter, diameter, 0f, 90f);
+            path.AddArc(bounds.Left, bounds.Bottom - diameter, diameter, diameter, 90f, 90f);
+            path.CloseFigure();
+            return path;
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
@@ -1,0 +1,195 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Identifies the visual category of a staged canvas change.
+    /// </summary>
+    public enum CanvasChangeKind
+    {
+        /// <summary>A component will be added.</summary>
+        ComponentAdded,
+
+        /// <summary>An existing component will be replaced with modified state.</summary>
+        ComponentModified,
+
+        /// <summary>A component will be removed.</summary>
+        ComponentRemoved,
+
+        /// <summary>A connection will be added.</summary>
+        ConnectionAdded,
+
+        /// <summary>A connection will be removed.</summary>
+        ConnectionRemoved,
+
+        /// <summary>A group will be added.</summary>
+        GroupAdded,
+
+        /// <summary>An existing group will be modified.</summary>
+        GroupModified,
+
+        /// <summary>A group will be removed.</summary>
+        GroupRemoved,
+    }
+
+    /// <summary>
+    /// Represents one independently selectable change in a staged canvas proposal.
+    /// </summary>
+    public sealed class CanvasChangeReviewItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasChangeReviewItem"/> class.
+        /// </summary>
+        /// <param name="key">Stable key within the proposal.</param>
+        /// <param name="kind">Change category.</param>
+        /// <param name="title">Short user-facing title.</param>
+        /// <param name="detail">Optional user-facing detail.</param>
+        public CanvasChangeReviewItem(string key, CanvasChangeKind kind, string title, string detail = "")
+        {
+            this.Key = key ?? throw new ArgumentNullException(nameof(key));
+            this.Kind = kind;
+            this.Title = title ?? throw new ArgumentNullException(nameof(title));
+            this.Detail = detail ?? string.Empty;
+        }
+
+        /// <summary>Gets the stable key within the proposal.</summary>
+        public string Key { get; }
+
+        /// <summary>Gets the visual change category.</summary>
+        public CanvasChangeKind Kind { get; }
+
+        /// <summary>Gets the short user-facing title.</summary>
+        public string Title { get; }
+
+        /// <summary>Gets the optional user-facing detail.</summary>
+        public string Detail { get; }
+
+        /// <summary>Gets or sets whether this change should be applied.</summary>
+        public bool IsAccepted { get; set; } = true;
+
+        /// <summary>Gets or sets the affected live component instance GUID.</summary>
+        public Guid? ExistingInstanceGuid { get; set; }
+
+        /// <summary>Gets or sets the proposed component ID.</summary>
+        public int? ComponentId { get; set; }
+
+        /// <summary>Gets or sets the index of the proposed connection.</summary>
+        public int? ConnectionIndex { get; set; }
+
+        /// <summary>Gets or sets the index of the proposed group.</summary>
+        public int? GroupIndex { get; set; }
+
+        /// <summary>Gets keys of component changes required by this change.</summary>
+        public IList<string> RequiredItemKeys { get; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Holds an immutable proposal document and mutable user selections for one review operation.
+    /// </summary>
+    public sealed class CanvasChangeReviewSession
+    {
+        private readonly IReadOnlyDictionary<string, CanvasChangeReviewItem> itemsByKey;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasChangeReviewSession"/> class.
+        /// </summary>
+        /// <param name="title">Review title.</param>
+        /// <param name="source">Name of the tool that produced the proposal.</param>
+        /// <param name="proposedDocument">Proposed GhJSON fragment.</param>
+        /// <param name="items">Selectable changes.</param>
+        public CanvasChangeReviewSession(
+            string title,
+            string source,
+            GhJsonDocument proposedDocument,
+            IEnumerable<CanvasChangeReviewItem> items)
+        {
+            this.Title = title ?? throw new ArgumentNullException(nameof(title));
+            this.Source = source ?? throw new ArgumentNullException(nameof(source));
+            this.ProposedDocument = proposedDocument ?? throw new ArgumentNullException(nameof(proposedDocument));
+            this.Items = (items ?? throw new ArgumentNullException(nameof(items))).ToList();
+            this.itemsByKey = this.Items.ToDictionary(item => item.Key, StringComparer.Ordinal);
+        }
+
+        /// <summary>Occurs when an acceptance selection changes.</summary>
+        public event EventHandler? SelectionChanged;
+
+        /// <summary>Gets the review title.</summary>
+        public string Title { get; }
+
+        /// <summary>Gets the proposal source.</summary>
+        public string Source { get; }
+
+        /// <summary>Gets the proposed GhJSON fragment.</summary>
+        public GhJsonDocument ProposedDocument { get; }
+
+        /// <summary>Gets the selectable changes.</summary>
+        public IReadOnlyList<CanvasChangeReviewItem> Items { get; }
+
+        /// <summary>Gets the number of accepted changes whose dependencies are also accepted.</summary>
+        public int AcceptedCount => this.Items.Count(this.IsEffectivelyAccepted);
+
+        /// <summary>
+        /// Determines whether a change and all of its dependencies are accepted.
+        /// </summary>
+        /// <param name="item">Change to inspect.</param>
+        /// <returns><c>true</c> when the change can be applied.</returns>
+        public bool IsEffectivelyAccepted(CanvasChangeReviewItem item)
+        {
+            return item.IsAccepted && item.RequiredItemKeys.All(key =>
+                !this.itemsByKey.TryGetValue(key, out var required) || required.IsAccepted);
+        }
+
+        /// <summary>
+        /// Updates one change selection.
+        /// </summary>
+        /// <param name="key">Change key.</param>
+        /// <param name="isAccepted">Whether the change is accepted.</param>
+        public void SetAccepted(string key, bool isAccepted)
+        {
+            if (!this.itemsByKey.TryGetValue(key, out var item) || item.IsAccepted == isAccepted)
+            {
+                return;
+            }
+
+            item.IsAccepted = isAccepted;
+            this.SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Updates all change selections.
+        /// </summary>
+        /// <param name="isAccepted">Whether all changes are accepted.</param>
+        public void SetAllAccepted(bool isAccepted)
+        {
+            var changed = false;
+            foreach (var item in this.Items)
+            {
+                if (item.IsAccepted == isAccepted)
+                {
+                    continue;
+                }
+
+                item.IsAccepted = isAccepted;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                this.SelectionChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
@@ -1,0 +1,275 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using Eto.Drawing;
+using Eto.Forms;
+using Rhino.UI;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Presents a modal checklist for a staged canvas proposal while the proposal is painted over the actual canvas.
+    /// </summary>
+    public sealed class CanvasChangeReviewDialog : Dialog<bool>
+    {
+        private readonly Dictionary<string, CheckBox> checkBoxes = new Dictionary<string, CheckBox>(StringComparer.Ordinal);
+        private readonly Label summaryLabel;
+        private readonly CanvasChangeReviewSession session;
+
+        private CanvasChangeReviewDialog(CanvasChangeReviewSession session)
+        {
+            this.session = session ?? throw new ArgumentNullException(nameof(session));
+            this.Title = session.Title;
+            this.Resizable = true;
+            this.ClientSize = new Size(440, 620);
+            this.MinimumSize = new Size(380, 420);
+            this.Padding = new Padding(16);
+
+            var title = new Label
+            {
+                Text = "Review AI canvas changes",
+                Font = new Font(SystemFont.Bold, 16),
+            };
+            var subtitle = new Label
+            {
+                Text = $"{session.Items.Count} staged change(s) from {session.Source}. The canvas is unchanged until you apply.",
+                Wrap = WrapMode.Word,
+                TextColor = Colors.Gray,
+            };
+
+            var changesLayout = new DynamicLayout
+            {
+                DefaultSpacing = new Size(8, 5),
+                Padding = new Padding(0, 8),
+            };
+            foreach (var item in session.Items)
+            {
+                changesLayout.Add(this.CreateChangeRow(item));
+            }
+
+            var scrollable = new Scrollable
+            {
+                Border = BorderType.None,
+                Content = changesLayout,
+                ExpandContentWidth = true,
+            };
+            this.summaryLabel = new Label
+            {
+                TextColor = Colors.Gray,
+            };
+
+            var acceptAllButton = new Button { Text = "Accept all" };
+            acceptAllButton.Click += (_, _) => this.SetAll(true);
+            var rejectAllButton = new Button { Text = "Reject all" };
+            rejectAllButton.Click += (_, _) => this.SetAll(false);
+            var cancelButton = new Button { Text = "Cancel" };
+            cancelButton.Click += (_, _) => this.Close(false);
+            var applyButton = new Button { Text = "Apply selected" };
+            applyButton.Click += (_, _) => this.Close(true);
+            this.DefaultButton = applyButton;
+            this.AbortButton = cancelButton;
+
+            var selectionButtons = new StackLayout
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Items = { acceptAllButton, rejectAllButton },
+            };
+            var actionButtons = new StackLayout
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalContentAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Items = { cancelButton, applyButton },
+            };
+
+            this.Content = new TableLayout
+            {
+                Spacing = new Size(8, 10),
+                Rows =
+                {
+                    new TableRow(title),
+                    new TableRow(subtitle),
+                    new TableRow(scrollable) { ScaleHeight = true },
+                    new TableRow(this.summaryLabel),
+                    new TableRow(new TableLayout
+                    {
+                        Spacing = new Size(8, 0),
+                        Rows =
+                        {
+                            new TableRow(
+                                new TableCell(selectionButtons, true),
+                                new TableCell(actionButtons, false)),
+                        },
+                    }),
+                },
+            };
+
+            this.session.SelectionChanged += this.OnSelectionChanged;
+            this.UpdateSummary();
+        }
+
+        /// <summary>
+        /// Shows a staged review and returns whether the user chose to apply the selected changes.
+        /// </summary>
+        /// <param name="session">Review session.</param>
+        /// <returns><c>true</c> when the selected changes should be applied.</returns>
+        public static bool ShowReview(CanvasChangeReviewSession session)
+        {
+            using var dialog = new CanvasChangeReviewDialog(session);
+            CanvasChangePreviewOverlay.Begin(session);
+            try
+            {
+                return dialog.ShowModal(RhinoEtoApp.MainWindow) == true;
+            }
+            finally
+            {
+                CanvasChangePreviewOverlay.End();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            var referenceWindow = RhinoEtoApp.MainWindow ?? this.Owner;
+            var screen = referenceWindow != null
+                ? Screen.FromRectangle(referenceWindow.Bounds)
+                : Screen.PrimaryScreen;
+            if (screen != null)
+            {
+                var workArea = screen.WorkingArea;
+                this.Location = new Point(
+                    (int)(workArea.Right - this.Width - 24),
+                    (int)(workArea.Top + Math.Max(24, (workArea.Height - this.Height) / 2)));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.session.SelectionChanged -= this.OnSelectionChanged;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private Control CreateChangeRow(CanvasChangeReviewItem item)
+        {
+            var checkBox = new CheckBox
+            {
+                Checked = item.IsAccepted,
+            };
+            checkBox.CheckedChanged += (_, _) => this.session.SetAccepted(item.Key, checkBox.Checked == true);
+            this.checkBoxes[item.Key] = checkBox;
+
+            var kindLabel = new Label
+            {
+                Text = GetKindLabel(item.Kind),
+                TextColor = GetKindColor(item.Kind),
+                Font = new Font(SystemFont.Bold, 9),
+                VerticalAlignment = VerticalAlignment.Center,
+                Width = 62,
+            };
+            var titleLabel = new Label
+            {
+                Text = item.Title,
+                Font = new Font(SystemFont.Bold, 10),
+                Wrap = WrapMode.Word,
+            };
+            var detailLabel = new Label
+            {
+                Text = item.Detail,
+                TextColor = Colors.Gray,
+                Font = new Font(SystemFont.Default, 9),
+                Wrap = WrapMode.Word,
+            };
+            var textLayout = new DynamicLayout
+            {
+                DefaultSpacing = new Size(0, 2),
+            };
+            textLayout.Add(titleLabel);
+            if (!string.IsNullOrWhiteSpace(item.Detail))
+            {
+                textLayout.Add(detailLabel);
+            }
+
+            var row = new Panel
+            {
+                Padding = new Padding(7),
+                Content = new TableLayout
+                {
+                    Spacing = new Size(8, 0),
+                    Rows =
+                    {
+                        new TableRow(
+                            new TableCell(checkBox, false),
+                            new TableCell(kindLabel, false),
+                            new TableCell(textLayout, true)),
+                    },
+                },
+            };
+            row.MouseEnter += (_, _) => CanvasChangePreviewOverlay.Highlight(item.Key);
+            row.MouseLeave += (_, _) => CanvasChangePreviewOverlay.Highlight(null);
+            return row;
+        }
+
+        private void SetAll(bool isAccepted)
+        {
+            this.session.SetAllAccepted(isAccepted);
+            foreach (var checkBox in this.checkBoxes.Values)
+            {
+                checkBox.Checked = isAccepted;
+            }
+        }
+
+        private void OnSelectionChanged(object? sender, EventArgs e)
+        {
+            this.UpdateSummary();
+        }
+
+        private void UpdateSummary()
+        {
+            this.summaryLabel.Text = $"{this.session.AcceptedCount} of {this.session.Items.Count} changes selected. Applied changes are recorded in Grasshopper's undo history.";
+        }
+
+        private static string GetKindLabel(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => "ADD",
+                CanvasChangeKind.ComponentModified => "MODIFY",
+                CanvasChangeKind.ComponentRemoved => "REMOVE",
+                CanvasChangeKind.ConnectionAdded => "WIRE +",
+                CanvasChangeKind.ConnectionRemoved => "WIRE −",
+                CanvasChangeKind.GroupAdded => "GROUP +",
+                CanvasChangeKind.GroupModified => "GROUP",
+                CanvasChangeKind.GroupRemoved => "GROUP −",
+                _ => "CHANGE",
+            };
+        }
+
+        private static Color GetKindColor(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => Color.FromArgb(45, 164, 78),
+                CanvasChangeKind.ComponentModified => Color.FromArgb(191, 135, 0),
+                CanvasChangeKind.ComponentRemoved => Color.FromArgb(207, 34, 46),
+                CanvasChangeKind.ConnectionAdded or CanvasChangeKind.ConnectionRemoved => Color.FromArgb(9, 105, 218),
+                _ => Color.FromArgb(130, 80, 223),
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
@@ -1,0 +1,293 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using GhJSON.Core.SchemaModels;
+using GhJSON.Grasshopper;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Describes a proposed connection or disconnection between two live canvas objects.
+    /// </summary>
+    public sealed class CanvasConnectionReviewProposal
+    {
+        /// <summary>Gets or sets the source object instance GUID.</summary>
+        public Guid SourceGuid { get; set; }
+
+        /// <summary>Gets or sets the target object instance GUID.</summary>
+        public Guid TargetGuid { get; set; }
+
+        /// <summary>Gets or sets the optional source parameter name.</summary>
+        public string? SourceParameter { get; set; }
+
+        /// <summary>Gets or sets the optional target parameter name.</summary>
+        public string? TargetParameter { get; set; }
+    }
+
+    /// <summary>
+    /// Creates and displays reusable review sessions for AI-proposed structural canvas changes.
+    /// </summary>
+    public static class CanvasChangeReviewService
+    {
+        /// <summary>
+        /// Displays a review dialog on the Rhino UI thread.
+        /// </summary>
+        /// <param name="session">Session to review.</param>
+        /// <returns><c>true</c> when the user chooses to apply selected changes.</returns>
+        public static async Task<bool> ReviewAsync(CanvasChangeReviewSession session)
+        {
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            global::Rhino.RhinoApp.InvokeOnUiThread(() =>
+            {
+                try
+                {
+                    completion.SetResult(CanvasChangeReviewDialog.ShowReview(session));
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            });
+            return await completion.Task.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a review session for removing live canvas objects.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="instanceGuids">Objects proposed for removal.</param>
+        /// <returns>A session containing objects currently present on the canvas.</returns>
+        public static CanvasChangeReviewSession CreateRemovalSession(string source, IEnumerable<Guid> instanceGuids)
+        {
+            var document = GhJsonGrasshopper.GetByGuids(instanceGuids);
+            var items = document.Components
+                .Where(component => component.InstanceGuid.HasValue)
+                .Select(component => new CanvasChangeReviewItem(
+                    $"remove:{component.InstanceGuid}",
+                    CanvasChangeKind.ComponentRemoved,
+                    component.NickName ?? component.Name ?? "Component",
+                    component.Library ?? "Existing canvas object")
+                {
+                    ComponentId = component.Id,
+                    ExistingInstanceGuid = component.InstanceGuid,
+                })
+                .ToList();
+            if (document.Groups != null)
+            {
+                items.AddRange(document.Groups
+                    .Select((group, index) => new CanvasChangeReviewItem(
+                        $"remove:{group.InstanceGuid}",
+                        CanvasChangeKind.GroupRemoved,
+                        group.Name ?? "Group",
+                        $"{group.Members.Count} member(s)")
+                    {
+                        ExistingInstanceGuid = group.InstanceGuid,
+                        GroupIndex = index,
+                    }));
+            }
+            return new CanvasChangeReviewSession(
+                "Review AI canvas removals",
+                source,
+                document,
+                items);
+        }
+
+        /// <summary>
+        /// Creates a review session for proposed component moves.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="targets">Target positions or offsets by instance GUID.</param>
+        /// <param name="relative">Whether targets are relative offsets.</param>
+        /// <returns>A session containing proposed component pivots.</returns>
+        public static CanvasChangeReviewSession CreateMoveSession(
+            string source,
+            IReadOnlyDictionary<Guid, PointF> targets,
+            bool relative)
+        {
+            var document = GhJsonGrasshopper.GetByGuids(targets.Keys);
+            var proposedComponents = document.Components.Select(component =>
+            {
+                if (!component.InstanceGuid.HasValue ||
+                    !targets.TryGetValue(component.InstanceGuid.Value, out var target))
+                {
+                    return component;
+                }
+
+                var current = component.Pivot ?? new GhJsonPivot();
+                return CopyWithPivot(component, new GhJsonPivot(
+                    relative ? current.X + (int)Math.Round(target.X) : (int)Math.Round(target.X),
+                    relative ? current.Y + (int)Math.Round(target.Y) : (int)Math.Round(target.Y)));
+            }).ToList();
+            var proposedDocument = new GhJsonDocument(
+                document.Schema,
+                document.Metadata,
+                proposedComponents,
+                document.Connections,
+                document.Groups);
+            var items = proposedComponents
+                .Where(component => component.InstanceGuid.HasValue && targets.ContainsKey(component.InstanceGuid.Value))
+                .Select(component => new CanvasChangeReviewItem(
+                    $"move:{component.InstanceGuid}",
+                    CanvasChangeKind.ComponentModified,
+                    component.NickName ?? component.Name ?? "Component",
+                    component.Pivot == null ? "Move component" : $"Move to {component.Pivot.X}, {component.Pivot.Y}")
+                {
+                    ComponentId = component.Id,
+                    ExistingInstanceGuid = component.InstanceGuid,
+                })
+                .ToList();
+            return new CanvasChangeReviewSession(
+                "Review AI component moves",
+                source,
+                proposedDocument,
+                items);
+        }
+
+        /// <summary>
+        /// Gets accepted component instance GUIDs from a review session.
+        /// </summary>
+        /// <param name="session">Reviewed session.</param>
+        /// <returns>Accepted component identifiers.</returns>
+        public static IReadOnlySet<Guid> GetAcceptedComponentGuids(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item => item.ExistingInstanceGuid.HasValue && session.IsEffectivelyAccepted(item))
+                .Select(item => item.ExistingInstanceGuid!.Value)
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Creates a review session for proposed live-object connections or disconnections.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="proposals">Connection proposals.</param>
+        /// <param name="kind">Connection change category.</param>
+        /// <returns>A session whose connection indexes align with <paramref name="proposals"/>.</returns>
+        public static CanvasChangeReviewSession CreateConnectionSession(
+            string source,
+            IReadOnlyList<CanvasConnectionReviewProposal> proposals,
+            CanvasChangeKind kind)
+        {
+            if (kind != CanvasChangeKind.ConnectionAdded && kind != CanvasChangeKind.ConnectionRemoved)
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            var document = GhJsonGrasshopper.GetByGuids(proposals
+                .SelectMany(proposal => new[] { proposal.SourceGuid, proposal.TargetGuid })
+                .Distinct());
+            var idsByGuid = document.Components
+                .Where(component => component.InstanceGuid.HasValue && component.Id.HasValue)
+                .ToDictionary(component => component.InstanceGuid!.Value, component => component.Id!.Value);
+            var connections = new List<GhJsonConnection>();
+            var items = new List<CanvasChangeReviewItem>();
+            for (var index = 0; index < proposals.Count; index++)
+            {
+                var proposal = proposals[index];
+                if (!idsByGuid.TryGetValue(proposal.SourceGuid, out var sourceId) ||
+                    !idsByGuid.TryGetValue(proposal.TargetGuid, out var targetId))
+                {
+                    continue;
+                }
+
+                var connectionIndex = connections.Count;
+                connections.Add(new GhJsonConnection
+                {
+                    From = new GhJsonConnectionEndpoint
+                    {
+                        Id = sourceId,
+                        ParamName = proposal.SourceParameter,
+                    },
+                    To = new GhJsonConnectionEndpoint
+                    {
+                        Id = targetId,
+                        ParamName = proposal.TargetParameter,
+                    },
+                });
+                var sourceComponent = document.Components.First(component => component.Id == sourceId);
+                var targetComponent = document.Components.First(component => component.Id == targetId);
+                items.Add(new CanvasChangeReviewItem(
+                    $"connection:{index}",
+                    kind,
+                    $"{sourceComponent.NickName ?? sourceComponent.Name} → {targetComponent.NickName ?? targetComponent.Name}",
+                    $"{proposal.SourceParameter ?? "first output"} → {proposal.TargetParameter ?? "first input"}")
+                {
+                    ComponentId = index,
+                    ConnectionIndex = connectionIndex,
+                });
+            }
+
+            var reviewDocument = new GhJsonDocument(
+                document.Schema,
+                document.Metadata,
+                document.Components,
+                connections,
+                document.Groups);
+            return new CanvasChangeReviewSession(
+                kind == CanvasChangeKind.ConnectionAdded ? "Review AI connections" : "Review AI disconnections",
+                source,
+                reviewDocument,
+                items);
+        }
+
+        /// <summary>
+        /// Gets accepted proposal indexes from a connection review session.
+        /// </summary>
+        /// <param name="session">Reviewed connection session.</param>
+        /// <returns>Accepted indexes into the caller's proposal list.</returns>
+        public static IReadOnlySet<int> GetAcceptedConnectionProposalIndexes(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item => item.ComponentId.HasValue && session.IsEffectivelyAccepted(item))
+                .Select(item => item.ComponentId!.Value)
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Gets accepted instance GUIDs from a component-removal session.
+        /// </summary>
+        /// <param name="session">Reviewed removal session.</param>
+        /// <returns>Accepted live object identifiers.</returns>
+        public static IReadOnlyList<Guid> GetAcceptedRemovalGuids(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item =>
+                    item.ExistingInstanceGuid.HasValue &&
+                    session.IsEffectivelyAccepted(item))
+                .Select(item => item.ExistingInstanceGuid!.Value)
+                .ToList();
+        }
+
+        private static GhJsonComponent CopyWithPivot(GhJsonComponent component, GhJsonPivot pivot)
+        {
+            return new GhJsonComponent
+            {
+                Id = component.Id,
+                InstanceGuid = component.InstanceGuid,
+                ComponentGuid = component.ComponentGuid,
+                Name = component.Name,
+                NickName = component.NickName,
+                Library = component.Library,
+                Pivot = pivot,
+                InputSettings = component.InputSettings,
+                OutputSettings = component.OutputSettings,
+                ComponentState = component.ComponentState,
+                Errors = component.Errors,
+                Warnings = component.Warnings,
+                Remarks = component.Remarks,
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;


### PR DESCRIPTION
## Description
Added document-staged visual review for structural AI canvas changes. `gh_put`, `gh_remove`, `gh_clear`, `gh_connect`, `gh_disconnect`, `gh_move`, `gh_group`, and `gh_group_selected` now paint proposed additions, modifications, removals, wires, target positions, and groups over the actual Grasshopper canvas and apply only user-accepted changes.

Added reusable `CanvasChangeReviewSession`, `CanvasChangeReviewService`, `CanvasChangePreviewOverlay`, and Eto review dialog infrastructure.

## Breaking Changes
No

## Testing Done

_Not verified by automation — to be completed by the author._

## Checklist

- [ ] This PR is focused on a single feature or bug fix
- [ ] CHANGELOG.md has been updated with relevant information to end user