### PR TITLE
feat(agent): add copilot planning, tool surfaces, and canvas mutation consent

### DIFF
--- a/.devin/plans/260910-agent-features-plan.md
+++ b/.devin/plans/260910-agent-features-plan.md
@@ -1,0 +1,724 @@
+---
+agent: devin-local
+created: 2026-09-10
+status: implemented-unverified
+branch: feature/2.1.0-agent-features
+prerequisite: https://github.com/architects-toolkit/SmartHopper/pull/816
+---
+
+# SmartHopper agent-features plan
+
+## Implementation status
+
+Implemented on `feature/2.1.0-agent-features` after fast-forwarding PR #816's visual-diff branch. Compilation and automated tests were skipped at the user's direction because this environment has no installed .NET SDK; Roslyn syntax checks pass except expected source-generator partial-method diagnostics. Every concrete `AIMutatingTool` is wrapped by the Grasshopper undo coordinator, which verifies undo creation and merges multiple records from one call.
+
+One conservative deviation remains: patch-to-canvas routes removals and placement through the same consent system as two sequential graphical reviews and aborts if removals are not fully accepted. It does not yet combine both stages into one atomic visual proposal because `gh_put` owns its accepted-subset placement pipeline. No deletion occurs without consent.
+
+## 1. Objective
+
+Turn WebChat into an opt-in agentic copilot without turning SmartHopper's generic tool catalog or MCP server into an agent runtime.
+
+The copilot should:
+
+1. Let the model call `plan_propose` when a user request benefits from a multi-step plan.
+2. Pause that tool call until the user approves or rejects the proposed plan.
+3. Treat plan approval as permission to continue reasoning only, not as permission for future canvas edits.
+4. Pause every canvas-mutating tool call independently at a centralized `ConsentGate`.
+5. Use the graphical, selectively applicable canvas diff from PR #816 for structural changes instead of a binary yes/no prompt.
+6. Apply only the subchanges accepted in that graphical review.
+7. Apply the same consent invariant to mutating Grasshopper components and direct component utilities even when no WebChat or `ConversationSession` exists.
+8. Keep control tools such as `plan_propose` unavailable through MCP and batch execution.
+9. Preserve existing MCP behavior for ordinary tools and avoid adding planning responsibilities to MCP.
+
+## 2. Confirmed product decisions
+
+- Agent surface: SmartHopper WebChat/copilot only.
+- Planner entry point: model-initiated `plan_propose` AITool.
+- Planning is optional: the model calls it when appropriate based on the user request and system guidance.
+- Plan interaction: v2 async pause/resume. The tool remains pending while the user reviews it.
+- Consent scope default: one tool call only.
+- Plan approval does not grant consent to later mutating calls.
+- Planning is not a prerequisite for mutation: if the model skips planning, the `ConsentGate` still reviews every mutating call.
+- Every mutating call receives its own review.
+- The two approval layers are deliberate: textual plan approval authorizes the approach, while graphical per-call review authorizes only the selected concrete canvas changes.
+- Structural mutation approval uses PR #816's graphical diff and per-change selection.
+- Control tools are excluded from MCP and batch processing.
+- MCP remains a transport over ordinary AITools; this feature does not add an MCP-side agent runtime.
+- Consent is not WebChat-specific: direct Grasshopper components and component utilities must use the same reviewed-operation path.
+- Low-level mutation primitives do not open dialogs; their invoking operation prepares and obtains consent before applying.
+
+## 3. Dependency on PR #816
+
+This work should start after PR #816 (`feature/2.1.0-visual-diff`) lands in `main`, then this branch should be rebased or merged from the updated `main` before implementation.
+
+PR #816 already introduces:
+
+- `CanvasChangeReviewSession`
+- `CanvasChangeReviewItem`
+- `CanvasChangeReviewService`
+- `CanvasChangePreviewOverlay`
+- `CanvasChangeReviewDialog`
+- `GhPutChangePlan`
+- selective acceptance and dependency filtering
+- staged review integrations for `gh_put`, `gh_remove`, `gh_clear`, `gh_connect`, `gh_disconnect`, `gh_move`, `gh_group`, and `gh_group_selected`
+
+The agent feature must reuse and generalize these contracts rather than creating a second canvas approval UI. In this plan, “GhGraphDiff” refers to that graphical review workflow; PR #816 does not currently declare a type named `GhGraphDiff`.
+
+Important findings from review of PR #816:
+
+- Review currently occurs inside each tool body.
+- `CanvasChangeReviewService.ReviewAsync` uses a `TaskCompletionSource<bool>` and an Eto modal dialog on Rhino's UI thread.
+- Review returns a binary “apply/cancel” result while the session independently records per-item selections.
+- Cancellation tokens and late/zombie completion protection are not yet part of the review API.
+- The proposal is painted without mutating the document.
+- Accepted and rejected changes are reported back in tool results.
+- Protected objects are filtered by each tool before review.
+
+## 4. Non-goals
+
+- No autonomous background execution.
+- No long-term memory or cross-document memory in this phase.
+- No MCP planner, MCP plan resource, or MCP consent protocol.
+- No batch planning or batch control tools.
+- No automatic approval of later calls based on an approved plan.
+- No replacement of `ConversationSession`.
+- No generic shell, filesystem, or unrestricted network agent tools.
+- No hidden execution of rejected canvas changes.
+- No multi-agent delegation in this phase.
+
+## 5. Architecture
+
+### 5.1 Responsibility split
+
+| Concern | Owner |
+| --- | --- |
+| Tool metadata and callable delegate | `AITool` |
+| Standard two-phase mutation contract | new `AIMutatingTool` |
+| Pending consent lifecycle and one-call grants | new centralized `ConsentGate` |
+| Generic consent request/decision contracts | `SmartHopper.Infrastructure` |
+| Canvas proposal model and selective decisions | PR #816 classes in `SmartHopper.Core.Grasshopper` |
+| Canvas visual presenter | adapter over `CanvasChangeReviewService` |
+| Plan control tool | `SmartHopper.Core.Grasshopper/AITools/plan_propose.cs` |
+| Plan approval UI | WebChat consent presenter/card |
+| Multi-turn model/tool loop | existing `ConversationSession` |
+| MCP filtering | `AIToolMcpAdapter` based on explicit tool surfaces |
+| Batch filtering | batch interception/execution based on explicit tool surfaces |
+
+### 5.2 Agent flow
+
+```text
+User request
+  -> WebChat ConversationSession
+  -> model optionally calls plan_propose
+  -> plan_propose validates plan and requests plan review
+  -> WebChat renders pending plan card
+  -> tool call awaits user decision
+      -> reject/cancel: tool result says rejected; model reports or replans
+      -> approve: tool result says approved; model continues
+  -> model calls a canvas-mutating tool
+  -> AIMutatingTool prepares a non-mutating proposal
+  -> ConsentGate registers a one-call pending request
+  -> canvas presenter opens PR #816 graphical diff review
+  -> user selects subchanges and applies or cancels
+  -> ConsentGate atomically resolves the request
+  -> AIMutatingTool applies only accepted subchanges
+  -> ordinary tool result is appended
+  -> ConversationSession continues to a stable assistant response
+```
+
+### 5.3 Why consent is centralized but presentation is not
+
+`ConsentGate` should own the invariant and lifecycle:
+
+- each mutation needs an explicit decision
+- the default scope is one call
+- decisions are consumed once
+- cancellation/timeout closes the request
+- late UI events cannot revive an expired request
+- no mutation starts before the decision is resolved
+
+The gate must not own Grasshopper UI types. Presentation stays behind an infrastructure interface so WebChat can present a plan card and Core.Grasshopper can present a canvas diff.
+
+### 5.4 Consent without WebChat or `ConversationSession`
+
+Consent is attached to a mutation invocation, not to a conversation. A `ConversationSession` is one possible source of invocation context, but must not be required.
+
+```text
+WebChat tool call -----------\
+Direct AIToolCall ------------> MutatingOperationExecutor -> ConsentGate -> presenter -> apply
+Grasshopper component -------/
+Component utility command ---/
+MCP mutating tool call ------/
+```
+
+Add a host-agnostic `MutationInvocationContext` with:
+
+- unique invocation ID
+- source (`WebChat`, `GrasshopperComponent`, `Mcp`, `DirectTool`, `Internal`)
+- optional owner ID (conversation/session ID or Grasshopper component instance GUID)
+- optional tool-call ID and tool name
+- active Grasshopper document ID/fingerprint where relevant
+- execution surface
+- linked cancellation token
+
+A missing conversation ID is valid. A missing invocation context at an externally reachable mutating boundary is not: the boundary must construct a fresh direct context or deny execution, never silently bypass review.
+
+Direct integration examples:
+
+- `GhPutComponents` already creates and executes an `AIToolCall` for `gh_put`; mark it as `GrasshopperComponent`, set the owner to the component instance GUID, and pass its worker cancellation token to `Exec(token)`. It then follows the same `AIMutatingTool` and GhGraphDiff path as WebChat.
+- `GhPatchApplyToCanvasComponents` computes a patch, directly deletes removed components, then calls `gh_put`. Replace that split mutation with one prepared patch-to-canvas operation containing removals, modifications, additions, wires, and groups; review it once and apply the accepted coherent subset under one undo record.
+- Component-base `CallAIToolAsync` must create a component/direct invocation context. It must not impersonate WebChat merely to access a tool.
+- MCP creates an `Mcp` invocation context. Ordinary mutating tools may still use the local graphical canvas presenter when exposed, but Chat-only control tools remain unavailable.
+
+### 5.5 Low-level mutation primitives
+
+`ScriptModifier`, `CanvasAccess`, and `GhJsonGrasshopper` calls are apply primitives, not consent presenters. Making every low-level setter asynchronous or opening modal UI from these helpers would couple reusable code to policy and create nested prompts.
+
+Introduce a shared execution layer:
+
+- `IConsentControlledOperation` / `MutatingOperation<TPreparation, TResult>`: prepare without side effects, then apply an accepted decision.
+- `MutatingOperationExecutor`: the only public prepare -> consent -> apply coordinator; uses `ConsentGate`.
+- `AIMutatingTool`: adapts an operation to `AITool`/`AIReturn`.
+- Direct components: invoke the same operation through `MutatingOperationExecutor` or, where already appropriate, through `AIToolCall`.
+- Low-level helpers: apply only after authorization and never request consent themselves.
+
+For stronger bypass resistance, mutation utilities used only by SmartHopper-controlled operations should become `internal` where compatibility allows. If a public helper must remain public, document it as a raw primitive and ensure no AI-facing or user-triggered SmartHopper path calls it outside a reviewed operation.
+
+For `ScriptModifier`, create a `ScriptModificationOperation` that:
+
+1. resolves and validates the target script component
+2. rejects protected targets
+3. serializes the current component state
+4. creates the proposed script/parameter state off-canvas (prefer GhJSON/GhPatch representation)
+5. builds a graphical review proposal showing code/parameter/state changes
+6. revalidates target identity and document fingerprint after review
+7. records undo
+8. invokes `ScriptModifier` only during apply
+
+If a script parameter change cannot yet be represented faithfully in GhJSON, use a specialized script-change proposal rendered by the same review dialog/presenter contract. Do not silently fall back to immediate mutation.
+
+## 6. Core contracts
+
+Names are proposed and may be refined during implementation, but responsibilities should remain stable.
+
+### 6.1 Explicit tool surfaces
+
+Add a flags enum rather than using free-form tags as access control:
+
+```csharp
+[Flags]
+public enum AIToolSurface
+{
+    None = 0,
+    Chat = 1,
+    Direct = 2,
+    Batch = 4,
+    Mcp = 8,
+    All = Chat | Direct | Batch | Mcp,
+}
+```
+
+- Existing tools default to `All` for compatibility.
+- `plan_propose` uses `Chat` only.
+- `AIMutatingTool` defaults to `Chat | Direct | Mcp`; batch is excluded unless a future mutating tool explicitly supports a meaningful batch proposal flow.
+- `Tags` remain descriptive and must not enforce exposure.
+- `Enabled` remains the global master switch.
+
+Because provider formatting occurs in `SmartHopper.ProviderSdk`, add the surface to the SDK-side tool projection (`ProviderToolDefinition`) and carry the current tool surface on the request/session execution context. Preserve compatibility overloads where possible.
+
+Required enforcement points:
+
+1. Provider tool formatting: only expose definitions valid for the current request surface.
+2. `AIToolMcpAdapter.IsExposed`: reject tools without `Mcp` even if allow-listed.
+3. Batch interception: reject tools without `Batch`; do not silently fall through to synchronous execution.
+4. `AIToolManager.ExecuteTool`: enforce the declared surface again at execution time.
+
+### 6.2 Consent contracts
+
+Add provider-agnostic contracts under `SmartHopper.Infrastructure/Consent/`:
+
+- `IConsentGate`
+- `IConsentPresenter`
+- `IConsentProposal`
+- `ConsentContext`
+- `ConsentDecision`
+- `ConsentDecisionStatus` (`Approved`, `PartiallyApproved`, `Rejected`, `Cancelled`, `Expired`, `Unavailable`)
+- `PendingConsentRequest`
+
+`ConsentContext` should contain at minimum:
+
+- unique request/invocation ID
+- invocation source
+- optional owner ID (conversation/session ID or component instance GUID)
+- optional tool-call ID and tool name
+- execution surface
+- optional active-document identity/fingerprint
+- cancellation token linkage
+- creation time
+
+Do not require a conversation/session ID: direct components must be first-class consent callers.
+
+`ConsentDecision` should contain:
+
+- terminal status
+- accepted item keys (empty for rejection/cancellation)
+- optional user-facing reason
+- decision timestamp
+
+The gate registry must be concurrency-safe and keyed by the unique consent request ID, not only by tool name or turn ID.
+
+### 6.3 `AIMutatingTool`
+
+Add `AIMutatingTool : AITool` in Infrastructure. It must do more than set `MutatesCanvas = true`; it standardizes two-phase execution:
+
+1. Validate and prepare a proposal without mutating state.
+2. Ask `ConsentGate` for a one-call decision.
+3. Apply only the accepted subset.
+4. Return a normal `AIInteractionToolResult` describing applied, rejected, protected, and failed changes.
+
+Suggested delegates/contracts:
+
+- `PrepareMutationAsync(AIToolCall, CancellationToken) -> MutationPreparation`
+- `ApplyMutationAsync(AIToolCall, MutationPreparation, ConsentDecision, CancellationToken) -> AIReturn`
+
+`MutationPreparation` should carry an `IConsentProposal` and any immutable prepared data required for apply. It must not contain unvalidated live mutation state that can go stale unnoticed.
+
+The two-phase implementation should delegate to the shared `MutatingOperationExecutor`; `AIMutatingTool` is an adapter, not the only route into consent-controlled execution. This lets direct components use exactly the same operation without constructing a fake conversation.
+
+`AIMutatingTool` should force:
+
+- `MutatesCanvas = true`
+- no batch surface by default
+- no `BuildRequest` by default
+- a consent requirement that cannot be disabled by changing tags or descriptions
+
+Do not put Rhino, Grasshopper, Eto, or GhJSON references in Infrastructure.
+
+### 6.4 Canvas adapter over PR #816
+
+Add a Core.Grasshopper adapter implementing `IConsentProposal` and an `IConsentPresenter` implementation that delegates to the existing graphical review infrastructure.
+
+Possible types:
+
+- `CanvasMutationConsentProposal`
+- `CanvasChangeConsentPresenter`
+
+The proposal wraps the PR #816 `CanvasChangeReviewSession`. The presenter:
+
+1. starts the overlay
+2. opens the review dialog
+3. lets the user accept/reject individual changes
+4. returns accepted item keys
+5. ends the overlay in `finally`
+6. handles cancellation by closing the pending dialog and resolving exactly once
+
+Do not reduce the decision to a plain yes/no. `Apply selected` returns `Approved` or `PartiallyApproved` based on effective selections. `Cancel` returns `Cancelled`; selecting no items and applying returns `Rejected` or an explicit no-op decision.
+
+### 6.5 Plan proposal
+
+Add `plan_propose` as a read-only, control-category AITool with `AIToolSurface.Chat` only.
+
+Suggested input schema:
+
+```json
+{
+  "goal": "string",
+  "summary": "string",
+  "steps": [
+    {
+      "id": "stable step id",
+      "description": "user-facing action",
+      "tool": "optional registered tool name"
+    }
+  ],
+  "assumptions": ["string"],
+  "successCriteria": ["string"]
+}
+```
+
+Server-side validation must:
+
+- require a bounded number of steps
+- reject duplicate/empty step IDs
+- validate referenced tool names against `AIToolManager`
+- derive mutability and exposure from registered tool metadata rather than trusting model-supplied booleans
+- reject references to tools unavailable on the Chat surface
+- enforce payload size limits
+- sanitize all content before rendering in WebChat
+
+Execution:
+
+1. Build an immutable plan proposal.
+2. Send it through `ConsentGate` to the WebChat presenter.
+3. Await the user decision.
+4. Return an ordinary tool result with `planId`, status, and normalized steps.
+5. Let `ConversationSession` append the result and resume the provider turn normally.
+
+Plan approval means “continue with this approach.” It does not create consent tokens for listed mutating steps.
+
+### 6.6 WebChat plan presenter
+
+Add a pending plan card through the existing WebView host bridge:
+
+- `Approve plan`
+- `Reject`
+- `Cancel run`
+
+The initial phase should not support editing plan text inline; rejection lets the user send correction instructions in the next message. Inline editing can be added later without changing consent contracts.
+
+The card should display:
+
+- goal and summary
+- ordered steps
+- which steps name mutating tools (derived server-side)
+- assumptions
+- success criteria
+- clear statement that each actual canvas mutation will still receive a graphical diff review
+
+The presenter owns only UI completion. `ConsentGate` owns request state and prevents duplicate/late resolution.
+
+Pending requests are runtime state. The final `plan_propose` tool result remains in normal conversation history and records the user's decision for audit/replay. A rehydrated historical plan must render as resolved, never as an active approval control.
+
+## 7. Execution timeout and cancellation
+
+This is a required safety refactor.
+
+Current `AIToolCall.Exec` wraps all of `AIToolManager.ExecuteTool` in `Task.WhenAny` with a delay. If consent waits inside that task, the timeout can return while the original execution continues; a late approval could then mutate the canvas after the caller saw a timeout.
+
+Refactor execution into explicit phases:
+
+1. resolve and validate tool
+2. verify tool surface
+3. prepare mutation proposal (for `AIMutatingTool`)
+4. await consent using the session cancellation token; execution timeout does not run while a human is reviewing
+5. atomically consume the one-call decision
+6. start the tool execution timeout
+7. apply with a linked cancellation token
+8. reject any late completion after cancellation/expiry
+
+The existing timeout behavior for ordinary tools should remain functionally compatible, but use a cancellable linked token rather than an unobserved task that can continue with side effects.
+
+Required cancellation paths:
+
+- WebChat Cancel button
+- conversation/session cancellation
+- dialog close
+- Rhino/Grasshopper shutdown
+- active document replacement or closure
+- tool timeout after approval
+
+All paths must remove the pending request, close/detach UI, end the overlay, and append a valid failed/cancelled tool result so provider history remains valid.
+
+## 8. Migration of canvas tools
+
+After PR #816 lands, migrate covered structural tools from ad hoc calls to `CanvasChangeReviewService.ReviewAsync` into `AIMutatingTool` preparation/apply delegates:
+
+- `gh_put`
+- `gh_remove`
+- `gh_clear`
+- `gh_connect`
+- `gh_disconnect`
+- `gh_move`
+- `gh_group`
+- `gh_group_selected`
+
+Preserve PR #816 behavior:
+
+- proposal rendered on the live canvas
+- no temporary document objects
+- protected objects filtered before they become selectable
+- dependency-aware effective acceptance
+- accepted/rejected counts in results
+- cancellation is a no-op
+- replacements validated before removal
+- external connections preserved
+- undo recorded for applied changes
+
+Do not force non-structural runtime actions into GhGraphDiff. Inventory and classify separately:
+
+- `button_click`
+- parameter modifiers
+- component preview/lock tools
+- `set_ai_provider_and_model`
+- script replacement tools
+- `gh_tidy_up`
+- `gh_smart_connect`
+- document save
+
+For each, choose one of:
+
+1. adopt a meaningful structural proposal and graphical review
+2. use a specialized one-call consent presenter
+3. remain outside `AIMutatingTool` only with documented rationale
+
+Also migrate non-WebChat mutation entry points:
+
+- `GhPutComponents`: retain its existing `gh_put` reuse, but propagate `GrasshopperComponent` invocation context and cancellation.
+- `GhPatchApplyToCanvasComponents`: replace direct pre-review deletion plus later `gh_put` with one atomic, reviewable patch-to-canvas operation.
+- `_script_parameter_modifier` tools: convert to `AIMutatingTool`/`ScriptModificationOperation` before enabling them.
+- `ScriptModifier`: keep as an apply primitive; route every SmartHopper AI-facing caller through `ScriptModificationOperation` and tighten raw method visibility where possible.
+- Any component that calls `CanvasAccess`, `GhJsonGrasshopper`, or modifier helpers to mutate another canvas object must use `MutatingOperationExecutor` unless the action is the component's ordinary self-maintenance rather than an AI/user-requested external mutation.
+
+The initial feature is not complete until every existing `MutatesCanvas=true` tool and every SmartHopper component that externally mutates other canvas objects is inventoried and explicitly classified.
+
+## 9. Tool results and model behavior
+
+Consent rejection/cancellation is an expected tool outcome, not an exception.
+
+Normalize mutating-tool results to include where applicable:
+
+- `status`
+- `appliedChanges`
+- `rejectedChanges`
+- `protectedChanges`
+- `failedChanges`
+- `analysis` or messages
+
+The model must receive enough information not to claim rejected changes were applied. It may propose a revised action but must not immediately repeat the same rejected mutation without a new user instruction or materially different proposal.
+
+Update `assistant-core.md` to state:
+
+- use `plan_propose` for non-trivial multi-step tasks
+- do not plan trivial read-only questions
+- plan approval is not mutation approval
+- every canvas change is reviewed per call
+- honor partial/rejected decisions
+- verify the resulting canvas after applied mutations
+
+## 10. Implementation phases
+
+### Phase 0 — integrate prerequisite
+
+1. Wait for PR #816 to merge.
+2. Rebase/merge this branch onto updated `main`.
+3. Run PR #816's focused tests/build before agent changes.
+4. Record any interface differences from this plan.
+
+### Phase 1 — surfaces and consent core
+
+1. Add `AIToolSurface` and compatibility defaults.
+2. Carry execution surface through request/tool-call context.
+3. Enforce surfaces in provider formatting, MCP, batch, and execution.
+4. Add `MutationInvocationContext`, consent contracts, and concurrency-safe `ConsentGate`.
+5. Add the host-agnostic `MutatingOperationExecutor` used by tools and components.
+6. Add fake presenters/gates for tests.
+7. Refactor cancellation/timeout boundaries before any waiting consent is enabled.
+
+### Phase 2 — mutating-tool standardization
+
+1. Add `AIMutatingTool` two-phase execution.
+2. Add canvas proposal/presenter adapter over PR #816.
+3. Migrate the eight PR #816 structural tool entries.
+4. Remove their direct review orchestration from tool bodies.
+5. Preserve tool-specific proposal building and accepted-subset application.
+6. Propagate component invocation context and cancellation through `GhPutComponents` and component-base `CallAIToolAsync`.
+7. Replace `GhPatchApplyToCanvasComponents`' split direct-delete/`gh_put` mutation with one reviewed operation.
+8. Add `ScriptModificationOperation` and route script modifier callers through it.
+9. Inventory and classify remaining mutating tools and non-tool component mutation entry points.
+
+### Phase 3 — `plan_propose`
+
+1. Add Chat-only control tool and schema.
+2. Validate plans against live tool metadata.
+3. Add WebChat plan presenter/card and host bridge events.
+4. Await approval/rejection through `ConsentGate`.
+5. Resume the existing `ConversationSession` tool loop with the tool result.
+6. Ensure historical resolved plans do not become interactive again.
+
+### Phase 4 — guidance, observability, and verification
+
+1. Update embedded assistant guidance and canonical workflows.
+2. Add structured diagnostics for requested, approved, partially approved, rejected, cancelled, expired, and unavailable consent.
+3. Avoid logging plan contents, GhJSON payloads, screenshots, or sensitive canvas data by default.
+4. Ensure the assistant performs existing `validate_change`-style checks after applied mutations through prompt/workflow guidance; a dedicated critic turn remains a later enhancement.
+
+### Phase 5 — documentation and changelog
+
+1. Update `/docs/Architecture.md` with the copilot flow.
+2. Add `/docs/Architecture/agent-copilot.md` and link it from the architecture index/entry point.
+3. Update `/docs/UI/Chat/index.md` for plan cards and pending consent lifecycle.
+4. Update PR #816's `/docs/UI/ai-change-review.md` with `ConsentGate` and `AIMutatingTool` ownership.
+5. Update `/docs/Tools/index.md`, MCP docs, batch docs, and AICall tool/session docs.
+6. Add `[Unreleased]` changelog entries under Added/Changed/Security as appropriate.
+
+## 11. Expected files and modules
+
+Exact names can change, but likely areas are:
+
+### Provider SDK
+
+- `SmartHopper.ProviderSdk/Hosting/IToolRegistryHost.cs`
+- request/tool-surface execution context
+- provider tool formatting compatibility overloads
+
+### Infrastructure
+
+- `AITools/AITool.cs`
+- new `AITools/AIMutatingTool.cs`
+- `AITools/ToolManager.cs`
+- `AICall/Tools/AIToolCall.cs`
+- new `Consent/*`
+- new host-agnostic mutating-operation contracts/executor
+- `Mcp/AIToolMcpAdapter.cs`
+- `Hosting/ProviderSdkHostAdapters.cs`
+- `AICall/Sessions/ConversationSession*` only for propagating session/surface/cancellation context, not for absorbing consent UI logic
+
+### Core / Core.Grasshopper
+
+- WebChat request creation marks Chat surface
+- WebChat bridge and resources for plan cards
+- canvas consent presenter adapter
+- `AITools/plan_propose.cs`
+- migrations of canvas mutation tools after PR #816
+- `GhPutComponents` invocation-context propagation
+- patch-to-canvas reviewed operation replacing direct deletion
+- `ScriptModificationOperation` around `ScriptModifier`
+- embedded `assistant-core.md` and workflows
+
+### Tests
+
+- `SmartHopper.Infrastructure.Tests` for gate, surfaces, execution, cancellation, and MCP filtering
+- `SmartHopper.Core.Tests` for WebChat-safe non-Rhino plan state/serialization where possible
+- `SmartHopper.Core.Grasshopper.Tests` for plan validation and proposal filtering that does not require Rhino runtime
+- `SmartHopper.Components.Test` for graphical overlay/dialog/tool mutation flows requiring Rhino/Grasshopper
+
+## 12. Test plan
+
+### Infrastructure unit tests
+
+- one-call decision is consumed exactly once
+- duplicate approval/rejection resolves only once
+- cancellation removes pending consent
+- late approval after cancellation cannot call apply
+- consent waiting does not consume tool execution timeout
+- tool timeout after approval cancels apply and cannot produce a later mutation
+- concurrent sessions and direct components do not share consent
+- direct component invocation works without a conversation/session ID
+- missing context creates a fresh direct context or denies; it never bypasses consent
+- rejected/partial decisions become valid tool results
+- `plan_propose` is Chat-only
+- MCP descriptors and calls reject control tools even if allow-listed
+- batch rejects control tools rather than falling through synchronously
+- execution-time surface enforcement prevents bypass
+- existing tools retain compatibility defaults
+
+### Plan-tool tests
+
+- valid plan accepted/rejected/cancelled flows
+- unknown tool references rejected
+- duplicate step IDs rejected
+- model-supplied mutability cannot override registered metadata
+- plan size and step count bounded
+- rendered text escaped/sanitized
+- historical resolved plan cannot resolve a new pending request
+
+### Canvas proposal tests without Rhino runtime
+
+- partial selection filters components/connections/groups correctly
+- dependency rejection prevents orphan connections
+- zero selected changes produces a no-op
+- protected targets never appear as approvable
+- accepted item keys map deterministically to applied changes
+
+### Rhino/Grasshopper testing components
+
+- proposal overlay appears without mutating the live document
+- Apply selected changes only
+- Cancel changes nothing
+- WebChat Cancel closes the graphical review and changes nothing
+- document close/replacement cancels pending review
+- undo restores an applied call as one coherent user action where supported
+- `gh_put` replacement preserves external connections
+- sequential mutating calls each require a separate review
+- `GhPutComponents` shows the same graphical review without WebChat and worker/component cancellation closes the pending review
+- patch-to-canvas shows one coherent proposal and never deletes objects before approval
+- script parameter/code modifications show the current/proposed change and do not call `ScriptModifier` before approval
+- direct and tool-driven execution of the same operation produce equivalent accepted-subset behavior
+
+### Verification commands
+
+- Focused unsigned CI-safe tests where applicable:
+  - `dotnet test src/SmartHopper.Infrastructure.Tests/SmartHopper.Infrastructure.Tests.csproj -p:SignAssembly=false`
+  - `dotnet test src/SmartHopper.ProviderSdk.Tests/SmartHopper.ProviderSdk.Tests.csproj -p:SignAssembly=false`
+  - focused Core/Core.Grasshopper tests if they build without Rhino activation
+- Official compile verification uses `./tools/Build-Solution.ps1` in Developer PowerShell for Visual Studio, following the repository signing workflow.
+- Rhino-dependent approval/overlay behavior is verified with testing components, not unit tests requiring Rhino runtime.
+
+## 13. Threat review
+
+This feature controls model-triggered side effects and therefore must use deny-by-default behavior when context is missing.
+
+Threats and mitigations:
+
+| Threat | Mitigation |
+| --- | --- |
+| Tool or direct component bypasses planning or consent | Shared mutating-operation executor plus enforcement at every AI-facing/user-triggered mutation boundary, not only WebChat |
+| Low-level helper opens nested UI or mutates during preparation | Helpers remain apply-only; proposal preparation is side-effect free and UI stays in presenters |
+| Model marks a mutation read-only | Mutability derived from registered tool type/metadata |
+| Late click executes after timeout/cancel | Atomic terminal decision, linked cancellation, pending-request removal, apply cannot start after terminal state |
+| Wrong conversation approves another call | consent keyed by session ID + tool-call ID + unique request ID |
+| Partial rejection leaves invalid graph | PR #816 dependency-aware accepted-subset filtering |
+| Protected component changed indirectly | protection filtering before presentation plus apply-time revalidation |
+| Canvas changes between preview and apply | proposal captures a document/version fingerprint; revalidate targets before apply and require re-review if stale |
+| Prompt/HTML injection in plan card | encode/sanitize all model-provided text; no raw HTML execution |
+| MCP or batch reaches control tool | explicit surface filtering at discovery and execution |
+| Sensitive design data logged | structured event metadata only; no plan/GhJSON/screenshot payload logging by default |
+| Repeated rejected operation | return explicit rejection and instruct model not to retry unchanged proposal |
+
+A document/version fingerprint is strongly recommended. Consent should authorize the reviewed proposal against the canvas state that produced it, not an arbitrary later state.
+
+## 14. Acceptance criteria
+
+- WebChat's model can call `plan_propose` and the tool call pauses until the user decides.
+- Approving a plan resumes the existing `ConversationSession`; rejecting/cancelling returns a valid tool result.
+- Plan approval grants no future mutation consent.
+- Every migrated mutating call receives a distinct one-call consent decision, whether invoked from WebChat, MCP, a direct AITool call, or a Grasshopper component.
+- `GhPutComponents` and patch-to-canvas are consent-controlled without requiring a `ConversationSession`.
+- Script modifications are prepared and reviewed before `ScriptModifier` applies them.
+- Structural canvas proposals use PR #816's overlay/checklist and support partial acceptance.
+- No accepted subset is applied before review completion.
+- Cancellation, timeout, document closure, and late UI events cannot cause zombie mutations.
+- `plan_propose` is absent from MCP `tools/list`, rejected by MCP `tools/call`, and rejected in batch execution.
+- MCP behavior for ordinary tools remains unchanged.
+- Existing non-agent components do not gain planner behavior.
+- All `MutatesCanvas=true` tools are inventoried and classified.
+- Applied changes remain undoable according to Grasshopper conventions.
+- CI-safe tests pass, and Rhino-dependent flows are covered by test components/manual checks.
+- Architecture docs and changelog are synchronized.
+
+## 15. Alternatives considered
+
+### Put all approval in `ConversationSession`
+
+Rejected. It would protect WebChat but not direct tool execution and would mix UI/security policy into conversation orchestration.
+
+### Keep review calls inside each tool
+
+Rejected as the final architecture. PR #816 proves the graphical UX, but ad hoc invocation does not standardize cancellation, execution surfaces, one-call scope, or bypass prevention.
+
+### Make plan approval grant all listed mutations
+
+Rejected. The user chose one-call consent, and a textual plan cannot faithfully preview the eventual GhGraphDiff or exact tool arguments.
+
+### Expose `plan_propose` through MCP
+
+Rejected. External MCP clients may have their own planners, and SmartHopper's control tool depends on WebChat-specific presentation and pause/resume semantics.
+
+### Use tags for access control
+
+Rejected. Tags are free-form metadata. Explicit surfaces are needed for reliable MCP, batch, and execution enforcement.
+
+### Add planning directly as a special turn
+
+Deferred. Special turns remain suitable for future host-forced planning or critic/verification turns, but model-initiated planning maps naturally to an AITool and the existing tool loop.
+
+## 16. Follow-up opportunities, out of this implementation
+
+- Host-forced “always plan” mode using a special turn.
+- Editable plan cards.
+- Dedicated post-action critic/verification special turn.
+- Session-scoped low-risk consent modes (default remains one call).
+- Persistent user preferences and project memory.
+- Richer graphical diffs for specialized mutating tools.
+- Parallel tool consent queue and multi-request review.
+- Optional MCP-specific consent protocol if a future MCP specification/client flow supports it cleanly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Many thanks to the following contributors to this release:
 
 ### Added
 
+- Added an agentic WebChat planning flow through the Chat-only `plan_propose` tool. Proposed multi-step plans pause in an interactive chat card until approved or rejected; plan approval never pre-approves later canvas edits.
+- Added invocation-scoped `ConsentGate`, explicit `AIToolSurface` exposure controls, and `AIMutatingTool` metadata so WebChat, MCP, direct AITool calls, and Grasshopper components share one-call mutation consent without requiring a `ConversationSession`.
+- Added automatic Grasshopper undo coordination around every `AIMutatingTool`: operation-specific undo actions are verified and multiple records from one tool call are merged into one Ctrl+Z step.
 - Added document-staged visual review for structural AI canvas changes. `gh_put`, `gh_remove`, `gh_clear`, `gh_connect`, `gh_disconnect`, `gh_move`, `gh_group`, and `gh_group_selected` now paint proposed additions, modifications, removals, wires, target positions, and groups over the actual Grasshopper canvas and apply only user-accepted changes.
 - Added reusable `CanvasChangeReviewSession`, `CanvasChangeReviewService`, `CanvasChangePreviewOverlay`, and Eto review dialog infrastructure in `SmartHopper.Core.Grasshopper`.
 - Pull request descriptions and titles are now drafted automatically, with a deterministic fallback when AI is unavailable and no overwriting of descriptions written by a person.
@@ -35,6 +38,8 @@ Many thanks to the following contributors to this release:
 
 ### Changed
 
+- Canvas mutation reviews now run through centralized consent lifecycle and cancellation handling. Direct `GhPut` and patch-to-canvas components propagate component invocation context, and compound generation/script tools propagate consent into their nested `gh_put` calls.
+- Chat-only control tools are excluded from MCP discovery/calls and provider batch execution through explicit surface checks rather than descriptive tags.
 - WebChat requests now prepend mandatory shared Grasshopper operating knowledge before component or user instructions. MCP resources and the in-process `smarthopper_readme` and `smarthopper_workflows` tools consume the same embedded source of truth.
 - `FileContextProvider` no longer reports selected object metadata. Use the new `SelectionContextProvider` for `selected-count`, `selected-objects`, `selected-topology`, and `selected-runtime-values`.
 - Removed redundant `new` modifiers on `provider` fields in first-party `*ProviderSettings` classes; the base `AIProviderSettings` does not expose a conflicting accessible member, so the modifier only produced compiler warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Many thanks to the following contributors to this release:
 
 ### Added
 
+- Added document-staged visual review for structural AI canvas changes. `gh_put`, `gh_remove`, `gh_clear`, `gh_connect`, `gh_disconnect`, `gh_move`, `gh_group`, and `gh_group_selected` now paint proposed additions, modifications, removals, wires, target positions, and groups over the actual Grasshopper canvas and apply only user-accepted changes.
+- Added reusable `CanvasChangeReviewSession`, `CanvasChangeReviewService`, `CanvasChangePreviewOverlay`, and Eto review dialog infrastructure in `SmartHopper.Core.Grasshopper`.
 - Pull request descriptions and titles are now drafted automatically, with a deterministic fallback when AI is unavailable and no overwriting of descriptions written by a person.
 - Added `AIBody.WithReplaced` extension for replacing a specific interaction by reference in an immutable body.
 - Added `AITool.GetRequiredParameters()` helper to parse required parameter names from a tool's JSON schema.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,3 +208,58 @@ $pwd = ConvertTo-SecureString "your-password" -AsPlainText -Force
 **Note:** If you don't provide `-PfxPassword`, the signing script will prompt interactively when needed.
 
 **Environment requirement:** Run `tools/Build-Solution.ps1` (and the underlying signing scripts) from **Developer PowerShell for Visual Studio 2022** or another VS Developer shell. This ensures `sn.exe` and Windows SDK tools are on `PATH`. Running from a plain PowerShell may fail with errors like `sn.exe not found`.
+
+### Troubleshooting
+
+#### PowerShell execution policy blocks `Build-Solution.ps1`
+
+If you see an error such as:
+
+```text
+.\tools\Build-Solution.ps1 : Cannot load ... because running scripts is disabled on this system.
+```
+
+PowerShell's execution policy is preventing the script from running. Choose one of the following fixes:
+
+1. **Recommended: allow local scripts for your user**
+
+   Open **Developer PowerShell for Visual Studio 2022 as Administrator** and run:
+
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+   ```
+
+   This allows locally created scripts to run while still requiring downloaded scripts to be signed or unblocked.
+
+2. **Unblock the script files**
+
+   If the files came from a download or a zip archive, Windows may have marked them as blocked. In a PowerShell prompt from the repository root, run:
+
+   ```powershell
+   Get-ChildItem -Path tools\*.ps1 | Unblock-File
+   ```
+
+   Then retry `Build-Solution.ps1`.
+
+3. **Run a single invocation with the policy bypassed**
+
+   If you cannot or do not want to change the persistent execution policy, run the script explicitly with a bypass for that call only:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\tools\Build-Solution.ps1 -Testing
+   ```
+
+   This does not change your system settings.
+
+4. **Set policy for the current process only**
+
+   For the current shell session only, run:
+
+   ```powershell
+   Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
+   .\tools\Build-Solution.ps1 -Testing
+   ```
+
+   The policy reverts when the shell closes.
+
+**Security note:** Do not set `Unrestricted` at the `LocalMachine` scope unnecessarily. Prefer `RemoteSigned` at the `CurrentUser` scope, or use a per-process/per-invocation bypass.

--- a/SmartHopper.sln
+++ b/SmartHopper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.8.12023.21 stable
+VisualStudioVersion = 18.8.12023.21
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartHopper.Core", "src\SmartHopper.Core\SmartHopper.Core.csproj", "{D4C6D3D5-2B3A-4B6C-8C3D-57B2D0D3C1E1}"
 EndProject

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -275,3 +275,4 @@ src/
 - [ComponentBase](./Components/ComponentBase/index.md) -- component hierarchy
 - [Provider System](./Providers/index.md) -- provider management
 - [Context System](./Context/index.md) -- context providers
+- [Agentic Copilot and Consent](./Architecture/agent-copilot.md) -- planning, tool surfaces, and invocation-scoped mutation review

--- a/docs/Architecture/agent-copilot.md
+++ b/docs/Architecture/agent-copilot.md
@@ -1,0 +1,88 @@
+# Agentic Copilot and Consent
+
+SmartHopper WebChat can propose explicit plans and all supported AI-driven canvas mutations pass through a shared, invocation-scoped consent gate.
+
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Infrastructure/Consent/`, `src/SmartHopper.Core/UI/Chat/`, `src/SmartHopper.Core.Grasshopper/AITools/` |
+| **Since Version** | 2.1.0 |
+| **Last Updated** | 2026-09-10 |
+| **Documentation Maintainer** | Devin AI |
+
+---
+
+## Why Read This?
+
+Read this when changing plan approval, tool exposure, graphical canvas review, or any path that lets AI tools and components modify another Grasshopper object.
+
+## End-User Guide
+
+For non-trivial multi-step work, the assistant may show a plan card. Approving it permits the assistant to continue with that approach; it does not approve later canvas edits.
+
+Each concrete canvas mutation is reviewed separately. Structural and component-state changes are painted on the live canvas and listed as selectable changes. Apply accepts the selected subset; Reject or Cancel leaves the rejected subset unchanged.
+
+The same graphical review applies when a mutating tool is triggered by WebChat, MCP, another AI tool, or a direct SmartHopper Grasshopper component such as Place GhJSON.
+
+## Developer Reference
+
+### Core contracts
+
+| Type | Responsibility |
+| --- | --- |
+| `AIToolSurface` | Explicit Chat, Direct, Batch, and MCP exposure policy |
+| `AIMutatingTool` | Standard metadata for non-batch canvas-mutating tools |
+| `MutationInvocationContext` | Identifies the invocation independently of a conversation |
+| `IConsentProposal` | Immutable proposal presented for one invocation |
+| `IConsentPresenter` | UI adapter for a proposal kind |
+| `ConsentGate` | Tracks one pending request per invocation and consumes one terminal decision |
+| `MutationUndoCoordinator` | Host seam that verifies and coalesces undo records for every `AIMutatingTool` |
+| `GrasshopperMutationUndoCoordinator` | Grasshopper implementation using the active document undo server |
+| `CanvasMutationConsentProposal` | Adapts `CanvasChangeReviewSession` to consent |
+| `CanvasChangeConsentPresenter` | Uses the graphical canvas review dialog and overlay |
+| `PlanConsentProposal` | Structured WebChat plan |
+
+### Execution flow
+
+```text
+caller -> AIToolCall / mutation operation
+       -> validate tool surface
+       -> prepare proposal without canvas changes
+       -> ConsentGate -> matching presenter
+       -> approved selection
+       -> revalidate and apply
+       -> normal tool result
+```
+
+`ConversationSession` propagates the WebChat presenter and Chat surface but does not own consent policy. Direct components create a `GrasshopperComponent` invocation context and can use the same gate without a conversation.
+
+### Tool surfaces
+
+- Existing ordinary tools default to all surfaces for compatibility.
+- `plan_propose` is Chat-only and is rejected by MCP and batch execution.
+- `AIMutatingTool` excludes Batch by default.
+- Surface checks occur both when formatting/discovering tools and immediately before execution.
+
+### Cancellation
+
+Consent waits use the invocation cancellation token. Cancelling WebChat, a component worker, or the graphical dialog resolves the request without applying changes. Tool execution uses linked timeout cancellation so an operation cannot complete later as an unobserved mutation after reporting timeout.
+
+## Architecture & Design
+
+Every `AIMutatingTool` is wrapped by the host undo coordinator. Existing operation-specific APIs still record the correct pivot, wire, object, state, add, and remove actions; the coordinator verifies that a successful call produced an undo record and merges multiple records from one tool call into one Ctrl+Z step.
+
+Consent is invocation-scoped rather than conversation-scoped because SmartHopper has several mutation callers. UI is separated through presenters: WebChat renders plan cards, while Core.Grasshopper owns GhJSON-aware canvas overlays. Low-level helpers such as `ScriptModifier`, `CanvasAccess`, and `GhJsonGrasshopper` remain apply primitives and must not open consent UI themselves.
+
+Plan approval and mutation approval are deliberately separate. A textual plan cannot authorize a later concrete graph whose arguments or affected objects may differ.
+
+Control tags are descriptive only. `AIToolSurface` is the access-control contract used for MCP and batch isolation.
+
+## Related Documentation
+
+- [AI Canvas Change Review](../UI/ai-change-review.md)
+- [Chat UI](../UI/Chat/index.md)
+- [AICall Tools](../Providers/AICall/tools.md)
+- [MCP Server](mcp-server.md)

--- a/docs/Architecture/mcp-server.md
+++ b/docs/Architecture/mcp-server.md
@@ -65,6 +65,7 @@ The user-facing component is `SmartHopperMcpServerComponent` in `src/SmartHopper
 - **Bearer token optional.** If a token is configured, requests without `Authorization: Bearer ...` are rejected with HTTP 401.
 - **Read-only by default.** Tools that alter the canvas are hidden unless `ExposeMutatingTools` is enabled.
 - **Disabled tools are never exposed.** If `AITool.Enabled` is `false`, the tool is hidden from MCP regardless of the allow-list or mutating-tool policy.
+- **Tool surfaces are enforced.** Tools without `AIToolSurface.Mcp`, including WebChat control tools such as `plan_propose`, remain hidden even when named in an MCP allow-list.
 - **Allow-list overrides the mutating filter.** If `EnabledTools` is set, only those tools are exposed; this overrides `ExposeMutatingTools` but not the `Enabled` flag.
 - **No file-system or shell access.** MCP only exposes existing `IAIToolProvider` tools.
 - **No payload logging.** Requests are logged without GhJSON payload contents.

--- a/docs/Components/Modifiers/script-modifier.md
+++ b/docs/Components/Modifiers/script-modifier.md
@@ -34,7 +34,7 @@ _Note: This documentation was written by AI on its own. It may contain some mist
 
 ### Overview
 
-`ScriptModifier` provides a complete API for modifying script components programmatically, with **100% parity** with GhJSON serialization capabilities.
+`ScriptModifier` provides low-level apply primitives for modifying script components programmatically. SmartHopper AI tools and components must stage and review the proposed script change through the shared consent pipeline before invoking these methods; `ScriptModifier` itself does not open UI.
 
 **Key Features**:
 

--- a/docs/Providers/AICall/tools.md
+++ b/docs/Providers/AICall/tools.md
@@ -43,6 +43,8 @@ This page documents how tool calls are represented, executed, and orchestrated w
 ### Safety and capability notes
 
 - Keep `ToolFilter` restrictive; enable only the tools you need for the task.
+- Tool surfaces are enforced separately from filters. Chat-only control tools such as `plan_propose` are unavailable through MCP and batch execution.
+- Canvas-mutating tools use invocation-scoped consent and graphical review; approval applies to one concrete call only.
 - Ensure tool argument validation and defensive coding in tool implementations.
 - Providers may infer `FunctionCalling` capability when tools are enabled via `AIRequestCall.IsValid()`; verify capability selection and errors through structured runtime messages.
 

--- a/docs/Tools/index.md
+++ b/docs/Tools/index.md
@@ -92,7 +92,9 @@ public abstract class AITool
 
 | Type | Purpose |
 | --- | --- |
-| `AITool` | Base class for all tools |
+| `AITool` | Base class for tool metadata, schemas, execution, and surfaces |
+| `AIMutatingTool` | Non-batch tool type for consent-controlled canvas/document changes |
+| `AIToolSurface` | Explicit Chat, Direct, Batch, and MCP exposure flags |
 | `AIToolRequest` | Request wrapper with name and parameters |
 | `ToolResult` | Structured result with payload and envelope |
 | `ToolResultEnvelope` | Standard metadata attached to every result |

--- a/docs/UI/Chat/index.md
+++ b/docs/UI/Chat/index.md
@@ -67,6 +67,8 @@ This page references rendering at a high level and leaves type-level details to 
 - `ConversationSession` is the single source of truth for conversation history and for orchestrating provider calls and tool passes.
 - `WebChatUtils.CreateWebChatRequest` composes the system prompt before creating the dialog. It prepends the mandatory embedded `assistant-core` knowledge through `AgentKnowledgeCatalog`, then appends caller or user specialization and enables the default runtime-context providers.
 - Focused Grasshopper guidance is available to the agent through the `smarthopper_readme` and `smarthopper_workflows` instruction tools, backed by the same embedded catalog exposed through MCP.
+- For non-trivial work, the model may call the Chat-only `plan_propose` control tool. WebChat renders an approval card and keeps the tool call pending until the user approves, rejects, or cancels.
+- Plan approval permits continuing with the approach but does not approve later canvas mutations; each mutation receives a separate graphical review.
 - `HtmlChatRenderer` (+ `ChatResourceManager`) converts `IAIInteraction` instances to HTML message bubbles. Markdig is used for Markdown -> HTML.
 - `WebChatDialog` is a thin host adapter:
   - Loads initial HTML (CSS/JS inline) via `HtmlChatRenderer.GetInitialHtml()`.

--- a/docs/UI/ai-change-review.md
+++ b/docs/UI/ai-change-review.md
@@ -1,0 +1,195 @@
+# AI Canvas Change Review
+
+Structural AI canvas changes are staged as a visual proposal on the actual Grasshopper canvas and applied only after explicit user acceptance.
+
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| **Since Version** | 2.1.0 |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+_Note: This documentation was written by AI on its own. It may contain some mistakes. If you would like to help, read this documentation and delete this comment if everything is okay._
+
+---
+
+## Why Read This?
+
+AI tools can add, modify, move, connect, group, and delete Grasshopper objects. Without a review step, every proposed mutation becomes part of the document immediately. This feature stages structural changes first, paints them over the live canvas, and applies only what the user accepts.
+
+**You should read this if you:**
+
+- Want to review or partially accept AI-proposed canvas changes
+- Are integrating a canvas-mutating AI tool with the shared review flow
+- Need to understand how SmartHopper splits responsibilities with `ghjson-dotnet`
+- Are debugging overlay rendering, proposal filtering, or undo behavior
+
+---
+
+## End-User Guide
+
+### What Is This?
+
+When an AI tool wants to change the canvas, SmartHopper shows a review dialog next to the Grasshopper window and paints the proposal directly on the canvas. Nothing is added to or removed from the document until the user clicks **Apply**.
+
+### Overlay Color Legend
+
+| Color | Meaning |
+| --- | --- |
+| Green | Component additions |
+| Amber | Modifications and proposed move targets |
+| Red | Removals and disconnections |
+| Blue | New connections |
+| Purple | Groups |
+
+### Step-by-Step
+
+1. Run an AI request that mutates the canvas (for example `gh_put`, `gh_move`, or `gh_disconnect`).
+2. Inspect the painted proposal on the canvas and the matching rows in the review dialog.
+3. Uncheck any change you do not want, or cancel to apply nothing.
+4. Click **Apply** to execute only the effectively accepted changes.
+5. The tool reports accepted and rejected counts back to the AI so it can continue without assuming rejected changes were applied.
+
+### Common Questions
+
+**Q: Does the preview create temporary components on the canvas?**
+A: No. The preview is painted during `CanvasPostPaintOverlay`. It never creates a duplicate `GH_Document` or temporary `IGH_DocumentObject` instances.
+
+**Q: What happens when I cancel the dialog?**
+A: The proposal is discarded and the document is left untouched.
+
+**Q: Can protected components be changed by the AI?**
+A: No. Protected canvas objects are filtered out before review and cannot be accepted indirectly through dependent changes.
+
+---
+
+## Developer Reference
+
+### API Overview
+
+```csharp
+// Review entry point: shows the dialog and overlay, returns true when applied.
+public static class CanvasChangeReviewService
+{
+    public static Task<bool> ReviewAsync(CanvasChangeReviewSession session);
+    public static CanvasChangeReviewSession CreateRemovalSession(string source, IEnumerable<Guid> instanceGuids);
+    public static CanvasChangeReviewSession CreateMoveSession(string source, IReadOnlyDictionary<Guid, PointF> targets, bool relative);
+    public static CanvasChangeReviewSession CreateConnectionSession(string source, IReadOnlyList<CanvasConnectionReviewProposal> proposals, CanvasChangeKind kind);
+    public static IReadOnlySet<Guid> GetAcceptedComponentGuids(CanvasChangeReviewSession session);
+    public static IReadOnlyList<Guid> GetAcceptedRemovalGuids(CanvasChangeReviewSession session);
+    public static IReadOnlySet<int> GetAcceptedConnectionProposalIndexes(CanvasChangeReviewSession session);
+}
+```
+
+### Key Types
+
+| Type | Purpose |
+| --- | --- |
+| `CanvasChangeReviewItem` | One independently selectable structural change, with optional dependencies via `RequiredItemKeys` |
+| `CanvasChangeReviewSession` | Immutable proposal (`GhJsonDocument`) plus mutable user selections |
+| `CanvasChangeReviewService` | UI-thread review entry point and proposal factories for removals, moves, and connections |
+| `CanvasChangePreviewOverlay` | Actual-canvas renderer hooked on `CanvasPostPaintOverlay`; never mutates `GH_Document` |
+| `CanvasChangeReviewDialog` | Eto dialog with per-change accept/reject checkboxes, positioned beside the canvas |
+| `GhPutChangePlan` | Compares an incoming GhJSON fragment with serialized live components and filters rejected components, connections, and groups |
+| `CanvasChangeKind` | Visual category: `ComponentAdded`, `ComponentModified`, `ComponentRemoved`, `ConnectionAdded`, `ConnectionRemoved`, `GroupAdded`, `GroupModified`, `GroupRemoved` |
+
+### Code Examples
+
+#### Building and Reviewing a Proposal
+
+```csharp
+// A tool builds review items, shows the session, and applies only accepted changes.
+var session = new CanvasChangeReviewSession(
+    "Review AI changes",
+    "gh_put",
+    proposedDocument,
+    items);
+
+var applied = await CanvasChangeReviewService.ReviewAsync(session);
+if (!applied)
+{
+    // Cancelled: apply nothing.
+}
+```
+
+#### Declaring Item Dependencies
+
+```csharp
+// A connection item can require its endpoint component items to be accepted.
+var wire = new CanvasChangeReviewItem(
+    "connection:0",
+    CanvasChangeKind.ConnectionAdded,
+    "Connect Number Slider -> Panel",
+    "New wire");
+wire.RequiredItemKeys.Add("component:42");
+```
+
+### Error Handling
+
+| Error | Cause | Solution |
+| --- | --- | --- |
+| Proposal appears empty | All items were filtered as protected or invalid | Check the tool result; rejected/protected items are reported to the AI |
+| Overlay not visible | Canvas was recreated or the session was cleared | Re-run the tool; overlays detach automatically on session end |
+| Rejected dependency still applied | Item keys were not declared in `RequiredItemKeys` | Add dependency keys so dependent changes are rejected together |
+
+---
+
+## Architecture & Design
+
+### Design Rationale
+
+**Problem**: AI canvas mutations were applied immediately, giving the user no chance to inspect or partially accept them before they became persistent document changes.
+
+**Approach**: Document staging. Tools build a proposed `GhJsonDocument` off-canvas, the overlay paints the proposal on the live canvas, and the final mutation runs only after user acceptance — ideally as a single undoable action.
+
+**Trade-offs**:
+
+- True staging (safe, honest preview) vs approximated ghost bounds for not-yet-instantiated components
+- Shared review contracts (consistent UX across tools) vs a small per-tool adapter to describe proposals
+
+### Ownership
+
+- **GhJSON.Core** owns portable GhJSON/GhPatch models, diffing, patching, checksums, and conflict handling.
+- **GhJSON.Grasshopper** owns generic canvas serialization, placement, connection, deletion, and undo integration.
+- **SmartHopper.Core.Grasshopper** owns AI proposal policy, user acceptance, Eto UI, and canvas overlays.
+
+This keeps GhJSON reusable by non-AI clients while avoiding SmartHopper-specific approval concepts in the format libraries.
+
+### Data Flow
+
+```text
+AI tool → build proposal (GhJsonDocument + review items)
+        → CanvasChangeReviewService.ReviewAsync
+        → CanvasChangePreviewOverlay paints on live canvas
+        → CanvasChangeReviewDialog collects accept/reject
+        → apply accepted subset only → tool result reports rejected items
+```
+
+### Tool Coverage
+
+The shared review flow currently gates:
+
+- `gh_put` additions, replacements, connections, and groups
+- `gh_remove` and `gh_clear` removals
+- `gh_connect` and `gh_disconnect` wire changes
+- `gh_move` target positions
+- `gh_group` and `gh_group_selected` group creation
+
+Runtime actions such as button clicks and script execution are not represented as structural diffs. They retain their existing execution semantics.
+
+### Gotchas
+
+- Added-component ghosts approximate component bounds because exact attributes are only available after Grasshopper instantiation.
+- Proposals without pivots use GhJSON dependency-graph layout for preview; Grasshopper-aware final layout may differ slightly.
+- Non-edit `gh_put` can auto-offset the accepted network to avoid live objects, so its final global offset can differ from the proposal coordinates.
+- Specialized structural tools (`gh_tidy_up`, `gh_smart_connect`, preview/lock changes, parameter modifiers) still use their existing execution paths and can adopt the same contracts later.
+
+### Related Documentation
+
+- [User Interface](./index.md)
+- [Chat UI](./Chat/index.md)
+- [Tools](../Tools/index.md)

--- a/docs/UI/ai-change-review.md
+++ b/docs/UI/ai-change-review.md
@@ -162,7 +162,8 @@ This keeps GhJSON reusable by non-AI clients while avoiding SmartHopper-specific
 ### Data Flow
 
 ```text
-AI tool → build proposal (GhJsonDocument + review items)
+AI tool/component → build proposal (GhJsonDocument + review items)
+        → ConsentGate (one invocation, one decision)
         → CanvasChangeReviewService.ReviewAsync
         → CanvasChangePreviewOverlay paints on live canvas
         → CanvasChangeReviewDialog collects accept/reject

--- a/docs/UI/icon-set-brief.md
+++ b/docs/UI/icon-set-brief.md
@@ -2,7 +2,66 @@
 
 Brief for generating a new, coherent icon set (e.g. with an AI icon-set generator such as mew.design) covering the Grasshopper component icons and app identity assets of SmartHopper.
 
-## 1. Technical constraints
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Components/Resources/` |
+| **Since Version** | ? |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+---
+
+## Why Read This?
+
+Component icons are the primary visual language of SmartHopper on the Grasshopper canvas. This brief defines the badge grammar, color system, and per-icon design specs so a regenerated icon set stays coherent.
+
+**You should read this if you:**
+
+- Are generating or redrawing component or brand icons
+- Need to understand the badge grammar (direction, source, and AI markers)
+- Are adding a new component and need a consistent icon spec
+
+---
+
+## End-User Guide
+
+### What users see
+
+Every component icon is a main central glyph plus one or two small corner badges that encode semantics: direction (data into AI vs out of AI), source/type, and whether the component calls an AI provider. The numbered sections below describe this grammar in detail.
+
+---
+
+## Developer Reference
+
+### Icon assets and assignment
+
+Component icons are 24×24 PNGs embedded as `Bitmap` resources and exposed through each component's `Icon` override:
+
+```csharp
+// Each component surfaces its icon from embedded resources.
+protected override Bitmap Icon => Properties.Resources.aichat;
+```
+
+The Grasshopper category tab icon is registered once at assembly load:
+
+```csharp
+// SmartHopperAssemblyPriority registers the category identity.
+Instances.ComponentServer.AddCategoryIcon("SmartHopper", Resources.smarthopper);
+```
+
+---
+
+## Architecture & Design
+
+### Design brief
+
+The numbered sections below are the full generation brief: technical constraints, the current icon system, the proposed badge grammar, the per-icon inventory, and the color system.
+
+### 1. Technical constraints
 
 | Constraint | Value | Why |
 | --- | --- | --- |
@@ -13,7 +72,7 @@ Brief for generating a new, coherent icon set (e.g. with an AI icon-set generato
 | Theme | Must work on light **and** dark Grasshopper themes | Avoid pure black or pure white-only silhouettes; prefer mid-tone fills + outlines |
 | Legibility rule | Max **2 badges** per icon, badges ≥ 8 px | At 24 px, anything finer turns to noise |
 
-## 2. Current system
+### 2. Current system
 
 Every component icon is a **main central glyph** plus **one or two small badges** at the bottom corners that encode semantics. The codebase already reveals a consistent grammar:
 
@@ -23,7 +82,7 @@ Every component icon is a **main central glyph** plus **one or two small badges*
 - GhJSON icons = document glyph + operation badge (get / put / merge / diff / patch).
 - "Side" icons (settings, context, models, metrics) have no direction badge.
 
-## 3. Proposed badge grammar
+### 3. Proposed badge grammar
 
 Fixed positions so badges are predictable:
 
@@ -38,7 +97,7 @@ Fixed positions so badges are predictable:
 
 Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 badges as standalone assets, then ask the generator to compose each icon. That guarantees consistency that one-shot generation won't.
 
-## 4. Similarity groups found in the codebase
+### 4. Similarity groups found in the codebase
 
 1. **Direction pairs** — the largest pattern: `toai-*` (B. Input) vs `aito*` (C. Output). Same type glyph, mirrored direction badge.
 2. **Data-type family** — text, text list, boolean, integer, number, JSON, list, image, audio, speech, file, web, GhJSON, context, prompt.
@@ -48,9 +107,9 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 6. **Side/config icons** — settings, extra settings, models, context providers, file metadata, metrics: no direction badge; these live next to the AI pipeline.
 7. **Viewers/captures** — image viewer, audio viewer, canvas/viewport capture: "display/capture" family, no AI badge.
 
-## 5. Full icon inventory and per-icon design spec
+### 5. Full icon inventory and per-icon design spec
 
-### 5.1 Brand / app identity
+#### 5.1 Brand / app identity
 
 | Asset | Used by | Design spec |
 | --- | --- | --- |
@@ -59,7 +118,7 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 | `img/smarthopper.png` | Repo/README logo | Large-format variant of the mascot. |
 | Provider logos (8) | `SmartHopper.Providers.*`: anthropic, deepseek, gemini, localai, mistralai, ollama, openai, openrouter | **Do not AI-generate** — third-party trademarks. Keep official brand marks, normalized to a consistent square frame. |
 
-### 5.2 "A. AI" category — assistant & configuration
+#### 5.2 "A. AI" category — assistant & configuration
 
 | Component | Icon resource | Design spec |
 | --- | --- | --- |
@@ -70,7 +129,7 @@ Recommended: generate the set **modularly** — first ~15 core glyphs and ~12 ba
 | File Metadata (`AIFileMetadataComponent`) | `context` | Document with a tag/label line — represents file-level metadata context. |
 | AI Models (`AIModelsComponent`) | `aimodels` | Stacked/layered nodes or a list with a spark — "catalog of models". |
 
-### 5.3 "B. Input" category — data → AI (`toai-*`)
+#### 5.3 "B. Input" category — data → AI (`toai-*`)
 
 Shared spec: **type glyph center + "arrow into AI spark" badge bottom-right**. List variants add a bottom-left `≡`/`[]` badge.
 
@@ -99,7 +158,7 @@ Shared spec: **type glyph center + "arrow into AI spark" badge bottom-right**. L
 | Ladybug Post to AI | **missing** | Post card | to-AI + Ladybug mark |
 | Ladybug Topic to AI | **missing** | Topic stack | to-AI + Ladybug mark |
 
-### 5.4 "C. Output" category — AI → data (`aito*`)
+#### 5.4 "C. Output" category — AI → data (`aito*`)
 
 Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right**. Mirror of 5.3.
 
@@ -120,7 +179,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI to Script | `aitoscript` | `</>` code glyph |
 | AI to GhJSON | `aitogh` | GH document |
 
-### 5.5 "Text" category — AI text ops
+#### 5.5 "Text" category — AI text ops
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -128,14 +187,14 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI Text To Text List | `textlistgenerate` | "T" + list lines + AI spark |
 | AI Text To Boolean | `textevaluate` | "T" + check/?-evaluate badge — reads as "question → true/false" |
 
-### 5.6 "List" category
+#### 5.6 "List" category
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
 | AI List Filter | `listfilter` | List `≡` + funnel badge + AI spark |
 | AI List To Boolean | `listevaluate` | List `≡` + check/evaluate badge + AI spark |
 
-### 5.7 "JSON" category — pure data toolkit (no AI)
+#### 5.7 "JSON" category — pure data toolkit (no AI)
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -152,7 +211,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | JSON Schema Prop | `jsonschemaprop` | Schema badge + single key glyph |
 | AI Text → JSON | `jsonai` | `{ }` + AI spark (only AI-powered member of the family) |
 
-### 5.8 "Knowledge" category — research sources
+#### 5.8 "Knowledge" category — research sources
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -169,7 +228,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | McNeel × (search / post get / post open / post summarize / topic summarize) | `mcneel*` | Same action badges, source glyph = McNeel mark (rhino/"M") |
 | Ladybug × same 5 actions | `ladybug*` | Same action badges, source glyph = ladybug beetle |
 
-### 5.9 "Grasshopper" category — GhJSON document ops
+#### 5.9 "Grasshopper" category — GhJSON document ops
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -189,7 +248,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | AI Smart Connect | **missing** | Two component nodes + wire/plug + AI spark |
 | AI Canvas Report | **missing** | Clipboard/report + canvas grid + AI spark |
 
-### 5.10 "Img" / "Audio" categories
+#### 5.10 "Img" / "Audio" categories
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -200,14 +259,14 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | Viewport To Image | **new:** `viewportcapture` (replaces shared `aitoimg`) | Perspective viewport frame + capture/camera badge; blue non-AI helper |
 | Audio Viewer | `audio` | Speaker/waveform in a display frame — no AI badge |
 
-### 5.11 "Script" category
+#### 5.11 "Script" category
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
 | AI Script Generate | `scriptgenerate` | `</>` code glyph + AI spark |
 | AI Script Review | `scriptreview` | `</>` + magnifier/check badge + AI spark |
 
-### 5.12 "Utils" / "MCP"
+#### 5.12 "Utils" / "MCP"
 
 | Component | Icon | Design spec |
 | --- | --- | --- |
@@ -215,7 +274,7 @@ Shared spec: **type glyph center + "AI spark with arrow out" badge bottom-right*
 | Combine Metrics | **missing** | Chart bars + merge badge |
 | SmartHopper MCP Server | **missing** (no `Icon` override) | Server/plug node + SmartHopper spark — represents the loopback MCP endpoint |
 
-## 6. New composed icons required because of missing or shared assets
+### 6. New composed icons required because of missing or shared assets
 
 The new set must include the following **22 distinct 24×24 component icons** in addition to replacing the icons already listed above. Fourteen fill current gaps; eight separate components that currently reuse an icon with different semantics. Resource names below are proposed identifiers and can be adjusted during integration.
 
@@ -244,7 +303,7 @@ The new set must include the following **22 distinct 24×24 component icons** in
 | Combine Metrics | `metricscombine` | Current `Icon => null` | Metrics-chart full glyph + merge badge |
 | SmartHopper MCP Server | `mcpserver` | No `Icon` override | Server-node full glyph + MCP/connection badge |
 
-## 7. Color system
+### 7. Color system
 
 Color should accelerate recognition, but **never carry meaning alone**: each role also has a unique full glyph or badge silhouette. Use color on the principal glyph and the semantically important badge, with dark slate outlines and off-white cutouts for contrast.
 
@@ -260,7 +319,7 @@ Color should accelerate recognition, but **never carry meaning alone**: each rol
 | Knockout / highlight | Off-white | `#F4F6F8` | Interior cutouts, badge symbols, separation keylines | Remains readable on dark canvas themes |
 | Error/status only | Red | `#C0392B` | Existing invalid-model runtime badge only | Reserve red for actual errors; never use it as a component-category color |
 
-### 7.1 Color application rules
+#### 7.1 Color application rules
 
 1. Use at most **two semantic colors** in one icon, plus slate and off-white neutrals.
 2. The **main glyph color identifies the domain**: gray configuration, pink knowledge, teal canvas/GhJSON, blue deterministic data/media, or green AI-first components.
@@ -271,11 +330,11 @@ Color should accelerate recognition, but **never carry meaning alone**: each rol
 7. Do not use gradients, shadows, semitransparent hairlines, or red/green color contrast as the only distinction.
 8. Third-party source marks may keep recognizable brand shapes, but recolor them raspberry pink where trademark guidance permits. If recoloring is not permitted, use the official mark inside a consistent pink source-badge frame.
 
-## 8. Deduplicated drawing inventory
+### 8. Deduplicated drawing inventory
 
 Generate these drawings as reusable masters before composing the 24×24 icons. A drawing appears **once** in this list even when dozens of icons reuse it.
 
-### 8.1 Full-size drawings
+#### 8.1 Full-size drawings
 
 Full-size drawings occupy approximately **14–18 px** of the 24×24 artboard and provide the icon's primary silhouette.
 
@@ -315,7 +374,7 @@ Full-size drawings occupy approximately **14–18 px** of the 24×24 artboard an
 | F32 | MCP server | Gray | Compact server stack with one network port/node | SmartHopper MCP Server |
 | F33 | Scattered components | Teal | Three displaced component rectangles | Tidy Up before-state |
 
-### 8.2 Badge-size drawings
+#### 8.2 Badge-size drawings
 
 Badge drawings occupy approximately **7–9 px**, use filled geometric silhouettes, and normally sit bottom-right. Source/type modifiers sit bottom-left. Draw every badge on the same nominal 9×9 artboard with at least a 1 px clear zone.
 
@@ -363,7 +422,7 @@ Badge drawings occupy approximately **7–9 px**, use filled geometric silhouett
 | B40 | Providers / registry | Gray | Three short rows with connection dots | Context Providers / AI Models |
 | B41 | MCP connection | Gray | Two linked nodes with a central port | MCP Server |
 
-### 8.3 Runtime badges drawn by code
+#### 8.3 Runtime badges drawn by code
 
 These are not PNG assets but should be included in the visual design handoff because they appear next to the generated icons. Keep their existing semantics and colors:
 
@@ -376,7 +435,7 @@ These are not PNG assets but should be included in the visual design handoff bec
 | Replaced model | Runtime 16×16 | Blue `#3498DB` | Filled circle + white refresh arrow |
 | Provider identity | Runtime 16×16 | Provider brand | Official provider logo in the bottom strip; do not regenerate |
 
-## 9. Gaps and cleanup notes
+### 9. Gaps and cleanup notes
 
 - **14 components currently ship without icons** (`Icon => null` or no override): the 4 forum `*2AI` inputs, 4 GhJSON/GhPatch file operations, `GhValidate`, `GhPatchApplyToCanvas`, `AIGhConnect`, `AIGhReport`, `CombineMetrics`, and `SmartHopperMcpServer`.
 - **Eight additional components require new dedicated compositions** because they currently reuse an icon with different semantics: Boolean/Integer/Number List to AI, JSON Get Value, JSON Set Value, AI Web To Markdown, Canvas To Image, and Viewport To Image.
@@ -385,7 +444,7 @@ These are not PNG assets but should be included in the visual design handoff bec
 - Template/junk entries `Bitmap1`, `Color1`, `Icon1`, and `Name1` should not be recreated.
 - Chat UI uses an inline chart emoji for metrics; it is outside the Grasshopper component icon set but should eventually use the same F29 metrics drawing for product consistency.
 
-## 10. Suggested generation prompts
+### 10. Suggested generation prompts
 
 Use one style preamble for every full-size drawing:
 

--- a/docs/UI/index.md
+++ b/docs/UI/index.md
@@ -1,0 +1,99 @@
+# User Interface
+
+Documentation for SmartHopper's user-facing UI: the WebView chat, canvas overlays and review dialogs, and the icon set design brief.
+
+---
+
+## Metadata
+
+| Property | Value |
+| --- | --- |
+| **Source Code** | `src/SmartHopper.Core/UI/` and `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| **Since Version** | ? |
+| **Last Updated** | 2026-09-07 |
+| **Documentation Maintainer** | Devin AI |
+
+_Note: This documentation was written by AI on its own. It may contain some mistakes. If you would like to help, read this documentation and delete this comment if everything is okay._
+
+---
+
+## Why Read This?
+
+SmartHopper surfaces AI capabilities through two main UI layers: the WebView-based chat and canvas-integrated overlays/dialogs. This index links the detailed pages and explains how they relate.
+
+**You should read this if you:**
+
+- Are working on the chat dialog, canvas overlays, or Eto dialogs
+- Need to find where a UI surface is implemented
+- Want to add a new user-facing review or visualization feature
+
+---
+
+## End-User Guide
+
+### UI Surfaces
+
+| Surface | Description | Documentation |
+| --- | --- | --- |
+| Chat UI | Full WebView chat interface bridged to the Rhino host | [Chat UI](Chat/index.md) |
+| AI Canvas Change Review | Staged visual review of AI-proposed canvas changes | [AI Canvas Change Review](ai-change-review.md) |
+| Icon Set | Component and brand asset design brief | [Icon Set Brief](icon-set-brief.md) |
+
+### Common Questions
+
+**Q: Where does the chat window live?**
+A: The WebView chat is hosted in `SmartHopper.Core` under `UI/Chat/`, with conversation state in `SmartHopper.Infrastructure`.
+
+**Q: Where are canvas overlays implemented?**
+A: Overlays live in `SmartHopper.Core.Grasshopper` under `Utils/Canvas/` and render via `GH_Canvas` paint callbacks.
+
+---
+
+## Developer Reference
+
+### Entry Points
+
+| Concern | Location |
+| --- | --- |
+| Chat dialog and renderer | `src/SmartHopper.Core/UI/Chat/` |
+| Canvas overlays and review | `src/SmartHopper.Core.Grasshopper/Utils/Canvas/` |
+| Assembly-level canvas registration | `src/SmartHopper.Components/SmartHopperAssemblyPriority.cs` |
+
+### Code Examples
+
+#### Registering a Canvas Overlay
+
+```csharp
+// Overlays are initialized once from the assembly priority load hook.
+public override GH_LoadingInstruction PriorityLoad()
+{
+    CanvasProtectionOverlay.Initialize();
+    CanvasChangePreviewOverlay.Initialize();
+    return GH_LoadingInstruction.Proceed;
+}
+```
+
+#### Showing a Staged Review
+
+```csharp
+// Tools hand a prepared session to the shared review service.
+var session = CanvasChangeReviewService.CreateMoveSession("gh_move", targets, relative: false);
+var applied = await CanvasChangeReviewService.ReviewAsync(session);
+```
+
+---
+
+## Architecture & Design
+
+### Design Rationale
+
+**Problem**: SmartHopper needs both a rich conversational UI and lightweight, in-context canvas feedback without duplicating UI frameworks.
+
+**Approach**: The chat uses a WebView hosted in Eto for rich HTML rendering; canvas feedback uses `GH_Canvas` paint callbacks plus small Eto dialogs. Both are owned by `SmartHopper.Core`/`SmartHopper.Core.Grasshopper` so provider and component projects stay UI-free.
+
+### Related Documentation
+
+- [Chat UI](Chat/index.md)
+- [AI Canvas Change Review](ai-change-review.md)
+- [Icon Set Brief](icon-set-brief.md)
+- [Documentation Hub](../index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ This is the root documentation hub for SmartHopper. It organizes all guides, ref
 - [AIInputPayload](Architecture/AIInputPayload.md) -- unified input format
 - [AIRequestParameters](Architecture/AIRequestParameters.md) -- request customization
 - [VersatileAudio](Architecture/VersatileAudio.md) -- audio type system
+- [Agentic Copilot and Consent](Architecture/agent-copilot.md) -- planning, tool surfaces, and graphical mutation approval
 - [Design Decisions](DESIGN_DECISIONS/index.md) -- rationale behind key choices
 
 #### Context & Tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ This is the root documentation hub for SmartHopper. It organizes all guides, ref
 
 #### UI
 
-- [Chat UI](UI/Chat/index.md) -- web chat interface and host bridge
+- [User Interface](UI/index.md) -- chat UI, canvas overlays, and AI change review
 
 #### Usage Guides
 

--- a/src/SmartHopper.Components/Grasshopper/GhPatchApplyToCanvasComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhPatchApplyToCanvasComponents.cs
@@ -29,6 +29,7 @@ using Grasshopper.Kernel;
 using Newtonsoft.Json.Linq;
 using SmartHopper.Core.ComponentBase;
 using SmartHopper.Infrastructure.AICall.Tools;
+using SmartHopper.Infrastructure.Consent;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
 using SmartHopper.ProviderSdk.Diagnostics;
@@ -257,10 +258,29 @@ namespace SmartHopper.Components.Grasshopper
                         var removedGuids = ExtractRemovedGuids(baseDoc, resultJson);
                         if (removedGuids.Count > 0)
                         {
-                            var deleteResult = GhJsonGrasshopper.Delete(removedGuids);
-                            if (!deleteResult.Success)
+                            var removeInteraction = new AIInteractionToolCall
                             {
-                                this.CollectMessage(SHRuntimeMessageSeverity.Warning, $"Failed to delete some removed components: {string.Join(", ", deleteResult.Failed)}");
+                                Name = "gh_remove",
+                                Arguments = new JObject
+                                {
+                                    ["instanceGuids"] = JArray.FromObject(removedGuids.Select(guid => guid.ToString())),
+                                },
+                                Agent = AIAgent.Assistant,
+                            };
+                            var removeCall = this.CreateComponentMutationCall(removeInteraction);
+                            var removeResult = await removeCall.Exec(token).ConfigureAwait(false);
+                            if (!removeResult.Success)
+                            {
+                                this.CollectMessage(SHRuntimeMessageSeverity.Warning, "Reviewed component removals did not complete successfully.");
+                                return;
+                            }
+
+                            var removalPayload = ToolCallResult.FromAIReturn(removeResult);
+                            var removedCount = removalPayload?["removedGuids"]?.Count() ?? 0;
+                            if (removedCount != removedGuids.Count)
+                            {
+                                this.CollectMessage(SHRuntimeMessageSeverity.Info, "Patch application stopped because not all removals were accepted.");
+                                return;
                             }
                         }
                     }
@@ -283,12 +303,8 @@ namespace SmartHopper.Components.Grasshopper
                             Agent = AIAgent.Assistant,
                         };
 
-                        var putToolCall = new AIToolCall();
-                        putToolCall.Endpoint = "gh_put";
-                        putToolCall.FromToolCallInteraction(putToolCallInteraction);
-                        putToolCall.SkipMetricsValidation = true;
-
-                        var putAiResult = await putToolCall.Exec().ConfigureAwait(false);
+                        var putToolCall = this.CreateComponentMutationCall(putToolCallInteraction);
+                        var putAiResult = await putToolCall.Exec(token).ConfigureAwait(false);
 
                         if (!putAiResult.Success)
                         {
@@ -305,6 +321,26 @@ namespace SmartHopper.Components.Grasshopper
                     Debug.WriteLine($"[GhPatchApplyToCanvas] Error: {ex.Message}");
                     this.error = ex.Message;
                 }
+            }
+
+            private AIToolCall CreateComponentMutationCall(AIInteractionToolCall interaction)
+            {
+                var call = new AIToolCall
+                {
+                    Endpoint = interaction.Name,
+                    SkipMetricsValidation = true,
+                    ToolSurface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct,
+                    InvocationContext = new MutationInvocationContext
+                    {
+                        Source = MutationInvocationSource.GrasshopperComponent,
+                        OwnerId = this.Parent.InstanceGuid.ToString(),
+                        ToolCallId = interaction.Id,
+                        ToolName = interaction.Name,
+                        Surface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct,
+                    },
+                };
+                call.FromToolCallInteraction(interaction);
+                return call;
             }
 
             /// <inheritdoc/>

--- a/src/SmartHopper.Components/Grasshopper/GhPutComponents.cs
+++ b/src/SmartHopper.Components/Grasshopper/GhPutComponents.cs
@@ -28,6 +28,7 @@ using Newtonsoft.Json.Linq;
 using SmartHopper.Components.Properties;
 using SmartHopper.Core.ComponentBase;
 using SmartHopper.Infrastructure.AICall.Tools;
+using SmartHopper.Infrastructure.Consent;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
 
@@ -146,11 +147,20 @@ namespace SmartHopper.Components.Grasshopper
                     var toolCall = new AIToolCall
                     {
                         Endpoint = "gh_put",
+                        ToolSurface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct,
+                        InvocationContext = new MutationInvocationContext
+                        {
+                            Source = MutationInvocationSource.GrasshopperComponent,
+                            OwnerId = this.Parent.InstanceGuid.ToString(),
+                            ToolCallId = toolCallInteraction.Id,
+                            ToolName = "gh_put",
+                            Surface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct,
+                        },
                     };
                     toolCall.FromToolCallInteraction(toolCallInteraction);
                     toolCall.SkipMetricsValidation = true;
 
-                    var aiResult = await toolCall.Exec().ConfigureAwait(false);
+                    var aiResult = await toolCall.Exec(token).ConfigureAwait(false);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
+++ b/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
@@ -21,6 +21,7 @@ using Grasshopper.Kernel;
 using SmartHopper.Components.Properties;
 using SmartHopper.Core.Grasshopper.Utils.Canvas;
 using SmartHopper.Core.UI;
+using SmartHopper.Infrastructure.AITools;
 using SmartHopper.Infrastructure.Dialogs;
 
 namespace SmartHopper.Components
@@ -44,6 +45,7 @@ namespace SmartHopper.Components
             };
 
             CanvasChangePreviewOverlay.EnsureInitialized();
+            MutationUndoCoordinator.Current = new GrasshopperMutationUndoCoordinator();
 
             // Initialize the visual overlay that marks protected components on the canvas.
             CanvasProtectionOverlay.EnsureInitialized();

--- a/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
+++ b/src/SmartHopper.Components/SmartHopperAssemblyPriority.cs
@@ -43,6 +43,8 @@ namespace SmartHopper.Components
                 DialogCanvasLink.RegisterLink(dialog, guid, color);
             };
 
+            CanvasChangePreviewOverlay.EnsureInitialized();
+
             // Initialize the visual overlay that marks protected components on the canvas.
             CanvasProtectionOverlay.EnsureInitialized();
 

--- a/src/SmartHopper.Core.Grasshopper.Tests/AITools/GhPutChangePlanTests.cs
+++ b/src/SmartHopper.Core.Grasshopper.Tests/AITools/GhPutChangePlanTests.cs
@@ -1,0 +1,153 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+using SmartHopper.Core.Grasshopper.AITools;
+using SmartHopper.Core.Grasshopper.Utils.Canvas;
+using Xunit;
+
+namespace SmartHopper.Core.Grasshopper.Tests.AITools
+{
+    /// <summary>
+    /// Tests document-only planning and selection without requiring a Rhino runtime.
+    /// </summary>
+    public sealed class GhPutChangePlanTests
+    {
+        /// <summary>
+        /// Verifies that unchanged, modified, and added components are classified correctly.
+        /// </summary>
+        [Fact]
+        public void Create_ClassifiesComponentChanges()
+        {
+            var modifiedGuid = Guid.NewGuid();
+            var unchangedGuid = Guid.NewGuid();
+            var existing = CreateDocument(
+                new[]
+                {
+                    CreateComponent(1, modifiedGuid, "Slider", "Old"),
+                    CreateComponent(2, unchangedGuid, "Panel", "Same"),
+                });
+            var proposed = CreateDocument(
+                new[]
+                {
+                    CreateComponent(1, modifiedGuid, "Slider", "New"),
+                    CreateComponent(2, unchangedGuid, "Panel", "Same"),
+                    CreateComponent(3, null, "Addition", "Add"),
+                });
+
+            var plan = GhPutChangePlan.Create(proposed, existing);
+
+            Assert.Equal(2, plan.Session.Items.Count);
+            Assert.Contains(plan.Session.Items, item => item.Kind == CanvasChangeKind.ComponentModified && item.ComponentId == 1);
+            Assert.Contains(plan.Session.Items, item => item.Kind == CanvasChangeKind.ComponentAdded && item.ComponentId == 3);
+        }
+
+        /// <summary>
+        /// Verifies that dependent wires and groups are omitted when a required component is rejected.
+        /// </summary>
+        [Fact]
+        public void BuildAcceptedDocument_RemovesRejectedDependencies()
+        {
+            var modifiedGuid = Guid.NewGuid();
+            var existing = CreateDocument(new[] { CreateComponent(1, modifiedGuid, "Slider", "Old") });
+            var components = new[]
+            {
+                CreateComponent(1, modifiedGuid, "Slider", "New"),
+                CreateComponent(2, null, "Addition", "Add"),
+            };
+            var connection = new GhJsonConnection
+            {
+                From = new GhJsonConnectionEndpoint { Id = 1, ParamName = "R" },
+                To = new GhJsonConnectionEndpoint { Id = 2, ParamName = "A" },
+            };
+            var group = new GhJsonGroup
+            {
+                Id = 3,
+                Name = "Generated",
+                Members = new List<int> { 1, 2 },
+            };
+            var proposed = CreateDocument(components, new[] { connection }, new[] { group });
+            var plan = GhPutChangePlan.Create(proposed, existing);
+            var added = plan.Session.Items.Single(item => item.Kind == CanvasChangeKind.ComponentAdded);
+
+            plan.Session.SetAccepted(added.Key, false);
+            var accepted = plan.BuildAcceptedDocument();
+
+            Assert.Single(accepted.Components);
+            Assert.Equal(1, accepted.Components[0].Id);
+            Assert.Null(accepted.Connections);
+            Assert.Single(accepted.Groups!);
+            Assert.Equal(new[] { 1 }, accepted.Groups![0].Members);
+            Assert.Equal(2, plan.Session.AcceptedCount);
+        }
+
+        /// <summary>
+        /// Verifies that accepted wires to unchanged live components are retained for post-placement connection.
+        /// </summary>
+        [Fact]
+        public void GetAcceptedExternalConnections_ReturnsConnectionsToUnchangedComponents()
+        {
+            var existingGuid = Guid.NewGuid();
+            var unchanged = CreateComponent(1, existingGuid, "Slider", "Same");
+            var added = CreateComponent(2, null, "Addition", "Add");
+            var connection = new GhJsonConnection
+            {
+                From = new GhJsonConnectionEndpoint { Id = 1, ParamName = "R" },
+                To = new GhJsonConnectionEndpoint { Id = 2, ParamName = "A" },
+            };
+            var plan = GhPutChangePlan.Create(
+                CreateDocument(new[] { unchanged, added }, new[] { connection }),
+                CreateDocument(new[] { unchanged }));
+
+            var accepted = plan.BuildAcceptedDocument();
+            var externalConnections = plan.GetAcceptedExternalConnections(accepted);
+
+            Assert.Single(accepted.Components);
+            Assert.Single(externalConnections);
+            Assert.Equal(existingGuid, plan.GetExistingInstanceGuid(1));
+        }
+
+        private static GhJsonDocument CreateDocument(
+            IEnumerable<GhJsonComponent> components,
+            IEnumerable<GhJsonConnection>? connections = null,
+            IEnumerable<GhJsonGroup>? groups = null)
+        {
+            return new GhJsonDocument("1.0", null, components, connections, groups);
+        }
+
+        private static GhJsonComponent CreateComponent(
+            int id,
+            Guid? instanceGuid,
+            string name,
+            string nickName)
+        {
+            return new GhJsonComponent
+            {
+                Id = id,
+                InstanceGuid = instanceGuid,
+                ComponentGuid = Guid.Parse("3e8f5f24-8e8c-4f11-a538-4dcd67e3590f"),
+                Name = name,
+                NickName = nickName,
+                Pivot = new GhJsonPivot(id * 100, 100),
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper.Tests/AITools/PlanProposeTests.cs
+++ b/src/SmartHopper.Core.Grasshopper.Tests/AITools/PlanProposeTests.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System.Linq;

--- a/src/SmartHopper.Core.Grasshopper.Tests/AITools/PlanProposeTests.cs
+++ b/src/SmartHopper.Core.Grasshopper.Tests/AITools/PlanProposeTests.cs
@@ -1,0 +1,91 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using SmartHopper.Core.Grasshopper.AITools;
+using SmartHopper.Infrastructure.AICall.Tools;
+using SmartHopper.Infrastructure.Consent;
+using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+using SmartHopper.ProviderSdk.Hosting;
+using Xunit;
+
+namespace SmartHopper.Core.Grasshopper.Tests.AITools
+{
+    /// <summary>
+    /// Tests the Chat-only planning control tool without Rhino runtime activation.
+    /// </summary>
+    public class PlanProposeTests
+    {
+        [Fact]
+        public void GetTools_ExposesPlanOnlyToChat()
+        {
+            var tool = new plan_propose().GetTools().Single();
+
+            Assert.Equal("plan_propose", tool.Name);
+            Assert.Equal(AIToolSurface.Chat, tool.Surfaces);
+            Assert.False(tool.MutatesCanvas);
+        }
+
+        [Fact]
+        public async Task Execute_ReturnsApprovalFromConsentPresenter()
+        {
+            var tool = new plan_propose().GetTools().Single();
+            var interaction = new AIInteractionToolCall
+            {
+                Id = "plan-call",
+                Name = tool.Name,
+                Arguments = new JObject
+                {
+                    ["goal"] = "Inspect canvas",
+                    ["summary"] = "Read the current definition",
+                    ["steps"] = new JArray
+                    {
+                        new JObject
+                        {
+                            ["id"] = "inspect",
+                            ["description"] = "Inspect the canvas",
+                        },
+                    },
+                },
+            };
+            var call = new AIToolCall
+            {
+                ToolSurface = AIToolSurface.Chat,
+                InvocationContext = new MutationInvocationContext
+                {
+                    Surface = AIToolSurface.Chat,
+                    Presenter = new ApprovingPresenter(),
+                },
+            };
+            call.FromToolCallInteraction(interaction);
+
+            var result = await tool.Execute(call);
+            var payload = result.Body.Interactions.OfType<AIInteractionToolResult>().Last().Result;
+
+            Assert.Equal("Approved", (string?)payload["status"]);
+        }
+
+        private sealed class ApprovingPresenter : IConsentPresenter
+        {
+            public bool CanPresent(IConsentProposal proposal, MutationInvocationContext context) => true;
+
+            public Task<ConsentDecision> PresentAsync(
+                IConsentProposal proposal,
+                MutationInvocationContext context,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new ConsentDecision { Status = ConsentDecisionStatus.Approved });
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/AITools/GhPutChangePlan.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/GhPutChangePlan.cs
@@ -1,0 +1,337 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core;
+using GhJSON.Core.SchemaModels;
+using Newtonsoft.Json.Linq;
+using SmartHopper.Core.Grasshopper.Utils.Canvas;
+
+namespace SmartHopper.Core.Grasshopper.AITools
+{
+    /// <summary>
+    /// Builds a selectable, non-mutating review plan for a <c>gh_put</c> proposal.
+    /// </summary>
+    public sealed class GhPutChangePlan
+    {
+        private GhPutChangePlan(
+            GhJsonDocument proposedDocument,
+            CanvasChangeReviewSession session)
+        {
+            this.ProposedDocument = proposedDocument;
+            this.Session = session;
+        }
+
+        /// <summary>Gets the original proposed document.</summary>
+        public GhJsonDocument ProposedDocument { get; }
+
+        /// <summary>Gets the user-review session.</summary>
+        public CanvasChangeReviewSession Session { get; }
+
+        /// <summary>
+        /// Creates a review plan by comparing proposed components with their live serialized state.
+        /// </summary>
+        /// <param name="proposedDocument">Incoming GhJSON proposal.</param>
+        /// <param name="existingDocument">Serialized live components matched by instance GUID.</param>
+        /// <returns>The review plan.</returns>
+        public static GhPutChangePlan Create(GhJsonDocument proposedDocument, GhJsonDocument existingDocument)
+        {
+            if (proposedDocument == null)
+            {
+                throw new ArgumentNullException(nameof(proposedDocument));
+            }
+
+            var existingByGuid = (existingDocument?.Components ?? Array.Empty<GhJsonComponent>())
+                .Where(component => component.InstanceGuid.HasValue)
+                .ToDictionary(component => component.InstanceGuid!.Value);
+            var items = new List<CanvasChangeReviewItem>();
+            var componentKeysById = new Dictionary<int, string>();
+            var unchangedIds = new HashSet<int>();
+
+            foreach (var component in proposedDocument.Components)
+            {
+                var key = $"component:{component.Id?.ToString() ?? component.InstanceGuid?.ToString() ?? items.Count.ToString()}";
+                if (component.Id.HasValue)
+                {
+                    componentKeysById[component.Id.Value] = key;
+                }
+
+                if (component.InstanceGuid.HasValue &&
+                    existingByGuid.TryGetValue(component.InstanceGuid.Value, out var existing))
+                {
+                    if (ComponentsAreEqual(component, existing))
+                    {
+                        if (component.Id.HasValue)
+                        {
+                            unchangedIds.Add(component.Id.Value);
+                        }
+
+                        continue;
+                    }
+
+                    items.Add(new CanvasChangeReviewItem(
+                        key,
+                        CanvasChangeKind.ComponentModified,
+                        DisplayName(component),
+                        DescribeChangedFields(component, existing))
+                    {
+                        ComponentId = component.Id,
+                        ExistingInstanceGuid = component.InstanceGuid,
+                    });
+                    continue;
+                }
+
+                items.Add(new CanvasChangeReviewItem(
+                    key,
+                    CanvasChangeKind.ComponentAdded,
+                    DisplayName(component),
+                    component.Library ?? "New component")
+                {
+                    ComponentId = component.Id,
+                });
+            }
+
+            if (proposedDocument.Connections != null)
+            {
+                for (var index = 0; index < proposedDocument.Connections.Count; index++)
+                {
+                    var connection = proposedDocument.Connections[index];
+                    var item = new CanvasChangeReviewItem(
+                        $"connection:{index}",
+                        CanvasChangeKind.ConnectionAdded,
+                        DescribeConnection(connection, proposedDocument),
+                        DescribeConnectionParameters(connection))
+                    {
+                        ConnectionIndex = index,
+                    };
+                    AddDependency(item, connection.From.Id, componentKeysById, unchangedIds);
+                    AddDependency(item, connection.To.Id, componentKeysById, unchangedIds);
+                    items.Add(item);
+                }
+            }
+
+            if (proposedDocument.Groups != null)
+            {
+                for (var index = 0; index < proposedDocument.Groups.Count; index++)
+                {
+                    var group = proposedDocument.Groups[index];
+                    var item = new CanvasChangeReviewItem(
+                        $"group:{index}",
+                        CanvasChangeKind.GroupAdded,
+                        string.IsNullOrWhiteSpace(group.Name) ? "Group" : group.Name!,
+                        $"{group.Members.Count} member(s)")
+                    {
+                        GroupIndex = index,
+                    };
+                    items.Add(item);
+                }
+            }
+
+            var previewDocument = proposedDocument.Components.Any(component => component.Pivot != null)
+                ? proposedDocument
+                : GhJson.ReorganizePivots(proposedDocument);
+            var session = new CanvasChangeReviewSession(
+                "Review AI canvas changes",
+                "gh_put",
+                previewDocument,
+                items);
+            return new GhPutChangePlan(proposedDocument, session);
+        }
+
+        /// <summary>
+        /// Gets accepted connections that cannot be created by placing the filtered fragment because at least one endpoint is an unchanged live component.
+        /// </summary>
+        /// <param name="acceptedDocument">Filtered document returned by <see cref="BuildAcceptedDocument"/>.</param>
+        /// <returns>Accepted connections requiring post-placement connection.</returns>
+        public IReadOnlyList<GhJsonConnection> GetAcceptedExternalConnections(GhJsonDocument acceptedDocument)
+        {
+            var placedIds = acceptedDocument.Components
+                .Where(component => component.Id.HasValue)
+                .Select(component => component.Id!.Value)
+                .ToHashSet();
+            var acceptedIndexes = this.Session.Items
+                .Where(item => item.ConnectionIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ConnectionIndex!.Value)
+                .ToHashSet();
+            return this.ProposedDocument.Connections?
+                .Select((connection, index) => new { Connection = connection, Index = index })
+                .Where(entry =>
+                    acceptedIndexes.Contains(entry.Index) &&
+                    (!placedIds.Contains(entry.Connection.From.Id) || !placedIds.Contains(entry.Connection.To.Id)))
+                .Select(entry => entry.Connection)
+                .ToList() ?? new List<GhJsonConnection>();
+        }
+
+        /// <summary>
+        /// Resolves a proposed component ID to its instance GUID when the proposal references a live component.
+        /// </summary>
+        /// <param name="componentId">Proposed component ID.</param>
+        /// <returns>The live instance GUID, or <c>null</c>.</returns>
+        public Guid? GetExistingInstanceGuid(int componentId)
+        {
+            return this.ProposedDocument.Components.FirstOrDefault(component => component.Id == componentId)?.InstanceGuid;
+        }
+
+        /// <summary>
+        /// Builds the GhJSON fragment containing only effectively accepted changes.
+        /// </summary>
+        /// <returns>A filtered GhJSON document.</returns>
+        public GhJsonDocument BuildAcceptedDocument()
+        {
+            var acceptedComponents = this.Session.Items
+                .Where(item => item.ComponentId.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ComponentId!.Value)
+                .ToHashSet();
+            var acceptedConnections = this.Session.Items
+                .Where(item => item.ConnectionIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.ConnectionIndex!.Value)
+                .ToHashSet();
+            var acceptedGroups = this.Session.Items
+                .Where(item => item.GroupIndex.HasValue && this.Session.IsEffectivelyAccepted(item))
+                .Select(item => item.GroupIndex!.Value)
+                .ToHashSet();
+
+            var components = this.ProposedDocument.Components
+                .Where(component => component.Id.HasValue && acceptedComponents.Contains(component.Id.Value))
+                .ToList();
+            var retainedIds = components
+                .Where(component => component.Id.HasValue)
+                .Select(component => component.Id!.Value)
+                .ToHashSet();
+            var connections = this.ProposedDocument.Connections?
+                .Select((connection, index) => new { Connection = connection, Index = index })
+                .Where(entry =>
+                    acceptedConnections.Contains(entry.Index) &&
+                    retainedIds.Contains(entry.Connection.From.Id) &&
+                    retainedIds.Contains(entry.Connection.To.Id))
+                .Select(entry => entry.Connection)
+                .ToList();
+            var groups = this.ProposedDocument.Groups?
+                .Select((group, index) => new { Group = group, Index = index })
+                .Where(entry => acceptedGroups.Contains(entry.Index))
+                .Select(entry => CopyGroup(entry.Group, retainedIds))
+                .Where(group => group.Members.Count > 0)
+                .ToList();
+
+            return new GhJsonDocument(
+                this.ProposedDocument.Schema,
+                this.ProposedDocument.Metadata,
+                components,
+                connections,
+                groups);
+        }
+
+        private static void AddDependency(
+            CanvasChangeReviewItem item,
+            int componentId,
+            IReadOnlyDictionary<int, string> componentKeysById,
+            ISet<int> unchangedIds)
+        {
+            if (!unchangedIds.Contains(componentId) &&
+                componentKeysById.TryGetValue(componentId, out var key) &&
+                !item.RequiredItemKeys.Contains(key))
+            {
+                item.RequiredItemKeys.Add(key);
+            }
+        }
+
+        private static GhJsonGroup CopyGroup(GhJsonGroup group, ISet<int> retainedIds)
+        {
+            return new GhJsonGroup
+            {
+                Id = group.Id,
+                InstanceGuid = group.InstanceGuid,
+                Name = group.Name,
+                Color = group.Color,
+                Members = group.Members.Where(retainedIds.Contains).ToList(),
+            };
+        }
+
+        private static string DescribeChangedFields(GhJsonComponent proposed, GhJsonComponent existing)
+        {
+            var proposedObject = Normalize(proposed);
+            var existingObject = Normalize(existing);
+            var changed = proposedObject.Properties()
+                .Select(property => property.Name)
+                .Union(existingObject.Properties().Select(property => property.Name))
+                .Where(name => !JToken.DeepEquals(proposedObject[name], existingObject[name]))
+                .ToList();
+            return changed.Count == 0 ? "Component state will change" : $"Changed: {string.Join(", ", changed)}";
+        }
+
+        private static string DescribeConnection(GhJsonConnection connection, GhJsonDocument document)
+        {
+            var from = document.Components.FirstOrDefault(component => component.Id == connection.From.Id);
+            var to = document.Components.FirstOrDefault(component => component.Id == connection.To.Id);
+            return $"{DisplayName(from)} → {DisplayName(to)}";
+        }
+
+        private static string DescribeConnectionParameters(GhJsonConnection connection)
+        {
+            var from = connection.From.ParamName ?? connection.From.ParamIndex?.ToString() ?? "output";
+            var to = connection.To.ParamName ?? connection.To.ParamIndex?.ToString() ?? "input";
+            return $"{from} → {to}";
+        }
+
+        private static string DisplayName(GhJsonComponent? component)
+        {
+            if (component == null)
+            {
+                return "Unknown component";
+            }
+
+            return !string.IsNullOrWhiteSpace(component.NickName) ? component.NickName! : component.Name ?? "Component";
+        }
+
+        private static bool ComponentsAreEqual(GhJsonComponent proposed, GhJsonComponent existing)
+        {
+            return JToken.DeepEquals(Normalize(proposed), Normalize(existing));
+        }
+
+        private static JObject Normalize(GhJsonComponent component)
+        {
+            var value = JObject.FromObject(component);
+            value.Remove("id");
+            value.Remove("errors");
+            value.Remove("warnings");
+            value.Remove("remarks");
+
+            if (value["componentState"] is JObject state)
+            {
+                state.Remove("selected");
+            }
+
+            foreach (var settingsKey in new[] { "inputSettings", "outputSettings" })
+            {
+                if (value[settingsKey] is not JArray settings)
+                {
+                    continue;
+                }
+
+                foreach (var setting in settings.OfType<JObject>())
+                {
+                    setting.Remove("runtimeData");
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/AITools/_gh_parameter_modifier.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/_gh_parameter_modifier.cs
@@ -47,7 +47,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// </summary>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_parameter_data_mapping_flatten",
                 description: "Set a parameter's data mapping to Flatten",
                 category: "NotTested",
@@ -62,13 +62,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.FlattenParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""parameterIndex"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_parameter_data_mapping_graft",
                 description: "Set a parameter's data mapping to Graft",
                 category: "NotTested",
@@ -83,13 +82,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.GraftParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""parameterIndex"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_parameter_data_mapping_none",
                 description: "Set a parameter's data mapping to None",
                 category: "NotTested",
@@ -104,13 +102,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.NoneParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""parameterIndex"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_parameter_reverse",
                 description: "Reverse the order of items in a parameter",
                 category: "NotTested",
@@ -126,13 +123,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.ReverseParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""parameterIndex"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_parameter_simplify",
                 description: "Simplify geometry in a parameter (removes redundant control points)",
                 category: "NotTested",
@@ -148,7 +144,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SimplifyParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""parameterIndex"": { ""type"": ""integer"" } } }",
@@ -315,8 +310,29 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 var toolInfo = toolCall.GetToolCall();
                 var args = toolInfo.GetArgumentsOrEmpty();
+                var componentGuid = Guid.Parse(args["componentGuid"]?.ToString() ?? throw new ArgumentException("Missing componentGuid"));
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolName,
+                    new[] { componentGuid },
+                    $"Apply parameter operation: {toolName}");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                if (!approved || !CanvasChangeReviewService.GetAcceptedComponentGuids(review).Contains(componentGuid))
+                {
+                    output.CreateSuccess(AIBodyBuilder.Create()
+                        .AddToolResult(new JObject
+                        {
+                            ["tool"] = toolName,
+                            ["success"] = false,
+                            ["rejected"] = true,
+                        }, toolInfo.Id, toolName)
+                        .Build(), toolCall);
+                    return output;
+                }
 
-                var tcs = new TaskCompletionSource<AIReturn>();
+                var tcs = new TaskCompletionSource<AIReturn>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 RhinoApp.InvokeOnUiThread(() =>
                 {

--- a/src/SmartHopper.Core.Grasshopper/AITools/_script_parameter_modifier.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/_script_parameter_modifier.cs
@@ -46,7 +46,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// </summary>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_add_input",
                 description: "Add a new input parameter to a script component",
                 category: "NotTested",
@@ -64,13 +64,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.AddInputParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_add_output",
                 description: "Add a new output parameter to a script component",
                 category: "NotTested",
@@ -86,13 +85,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.AddOutputParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_remove_input",
                 description: "Remove an input parameter from a script component",
                 category: "NotTested",
@@ -106,13 +104,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.RemoveInputParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_remove_output",
                 description: "Remove an output parameter from a script component",
                 category: "NotTested",
@@ -126,13 +123,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.RemoveOutputParameterAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_set_type_input",
                 description: "Set the type hint for a script component input parameter",
                 category: "NotTested",
@@ -147,13 +143,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetInputTypeHintAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_set_type_output",
                 description: "Set the type hint for a script component output parameter",
                 category: "NotTested",
@@ -168,13 +163,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetOutputTypeHintAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_set_access",
                 description: "Set how an input parameter receives data (item/list/tree)",
                 category: "NotTested",
@@ -189,13 +183,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetInputAccessAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_toggle_std_output",
                 description: "Show or hide the standard output parameter ('out') in a script component",
                 category: "NotTested",
@@ -209,13 +202,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.ToggleStandardOutputAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_set_principal_input",
                 description: "Set which input parameter drives the component's iteration",
                 category: "NotTested",
@@ -229,13 +221,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetPrincipalInputAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false)); // TODO: move to component modifiers
 
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "script_parameter_set_optional",
                 description: "Set whether a script input parameter is required or optional",
                 category: "NotTested",
@@ -250,7 +241,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetInputOptionalAsync,
                 requiredCapabilities: this.toolCapabilityRequirements,
-                mutatesCanvas: true,
                 enabled: false,
                 tags: new[] { "not-tested", "scripting", "script", "parameter", "canvas", "mutating" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""scriptGuid"": { ""type"": ""string"" }, ""index"": { ""type"": ""integer"" } } }",
@@ -385,7 +375,29 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 var toolInfo = toolCall.GetToolCall();
                 var args = toolInfo.GetArgumentsOrEmpty();
-                var tcs = new TaskCompletionSource<AIReturn>();
+                var scriptGuid = Guid.Parse(args["scriptGuid"]?.ToString() ?? throw new ArgumentException("Missing scriptGuid"));
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolName,
+                    new[] { scriptGuid },
+                    $"Apply script parameter operation: {toolName}");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                if (!approved || !CanvasChangeReviewService.GetAcceptedComponentGuids(review).Contains(scriptGuid))
+                {
+                    output.CreateSuccess(AIBodyBuilder.Create()
+                        .AddToolResult(new JObject
+                        {
+                            ["tool"] = toolName,
+                            ["success"] = false,
+                            ["rejected"] = true,
+                        }, toolInfo.Id, toolName)
+                        .Build(), toolCall);
+                    return output;
+                }
+
+                var tcs = new TaskCompletionSource<AIReturn>(TaskCreationOptions.RunContinuationsAsynchronously);
                 RhinoApp.InvokeOnUiThread(() =>
                 {
                     try

--- a/src/SmartHopper.Core.Grasshopper/AITools/button_click.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/button_click.cs
@@ -46,7 +46,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns>Collection of AI tools.</returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Simulate a momentary click on Grasshopper Buttons (not Boolean Toggles). The button is pressed for 100 ms, then released. Provide the instance GUIDs of the buttons.",
                 category: "Components",
@@ -62,13 +62,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""instanceGuids""]
                 }",
                 execute: this.ButtonClickToolAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "button" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""clickedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
         }
 
-        private Task<AIReturn> ButtonClickToolAsync(AIToolCall toolCall)
+        private async Task<AIReturn> ButtonClickToolAsync(AIToolCall toolCall)
         {
             var output = new AIReturn { Request = toolCall };
 
@@ -83,7 +82,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (guidArray == null || guidArray.Count == 0)
                 {
                     output.CreateError("Missing or empty 'instanceGuids' parameter.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var requestedGuids = guidArray
@@ -94,7 +93,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (requestedGuids.Count == 0)
                 {
                     output.CreateError("No valid GUIDs provided in 'instanceGuids'.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var (allowedGuids, protectedGuids) = CanvasProtection.FilterProtectedGuids(requestedGuids);
@@ -107,10 +106,21 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         CanvasProtection.FormatProtectionMessage(protectedGuids));
                 }
 
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolInfo.Name ?? "button_click",
+                    allowedGuids,
+                    "Trigger button action");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                var accepted = approved
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(review)
+                    : new HashSet<Guid>();
                 var clickedGuids = new List<Guid>();
                 var notFoundGuids = new List<string>();
 
-                foreach (var guid in allowedGuids)
+                foreach (var guid in allowedGuids.Where(accepted.Contains))
                 {
                     if (ComponentManipulation.ButtonClick(guid))
                     {
@@ -142,12 +152,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     .Build();
 
                 output.CreateSuccess(body, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Clear all components from the Grasshopper canvas. Optionally keep locked components. Protected components (and their direct neighbors) are always preserved. This is a destructive operation - use with caution. Supports undo (Ctrl+Z).",
+                description: "Stage removal of all components from the Grasshopper canvas and let the user visually review and select removals before applying them. Optionally keep locked components. Protected components (and their direct neighbors) are always preserved. Supports undo (Ctrl+Z).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -65,11 +65,11 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.ClearCanvasAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete", "destructive" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""deletedCount"": { ""type"": ""integer"" }, ""deleted"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""skippedLockedCount"": { ""type"": ""integer"" }, ""protectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""deletedCount"": { ""type"": ""integer"" }, ""deleted"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedCount"": { ""type"": ""integer"" }, ""skippedLockedCount"": { ""type"": ""integer"" }, ""protectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
         }
 
-        private Task<AIReturn> ClearCanvasAsync(AIToolCall toolCall)
+        private async Task<AIReturn> ClearCanvasAsync(AIToolCall toolCall)
         {
             var output = new AIReturn { Request = toolCall };
 
@@ -85,7 +85,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (doc == null)
                 {
                     output.CreateError("No active Grasshopper document found.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 // Collect all canvas object GUIDs
@@ -136,17 +136,26 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         .Build();
 
                     output.CreateSuccess(body, toolCall);
-                    return Task.FromResult(output);
+                    return output;
                 }
+
+                var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                IReadOnlyList<Guid> acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
+                    : Array.Empty<Guid>();
+                var rejectedCount = reviewSession.Items.Count - acceptedGuids.Count;
 
                 // Delete via GhJsonGrasshopper (handles UI thread + undo)
                 var deleteOptions = new DeleteOptions { Redraw = true };
-                var deleteResult = GhJsonGrasshopper.Delete(allowedGuids, deleteOptions);
+                var deleteResult = GhJsonGrasshopper.Delete(acceptedGuids, deleteOptions);
 
                 var result = new JObject
                 {
                     ["deletedCount"] = deleteResult.DeletedCount,
                     ["deleted"] = JArray.FromObject(deleteResult.Deleted.Select(g => g.ToString())),
+                    ["rejectedCount"] = rejectedCount,
                     ["skippedLockedCount"] = skippedLockedCount,
                     ["protectedGuids"] = JArray.FromObject(protectedGuids.Select(g => g.ToString())),
                 };
@@ -162,20 +171,22 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }
 
                 result["message"] = deleteResult.DeletedCount > 0
-                    ? $"Successfully cleared canvas. Deleted {deleteResult.DeletedCount} component(s)."
-                    : "No components were deleted.";
+                    ? $"Deleted {deleteResult.DeletedCount} component(s); the user rejected {rejectedCount} staged removal(s)."
+                    : rejectedCount > 0
+                        ? "The user rejected all staged removals."
+                        : "No components were deleted.";
 
                 var outBody = AIBodyBuilder.Create()
                     .AddToolResult(result)
                     .Build();
 
                 output.CreateSuccess(outBody, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error clearing canvas: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_clear.cs
@@ -48,7 +48,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <inheritdoc/>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage removal of all components from the Grasshopper canvas and let the user visually review and select removals before applying them. Optionally keep locked components. Protected components (and their direct neighbors) are always preserved. Supports undo (Ctrl+Z).",
                 category: "Components",
@@ -63,7 +63,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }",
                 execute: this.ClearCanvasAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete", "destructive" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""deletedCount"": { ""type"": ""integer"" }, ""deleted"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedCount"": { ""type"": ""integer"" }, ""skippedLockedCount"": { ""type"": ""integer"" }, ""protectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
@@ -141,7 +140,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
                 var applyReview = reviewSession.Items.Count > 0 &&
-                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false);
                 IReadOnlyList<Guid> acceptedGuids = applyReview
                     ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
                     : Array.Empty<Guid>();

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_component_lock.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_component_lock.cs
@@ -47,7 +47,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns></returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Lock (disable) or unlock (enable) components. Locked components don't execute and show as grayed out. Use this to temporarily disable parts of a definition without deleting them. Requires component GUIDs from gh_get.",
                 category: "Components",
@@ -67,13 +67,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [ ""guids"", ""locked"" ]
                 }",
                 execute: this.GhToggleLockAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "state" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_lock_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_component_lock_selected",
                 description: "Lock (disable) currently selected components. Quick way to disable selected items without needing to specify GUIDs manually. Locked components don't execute and show as grayed out. IMPORTANT: This tool will not affect the enabled SmartHopper MCP Server component or any component directly wired to it.",
                 category: "Components",
@@ -82,13 +81,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""properties"": {}
                 }",
                 execute: (toolCall) => this.GhToggleLockSelectedAsync(toolCall, locked: true),
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "state" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_unlock_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_component_unlock_selected",
                 description: "Unlock (enable) currently selected components. Quick way to enable selected items without needing to specify GUIDs manually. Unlocked components will execute normally. IMPORTANT: This tool will not affect the enabled SmartHopper MCP Server component or any component directly wired to it.",
                 category: "Components",
@@ -97,7 +95,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""properties"": {}
                 }",
                 execute: (toolCall) => this.GhToggleLockSelectedAsync(toolCall, locked: false),
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "state" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -147,12 +144,21 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         CanvasProtection.FormatProtectionMessage(protectedGuids));
                 }
 
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolInfo.Name ?? this.toolName,
+                    allowedGuids,
+                    locked ? "Lock component" : "Unlock component");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                var accepted = approved
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(review)
+                    : new HashSet<Guid>();
                 var updated = new List<string>();
-                foreach (var guid in allowedGuids)
+                foreach (var guid in allowedGuids.Where(accepted.Contains))
                 {
-                    Debug.WriteLine($"[GhObjTools] Parsed GUID: {guid}");
                     ComponentManipulation.SetComponentLock(guid, locked);
-                    Debug.WriteLine($"[GhObjTools] Set lock to {locked} for GUID: {guid}");
                     updated.Add(guid.ToString());
                 }
 
@@ -203,6 +209,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 Provider = toolCall.Provider,
                 Model = toolCall.Model,
+                ToolSurface = toolCall.ToolSurface,
+                CancellationToken = toolCall.CancellationToken,
+                InvocationContext = toolCall.InvocationContext.ForTool(toolInfo.Id, toolInfo.Name),
                 Body = AIBodyBuilder.Create()
                     .AddToolCall(
                         id: toolInfo.Id,

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_component_preview.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_component_preview.cs
@@ -46,7 +46,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns></returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Show or hide component geometry preview in the Rhino viewport. Hiding preview improves performance for complex definitions. Only affects components that generate geometry. Requires component GUIDs from gh_get.",
                 category: "Components",
@@ -66,13 +66,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [ ""guids"", ""previewOn"" ]
                 }",
                 execute: this.GhTogglePreviewAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "preview", "viewport" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_hide_preview_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_component_hide_preview_selected",
                 description: "Hide geometry preview for currently selected components. Quick way to hide preview for selected items without needing to specify GUIDs manually. Improves performance for complex definitions.",
                 category: "Components",
@@ -81,13 +80,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""properties"": {}
                 }",
                 execute: (toolCall) => this.GhTogglePreviewSelectedAsync(toolCall, previewOn: false),
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "preview", "viewport" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_show_preview_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_component_show_preview_selected",
                 description: "Show geometry preview for currently selected components. Quick way to enable preview for selected items without needing to specify GUIDs manually.",
                 category: "Components",
@@ -96,7 +94,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""properties"": {}
                 }",
                 execute: (toolCall) => this.GhTogglePreviewSelectedAsync(toolCall, previewOn: true),
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "preview", "viewport" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -119,22 +116,27 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 var guids = args["guids"]?.ToObject<List<string>>() ?? new List<string>();
                 var previewOn = args["previewOn"]?.ToObject<bool>() ?? false;
                 Debug.WriteLine($"[GhObjTools] GhTogglePreviewAsync: previewOn={previewOn}, guids count={guids.Count}");
+                var requested = guids
+                    .Select(value => Guid.TryParse(value, out var guid) ? (Guid?)guid : null)
+                    .OfType<Guid>()
+                    .ToList();
+                var (allowed, _) = CanvasProtection.FilterProtectedGuids(requested);
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolInfo.Name ?? this.toolName,
+                    allowed,
+                    previewOn ? "Enable viewport preview" : "Disable viewport preview");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                var accepted = approved
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(review)
+                    : new HashSet<Guid>();
                 var updated = new List<string>();
-
-                foreach (var s in guids)
+                foreach (var guid in allowed.Where(accepted.Contains))
                 {
-                    Debug.WriteLine($"[GhObjTools] Processing GUID string: {s}");
-                    if (Guid.TryParse(s, out var guid))
-                    {
-                        Debug.WriteLine($"[GhObjTools] Parsed GUID: {guid}");
-                        ComponentManipulation.SetComponentPreview(guid, previewOn);
-                        Debug.WriteLine($"[GhObjTools] Set preview to {previewOn} for GUID: {guid}");
-                        updated.Add(guid.ToString());
-                    }
-                    else
-                    {
-                        Debug.WriteLine($"[GhObjTools] Invalid GUID: {s}");
-                    }
+                    ComponentManipulation.SetComponentPreview(guid, previewOn);
+                    updated.Add(guid.ToString());
                 }
 
                 var toolResult = new JObject();
@@ -181,6 +183,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 Provider = toolCall.Provider,
                 Model = toolCall.Model,
+                ToolSurface = toolCall.ToolSurface,
+                CancellationToken = toolCall.CancellationToken,
+                InvocationContext = toolCall.InvocationContext.ForTool(toolInfo.Id, toolInfo.Name),
                 Body = AIBodyBuilder.Create()
                     .AddToolCall(
                         id: toolInfo.Id,

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Connect Grasshopper components together by creating wires between outputs and inputs. Use this to establish data flow between existing components on the canvas. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
+                description: "Stage wires between Grasshopper outputs and inputs, show the user an in-canvas visual review, and create only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -121,85 +121,108 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     return output;
                 }
 
-                var connectTcs = new TaskCompletionSource<(List<JObject> successful, List<JObject> failed)>();
+                var proposals = new List<CanvasConnectionReviewProposal>();
+                var failedConnections = new List<JObject>();
+                var protectedGuids = CanvasProtection.GetProtectedInstanceGuids();
+                foreach (var connSpec in connectionsArray)
+                {
+                    var sourceGuidString = connSpec["sourceGuid"]?.ToString();
+                    var targetGuidString = connSpec["targetGuid"]?.ToString();
+                    if (!Guid.TryParse(sourceGuidString, out var sourceGuid) ||
+                        !Guid.TryParse(targetGuidString, out var targetGuid))
+                    {
+                        failedConnections.Add(new JObject
+                        {
+                            ["error"] = "Missing or invalid sourceGuid or targetGuid",
+                            ["spec"] = connSpec,
+                        });
+                        continue;
+                    }
+
+                    if (protectedGuids.Contains(sourceGuid) || protectedGuids.Contains(targetGuid))
+                    {
+                        failedConnections.Add(new JObject
+                        {
+                            ["error"] = "Connection rejected because it involves a protected component.",
+                            ["sourceGuid"] = sourceGuidString,
+                            ["targetGuid"] = targetGuidString,
+                        });
+                        continue;
+                    }
+
+                    proposals.Add(new CanvasConnectionReviewProposal
+                    {
+                        SourceGuid = sourceGuid,
+                        TargetGuid = targetGuid,
+                        SourceParameter = connSpec["sourceParam"]?.ToString(),
+                        TargetParameter = connSpec["targetParam"]?.ToString(),
+                    });
+                }
+
+                var reviewSession = CanvasChangeReviewService.CreateConnectionSession(
+                    this.toolName,
+                    proposals,
+                    CanvasChangeKind.ConnectionAdded);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedIndexes = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
+                    : new HashSet<int>();
+                var representedIndexes = reviewSession.Items
+                    .Where(item => item.ComponentId.HasValue)
+                    .Select(item => item.ComponentId!.Value)
+                    .ToHashSet();
+                var connectTcs = new TaskCompletionSource<List<JObject>>();
                 Rhino.RhinoApp.InvokeOnUiThread(() =>
                 {
                     try
                     {
                         var successfulConnections = new List<JObject>();
-                        var failedConnections = new List<JObject>();
-                        var protectedGuids = CanvasProtection.GetProtectedInstanceGuids();
-
-                        foreach (var connSpec in connectionsArray)
+                        for (var index = 0; index < proposals.Count; index++)
                         {
-                            var sourceGuidStr = connSpec["sourceGuid"]?.ToString();
-                            var targetGuidStr = connSpec["targetGuid"]?.ToString();
-                            var sourceParamName = connSpec["sourceParam"]?.ToString();
-                            var targetParamName = connSpec["targetParam"]?.ToString();
-
-                            if (string.IsNullOrEmpty(sourceGuidStr) || string.IsNullOrEmpty(targetGuidStr))
+                            var proposal = proposals[index];
+                            if (!acceptedIndexes.Contains(index))
                             {
                                 failedConnections.Add(new JObject
                                 {
-                                    ["error"] = "Missing sourceGuid or targetGuid",
-                                    ["spec"] = connSpec
+                                    ["error"] = representedIndexes.Contains(index) ? "Connection rejected by the user." : "Source or target component was not found.",
+                                    ["sourceGuid"] = proposal.SourceGuid.ToString(),
+                                    ["targetGuid"] = proposal.TargetGuid.ToString(),
                                 });
                                 continue;
                             }
 
-                            if (!Guid.TryParse(sourceGuidStr, out var sourceGuid) || !Guid.TryParse(targetGuidStr, out var targetGuid))
+                            var success = GhJsonGrasshopper.Connect(
+                                proposal.SourceGuid,
+                                proposal.TargetGuid,
+                                proposal.SourceParameter,
+                                proposal.TargetParameter);
+                            var result = new JObject
                             {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Invalid GUID format",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
-                                continue;
-                            }
-
-                            if (protectedGuids.Contains(sourceGuid) || protectedGuids.Contains(targetGuid))
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection rejected because it involves a protected component.",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
-                                continue;
-                            }
-
-                            bool success = GhJsonGrasshopper.Connect(sourceGuid, targetGuid, sourceParamName, targetParamName);
-
+                                ["sourceGuid"] = proposal.SourceGuid.ToString(),
+                                ["targetGuid"] = proposal.TargetGuid.ToString(),
+                                ["sourceParam"] = proposal.SourceParameter ?? "(first output)",
+                                ["targetParam"] = proposal.TargetParameter ?? "(first input)",
+                            };
                             if (success)
                             {
-                                successfulConnections.Add(new JObject
-                                {
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                    ["sourceParam"] = sourceParamName ?? "(first output)",
-                                    ["targetParam"] = targetParamName ?? "(first input)",
-                                    ["status"] = "connected"
-                                });
+                                result["status"] = "connected";
+                                successfulConnections.Add(result);
                             }
                             else
                             {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection failed - check component GUIDs and parameter names",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr
-                                });
+                                result["error"] = "Connection failed - check component GUIDs and parameter names";
+                                failedConnections.Add(result);
                             }
                         }
 
-                        if (successfulConnections.Any())
+                        if (successfulConnections.Count > 0)
                         {
                             doc.NewSolution(false);
                             Instances.RedrawCanvas();
                         }
 
-                        connectTcs.SetResult((successfulConnections, failedConnections));
+                        connectTcs.SetResult(successfulConnections);
                     }
                     catch (Exception ex)
                     {
@@ -207,7 +230,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 });
 
-                var (successfulConnections, failedConnections) = await connectTcs.Task.ConfigureAwait(false);
+                var successfulConnections = await connectTcs.Task.ConfigureAwait(false);
 
                 var toolResult = new JObject
                 {

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_connect.cs
@@ -48,7 +48,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// </summary>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage wires between Grasshopper outputs and inputs, show the user an in-canvas visual review, and create only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
@@ -85,7 +85,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""connections""]
                 }",
                 execute: this.GhConnectToolAsync,
-                mutatesCanvas: true,
                 enabled: true,
                 tags: new[] { "canvas", "components", "mutating", "connections" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""successful"": { ""type"": ""array"", ""items"": { ""type"": ""object"" } }, ""failed"": { ""type"": ""array"", ""items"": { ""type"": ""object"" } }, ""successCount"": { ""type"": ""integer"" }, ""failCount"": { ""type"": ""integer"" } } }",
@@ -164,7 +163,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     proposals,
                     CanvasChangeKind.ConnectionAdded);
                 var applyReview = reviewSession.Items.Count > 0 &&
-                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false);
                 var acceptedIndexes = applyReview
                     ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
                     : new HashSet<int>();

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Disconnect Grasshopper components by removing wires between outputs and inputs. Use this to break data flow between existing components on the canvas. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
+                description: "Stage Grasshopper wire removals, show the user an in-canvas visual review, and remove only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -123,6 +123,37 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 var successfulDisconnections = new List<JObject>();
                 var failedDisconnections = new List<JObject>();
+                var proposals = connectionsArray
+                    .Select(connSpec => new
+                    {
+                        Source = connSpec["sourceGuid"]?.ToString(),
+                        Target = connSpec["targetGuid"]?.ToString(),
+                        SourceParameter = connSpec["sourceParam"]?.ToString(),
+                        TargetParameter = connSpec["targetParam"]?.ToString(),
+                    })
+                    .Where(value =>
+                        Guid.TryParse(value.Source, out var sourceGuid) &&
+                        Guid.TryParse(value.Target, out var targetGuid) &&
+                        !CanvasProtection.IsProtected(sourceGuid) &&
+                        !CanvasProtection.IsProtected(targetGuid))
+                    .Select(value => new CanvasConnectionReviewProposal
+                    {
+                        SourceGuid = Guid.Parse(value.Source!),
+                        TargetGuid = Guid.Parse(value.Target!),
+                        SourceParameter = value.SourceParameter,
+                        TargetParameter = value.TargetParameter,
+                    })
+                    .ToList();
+                var reviewSession = CanvasChangeReviewService.CreateConnectionSession(
+                    this.toolName,
+                    proposals,
+                    CanvasChangeKind.ConnectionRemoved);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedIndexes = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
+                    : new HashSet<int>();
+                var proposalIndex = 0;
 
                 foreach (var connSpec in connectionsArray)
                 {
@@ -159,6 +190,17 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             ["sourceGuid"] = sourceGuidStr,
                             ["targetGuid"] = targetGuidStr,
                             ["error"] = "Disconnection rejected because it involves a protected component.",
+                        });
+                        continue;
+                    }
+
+                    if (!acceptedIndexes.Contains(proposalIndex++))
+                    {
+                        failedDisconnections.Add(new JObject
+                        {
+                            ["sourceGuid"] = sourceGuidStr,
+                            ["targetGuid"] = targetGuidStr,
+                            ["error"] = "Disconnection rejected by the user or an endpoint was not found.",
                         });
                         continue;
                     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_disconnect.cs
@@ -48,7 +48,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// </summary>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage Grasshopper wire removals, show the user an in-canvas visual review, and remove only accepted connections. Requires component GUIDs (use gh_get_selected or gh_get to find them first).",
                 category: "Components",
@@ -85,7 +85,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""connections""]
                 }",
                 execute: this.GhDisconnectToolAsync,
-                mutatesCanvas: true,
                 enabled: true,
                 tags: new[] { "canvas", "components", "mutating", "connections", "disconnect" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""successful"": { ""type"": ""array"", ""items"": { ""type"": ""object"" } }, ""failed"": { ""type"": ""array"", ""items"": { ""type"": ""object"" } }, ""successCount"": { ""type"": ""integer"" }, ""failCount"": { ""type"": ""integer"" } } }",
@@ -149,7 +148,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     proposals,
                     CanvasChangeKind.ConnectionRemoved);
                 var applyReview = reviewSession.Items.Count > 0 &&
-                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false);
                 var acceptedIndexes = applyReview
                     ? CanvasChangeReviewService.GetAcceptedConnectionProposalIndexes(reviewSession)
                     : new HashSet<int>();

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_generate.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_generate.cs
@@ -108,7 +108,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "ghjson", "mutating", "ai-generation" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""ghjson"": { ""type"": [""string"", ""null""] }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""message"": { ""type"": ""string"" } }, ""required"": [""success""] }",
-                annotations: new AIToolAnnotations(destructiveHint: false));
+                annotations: new AIToolAnnotations(destructiveHint: false),
+                surfaces: SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp);
         }
 
         private async Task<AIReturn> ExecuteGenerateAsync(AIToolCall toolCall)
@@ -261,6 +262,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     Model = toolCall.Model,
                     Endpoint = "gh_put",
                     SkipMetricsValidation = true,
+                    ToolSurface = toolCall.ToolSurface,
+                    CancellationToken = toolCall.CancellationToken,
+                    InvocationContext = toolCall.InvocationContext.ForTool(ghPutInteraction.Id, "gh_put"),
                 };
                 ghPutToolCall.Body = AIBodyBuilder.Create()
                     .Add(ghPutInteraction)

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
@@ -50,7 +50,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// </summary>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage a visual group around components, show the user an in-canvas review, and create it only after acceptance. Use this to organize or annotate related components. Requires component GUIDs from gh_get.",
                 category: "Components",
@@ -74,13 +74,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""guids""]
                 }",
                 execute: this.GhGroupAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "organization" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""group"": { ""type"": ""string"", ""description"": ""Instance GUID of the created group."" }, ""grouped"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the components that were added to the group."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_group_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_group_selected",
                 description: "Stage a group around currently selected components and show the user an in-canvas review before creation. Quick way to organize selected items without specifying GUIDs manually.",
                 category: "Components",
@@ -98,7 +97,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }",
                 execute: this.GhGroupSelectedAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "organization" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""group"": { ""type"": ""string"", ""description"": ""Instance GUID of the created group."" }, ""grouped"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the components that were added to the group."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -172,7 +170,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     this.toolName,
                     proposedDocument,
                     new[] { reviewItem });
-                if (!await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false) ||
+                if (!await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false) ||
                     !reviewSession.IsEffectivelyAccepted(reviewItem))
                 {
                     var rejectedResult = new JObject

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_group.cs
@@ -21,6 +21,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using GhJSON.Core.SchemaModels;
+using GhJSON.Grasshopper;
 using Grasshopper;
 using Grasshopper.Kernel.Special;
 using Newtonsoft.Json.Linq;
@@ -50,7 +52,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Create a visual group container around components to organize and annotate them. Use this to highlight related components, mark areas of interest, or add notes to the canvas. Requires component GUIDs from gh_get.",
+                description: "Stage a visual group around components, show the user an in-canvas review, and create it only after acceptance. Use this to organize or annotate related components. Requires component GUIDs from gh_get.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -80,7 +82,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
             // Specialized wrapper: gh_group_selected
             yield return new AITool(
                 name: "gh_group_selected",
-                description: "Create a group around currently selected components. Quick way to organize selected items without needing to specify GUIDs manually.",
+                description: "Stage a group around currently selected components and show the user an in-canvas review before creation. Quick way to organize selected items without specifying GUIDs manually.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -137,6 +139,52 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     return output;
                 }
 
+                var reviewDocument = GhJsonGrasshopper.GetByGuids(validGuids);
+                var memberIds = reviewDocument.Components
+                    .Where(component =>
+                        component.Id.HasValue &&
+                        component.InstanceGuid.HasValue &&
+                        validGuids.Contains(component.InstanceGuid.Value))
+                    .Select(component => component.Id!.Value)
+                    .ToList();
+                var proposedGroup = new GhJsonGroup
+                {
+                    Id = 1,
+                    Name = groupName,
+                    Members = memberIds,
+                };
+                var proposedDocument = new GhJsonDocument(
+                    reviewDocument.Schema,
+                    reviewDocument.Metadata,
+                    reviewDocument.Components,
+                    reviewDocument.Connections,
+                    new[] { proposedGroup });
+                var reviewItem = new CanvasChangeReviewItem(
+                    "group:0",
+                    CanvasChangeKind.GroupAdded,
+                    groupName ?? "Group",
+                    $"{memberIds.Count} member(s)")
+                {
+                    GroupIndex = 0,
+                };
+                var reviewSession = new CanvasChangeReviewSession(
+                    "Review AI group",
+                    this.toolName,
+                    proposedDocument,
+                    new[] { reviewItem });
+                if (!await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false) ||
+                    !reviewSession.IsEffectivelyAccepted(reviewItem))
+                {
+                    var rejectedResult = new JObject
+                    {
+                        ["group"] = null,
+                        ["grouped"] = new JArray(),
+                        ["rejected"] = true,
+                    };
+                    output.CreateSuccess(AIBodyBuilder.Create().AddToolResult(rejectedResult).Build(), toolCall);
+                    return output;
+                }
+
                 GH_Group group = null;
 
                 // Combine UI operations and result resolution in a single UI thread callback.
@@ -183,6 +231,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         if (canvas?.Document != null)
                         {
                             canvas.Document.AddObject(group, false);
+                            canvas.Document.UndoUtil.RecordAddObjectEvent("[SH] Add reviewed group", group);
                         }
 
                         // Update UI

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
@@ -49,7 +49,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Reposition components on the canvas by specifying target coordinates. Use absolute coordinates (canvas position) or relative offsets (move by delta). Useful for organizing layouts or separating component groups. Requires component GUIDs from gh_get.",
+                description: "Stage component moves at absolute coordinates or relative offsets, show target positions on the live canvas, and move only components accepted by the user. Useful for organizing layouts. Requires component GUIDs from gh_get.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -123,7 +123,16 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }
 
-                var movedList = CanvasAccess.MoveInstance(dict, relative);
+                var reviewSession = CanvasChangeReviewService.CreateMoveSession(this.toolName, dict, relative);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                var acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(reviewSession)
+                    : new HashSet<Guid>();
+                var acceptedTargets = dict
+                    .Where(entry => acceptedGuids.Contains(entry.Key))
+                    .ToDictionary(entry => entry.Key, entry => entry.Value);
+                var movedList = CanvasAccess.MoveInstance(acceptedTargets, relative);
 
                 var toolResult = new JObject
                 {

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_move.cs
@@ -47,7 +47,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns></returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage component moves at absolute coordinates or relative offsets, show target positions on the live canvas, and move only components accepted by the user. Useful for organizing layouts. Requires component GUIDs from gh_get.",
                 category: "Components",
@@ -77,7 +77,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [ ""targets"" ]
                 }",
                 execute: this.GhMoveObjAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "layout" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""affectedGuids"": { ""type"": ""array"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -125,7 +124,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 var reviewSession = CanvasChangeReviewService.CreateMoveSession(this.toolName, dict, relative);
                 var applyReview = reviewSession.Items.Count > 0 &&
-                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false);
                 var acceptedGuids = applyReview
                     ? CanvasChangeReviewService.GetAcceptedComponentGuids(reviewSession)
                     : new HashSet<Guid>();

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
@@ -56,7 +56,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns></returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage components from GhJSON, show the user an in-canvas visual diff, and place only accepted changes. Use this to create component networks, add missing components, or build parametric definitions. The GhJSON must include component types, positions, and connections. Component-specific state (e.g. Number Slider values under componentState.extensions['gh.numberslider'].value using the format 'current<min~max>', Panel text under componentState.extensions['gh.panel'].text) is preserved. Example: gh_put({ ghjson: '...' }) or gh_put({ ghjson: 'C:/path/to/file.ghjson' }). See also: gh_get, script_generate_and_place_on_canvas.",
                 category: "Components",
@@ -70,7 +70,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""ghjson""]
                 }",
                 execute: this.GhPutToolAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "ghjson" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Names of the placed or replaced components."" }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the placed or replaced components."" }, ""acceptedChanges"": { ""type"": ""integer"" }, ""rejectedChanges"": { ""type"": ""integer"" }, ""analysis"": { ""type"": [""string"", ""null""], ""description"": ""Validation, review, error, or warning summary. Null when nothing notable happened."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -172,7 +171,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 var changePlan = GhPutChangePlan.Create(document, existingDocument);
                 if (changePlan.Session.Items.Count > 0)
                 {
-                    if (!await CanvasChangeReviewService.ReviewAsync(changePlan.Session).ConfigureAwait(false))
+                    if (!await CanvasChangeReviewService.ReviewAsync(changePlan.Session, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false))
                     {
                         return CreateNoPlacementResult(output, toolCall, "The user cancelled the staged canvas changes.", changePlan.Session.Items.Count);
                     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_put.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,7 +34,6 @@ using Newtonsoft.Json.Linq;
 using SmartHopper.Core.Grasshopper.Utils.Canvas;
 using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.Infrastructure.AITools;
-using SmartHopper.Infrastructure.Dialogs;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
 using SmartHopper.ProviderSdk.AICall.Core.Returns;
 using SmartHopper.ProviderSdk.Diagnostics;
@@ -60,13 +58,13 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Add new components to the canvas from GhJSON format. Use this to create component networks, add missing components, or build parametric definitions. The GhJSON must include component types, positions, and connections. Component-specific state (e.g. Number Slider values under componentState.extensions['gh.numberslider'].value using the format 'current<min~max>', Panel text under componentState.extensions['gh.panel'].text) is preserved. Example: gh_put({ ghjson: '...' }) or gh_put({ ghjson: 'C:/path/to/file.ghjson' }). See also: gh_get, script_generate_and_place_on_canvas.",
+                description: "Stage components from GhJSON, show the user an in-canvas visual diff, and place only accepted changes. Use this to create component networks, add missing components, or build parametric definitions. The GhJSON must include component types, positions, and connections. Component-specific state (e.g. Number Slider values under componentState.extensions['gh.numberslider'].value using the format 'current<min~max>', Panel text under componentState.extensions['gh.panel'].text) is preserved. Example: gh_put({ ghjson: '...' }) or gh_put({ ghjson: 'C:/path/to/file.ghjson' }). See also: gh_get, script_generate_and_place_on_canvas.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
                     ""properties"": {
                         ""ghjson"": { ""type"": ""string"", ""description"": ""GhJSON document string, or an absolute file path to a .ghjson file containing the document."" },
-                        ""editMode"": { ""type"": ""boolean"", ""description"": ""When true, existing components on canvas will be replaced. User will be prompted for confirmation."" },
+                        ""editMode"": { ""type"": ""boolean"", ""description"": ""When true, proposed components with matching instance GUIDs are reviewed as modifications instead of additions."" },
                         ""autoOffset"": { ""type"": ""boolean"", ""default"": true, ""description"": ""When true, newly placed components are offset on the canvas so they do not overlap existing objects. In edit mode this defaults to false."" }
                     },
                     ""required"": [""ghjson""]
@@ -74,7 +72,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.GhPutToolAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "ghjson" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Names of the placed or replaced components."" }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the placed or replaced components."" }, ""analysis"": { ""type"": [""string"", ""null""], ""description"": ""Validation, error, or warning summary. Null when nothing notable happened."" } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""components"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Names of the placed or replaced components."" }, ""instanceGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of the placed or replaced components."" }, ""acceptedChanges"": { ""type"": ""integer"" }, ""rejectedChanges"": { ""type"": ""integer"" }, ""analysis"": { ""type"": [""string"", ""null""], ""description"": ""Validation, review, error, or warning summary. Null when nothing notable happened."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
         }
 
@@ -147,188 +145,74 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }
 
-                // In edit mode, check for existing components that match instanceGuids
                 var existingComponents = new Dictionary<Guid, IGH_DocumentObject>();
-                var existingPositions = new Dictionary<Guid, PointF>();
                 var componentsToReplace = new List<Guid>();
-                HashSet<Guid> unchangedGuids = null;
-
-                // Captured external connections: source/target component + parameter names
                 var capturedConnections = new List<ConnectionInfo>();
+                var existingDocument = new GhJsonDocument();
 
-                if (editMode && document?.Components != null)
+                if (editMode)
                 {
-                    // Step 1: Pre-compare components with canvas.
-                    // Collect all incoming components with an instanceGuid that exists on canvas,
-                    // then batch-serialize via GhJsonGrasshopper.GetByGuids for efficiency.
-                    var incomingWithGuid = document.Components
-                        .Where(c => c.InstanceGuid.HasValue && c.InstanceGuid.Value != Guid.Empty)
-                        .ToList();
-
-                    foreach (var compProps in incomingWithGuid)
+                    foreach (var component in document.Components.Where(component =>
+                                 component.InstanceGuid.HasValue && component.InstanceGuid.Value != Guid.Empty))
                     {
-                        var guid = compProps.InstanceGuid.Value;
+                        var guid = component.InstanceGuid!.Value;
                         var existing = CanvasAccess.FindInstance(guid);
                         if (existing != null)
                         {
                             existingComponents[guid] = existing;
-                            existingPositions[guid] = existing.Attributes.Pivot;
                         }
                     }
 
                     if (existingComponents.Count > 0)
                     {
-                        var guidsToCompare = existingComponents.Keys.ToList();
-                        var existingDoc = GhJsonGrasshopper.GetByGuids(guidsToCompare);
-
-                        foreach (var compProps in incomingWithGuid)
-                        {
-                            var guid = compProps.InstanceGuid.Value;
-                            if (!existingComponents.ContainsKey(guid))
-                            {
-                                continue;
-                            }
-
-                            var existingComp = existingDoc.Components
-                                .FirstOrDefault(c => c.InstanceGuid == guid);
-
-                            if (existingComp != null && ComponentsAreEqual(compProps, existingComp))
-                            {
-                                Debug.WriteLine($"[gh_put] Component '{existingComponents[guid].Name}' ({guid}) is unchanged, skipping replacement");
-                            }
-                            else
-                            {
-                                componentsToReplace.Add(guid);
-                                Debug.WriteLine($"[gh_put] Component '{existingComponents[guid].Name}' ({guid}) has changes, will prompt for replacement");
-                            }
-                        }
-                    }
-
-                    // Step 2: Prompt user for confirmation for each modified component
-                    if (componentsToReplace.Count > 0)
-                    {
-                        var confirmedReplacements = new List<Guid>();
-
-                        foreach (var guid in componentsToReplace)
-                        {
-                            var confirmTcs = new TaskCompletionSource<bool>();
-                            var componentName = existingComponents.TryGetValue(guid, out var comp) ? comp.Name : "Unknown";
-
-                            Rhino.RhinoApp.InvokeOnUiThread(() =>
-                            {
-                                try
-                                {
-                                    var message = $"Do you want to replace component '{componentName}' with the new definition'?\n\n" +
-                                                  "Click 'Yes' to replace this component.\n" +
-                                                  "Click 'No' to create a new component instead.";
-                                    var result = StyledMessageDialog.ShowConfirmation(message, "Replace", guid);
-                                    confirmTcs.SetResult(result);
-                                }
-                                catch (Exception ex)
-                                {
-                                    Debug.WriteLine($"[gh_put] Error showing confirmation dialog: {ex.Message}");
-                                    confirmTcs.SetResult(false);
-                                }
-                            });
-
-                            var shouldReplace = await confirmTcs.Task.ConfigureAwait(false);
-
-                            if (shouldReplace)
-                            {
-                                confirmedReplacements.Add(guid);
-                                Debug.WriteLine($"[gh_put] User confirmed replacement of component '{componentName}' ({guid})");
-                            }
-                            else
-                            {
-                                Debug.WriteLine($"[gh_put] User chose to create new component instead of replacing '{componentName}' ({guid})");
-                            }
-                        }
-
-                        // Update the lists to only include confirmed replacements
-                        componentsToReplace.Clear();
-                        componentsToReplace.AddRange(confirmedReplacements);
-
-                        // Capture unchanged GUIDs BEFORE mutating existingComponents so Step 3
-                        // can still filter out unchanged components correctly.
-                        unchangedGuids = existingComponents.Keys.Except(confirmedReplacements).ToHashSet();
-
-                        // Remove non-confirmed components from tracking dictionaries
-                        foreach (var guid in unchangedGuids)
-                        {
-                            existingComponents.Remove(guid);
-                            existingPositions.Remove(guid);
-                        }
-
-                        Debug.WriteLine($"[gh_put] Final replacement count: {componentsToReplace.Count}");
-
-                        // If no replacements were needed, all existing components are unchanged.
-                        // Ensure unchangedGuids is populated so Step 3 filters them out.
-                        if (unchangedGuids == null && existingComponents.Count > 0)
-                        {
-                            unchangedGuids = existingComponents.Keys.ToHashSet();
-                        }
-
-                        // Capture external connections for replaced components before removal
-                        if (componentsToReplace.Count > 0)
-                        {
-                            capturedConnections = GhJsonGrasshopper.CaptureExternalConnections(componentsToReplace).ToList();
-                            Debug.WriteLine($"[gh_put] Captured {capturedConnections.Count} external connections");
-                        }
-                    }
-
-                    // Step 3: Filter the document to only include components that need placement.
-                    // Unchanged existing components are stripped out so they are not duplicated.
-                    if (document.Components != null)
-                    {
-                        var filteredComponents = new List<GhJsonComponent>();
-                        var skippedGuids = new HashSet<Guid>();
-
-                        foreach (var comp in document.Components)
-                        {
-                            if (comp.InstanceGuid.HasValue && comp.InstanceGuid.Value != Guid.Empty)
-                            {
-                                var guid = comp.InstanceGuid.Value;
-                                if (unchangedGuids != null && unchangedGuids.Contains(guid))
-                                {
-                                    // This is an unchanged existing component — skip it
-                                    skippedGuids.Add(guid);
-                                    continue;
-                                }
-                            }
-
-                            filteredComponents.Add(comp);
-                        }
-
-                        if (skippedGuids.Count > 0)
-                        {
-                            Debug.WriteLine($"[gh_put] Filtered out {skippedGuids.Count} unchanged component(s) from document");
-
-                            // Build a set of remaining component IDs for connection filtering
-                            var remainingIds = new HashSet<int>(filteredComponents.Where(c => c.Id.HasValue).Select(c => c.Id.Value));
-
-                            // Filter connections to only those between remaining components
-                            var filteredConnections = document.Connections?.Where(conn =>
-                                remainingIds.Contains(conn.From.Id) && remainingIds.Contains(conn.To.Id)).ToList();
-
-                            // Filter groups to only those with at least one remaining member
-                            var filteredGroups = document.Groups?.Where(g =>
-                                g.Members?.Any(m => remainingIds.Contains(m)) == true).ToList();
-
-                            document = new GhJsonDocument(
-                                document.Schema,
-                                document.Metadata,
-                                filteredComponents,
-                                filteredConnections,
-                                filteredGroups);
-                        }
+                        existingDocument = GhJsonGrasshopper.GetByGuids(existingComponents.Keys);
                     }
                 }
 
-                if (document?.Components == null || !document.Components.Any())
+                var changePlan = GhPutChangePlan.Create(document, existingDocument);
+                if (changePlan.Session.Items.Count > 0)
                 {
-                    var msg = analysisMsg ?? "JSON must contain a non-empty components array";
-                    output.CreateError(msg);
-                    return output;
+                    if (!await CanvasChangeReviewService.ReviewAsync(changePlan.Session).ConfigureAwait(false))
+                    {
+                        return CreateNoPlacementResult(output, toolCall, "The user cancelled the staged canvas changes.", changePlan.Session.Items.Count);
+                    }
+                }
+
+                document = changePlan.BuildAcceptedDocument();
+                var acceptedExternalConnections = changePlan.GetAcceptedExternalConnections(document);
+                componentsToReplace.AddRange(document.Components
+                    .Where(component =>
+                        component.InstanceGuid.HasValue &&
+                        existingComponents.ContainsKey(component.InstanceGuid.Value))
+                    .Select(component => component.InstanceGuid!.Value));
+
+                foreach (var guid in existingComponents.Keys.Except(componentsToReplace).ToList())
+                {
+                    existingComponents.Remove(guid);
+                }
+
+                if (componentsToReplace.Count > 0)
+                {
+                    var invalidReplacements = document.Components
+                        .Where(component =>
+                            component.InstanceGuid.HasValue &&
+                            componentsToReplace.Contains(component.InstanceGuid.Value) &&
+                            !GhJsonGrasshopper.CanInstantiate(component))
+                        .Select(component => component.NickName ?? component.Name ?? component.InstanceGuid!.Value.ToString())
+                        .ToList();
+                    if (invalidReplacements.Count > 0)
+                    {
+                        output.CreateError($"Cannot apply staged replacement(s) because these components are unavailable: {string.Join(", ", invalidReplacements)}");
+                        return output;
+                    }
+
+                    capturedConnections = GhJsonGrasshopper.CaptureExternalConnections(componentsToReplace).ToList();
+                    Debug.WriteLine($"[gh_put] Captured {capturedConnections.Count} external connections");
+                }
+
+                if (document.Components.Count == 0)
+                {
+                    return CreateNoPlacementResult(output, toolCall, "No staged canvas changes were selected.", changePlan.Session.Items.Count);
                 }
 
                 // Put operation must run on UI thread.
@@ -379,6 +263,41 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             throw new InvalidOperationException($"Put failed: {putResult.ErrorMessage}");
                         }
 
+                        var externalConnectionsCreated = 0;
+                        if (acceptedExternalConnections.Count > 0)
+                        {
+                            var resolvedGuids = new Dictionary<int, Guid>(putResult.IdToGuidMapping);
+                            foreach (var connection in acceptedExternalConnections)
+                            {
+                                if (!resolvedGuids.ContainsKey(connection.From.Id) &&
+                                    changePlan.GetExistingInstanceGuid(connection.From.Id) is Guid sourceGuid)
+                                {
+                                    resolvedGuids[connection.From.Id] = sourceGuid;
+                                }
+
+                                if (!resolvedGuids.ContainsKey(connection.To.Id) &&
+                                    changePlan.GetExistingInstanceGuid(connection.To.Id) is Guid targetGuid)
+                                {
+                                    resolvedGuids[connection.To.Id] = targetGuid;
+                                }
+
+                                if (resolvedGuids.TryGetValue(connection.From.Id, out var resolvedSource) &&
+                                    resolvedGuids.TryGetValue(connection.To.Id, out var resolvedTarget) &&
+                                    !protectedGuids.Contains(resolvedSource) &&
+                                    !protectedGuids.Contains(resolvedTarget))
+                                {
+                                    if (GhJsonGrasshopper.Connect(
+                                        resolvedSource,
+                                        resolvedTarget,
+                                        connection.From.ParamName,
+                                        connection.To.ParamName))
+                                    {
+                                        externalConnectionsCreated++;
+                                    }
+                                }
+                            }
+                        }
+
                         // Restore captured external connections
                         if (capturedConnections.Count > 0)
                         {
@@ -420,6 +339,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             }
                         }
 
+                        if (externalConnectionsCreated > 0)
+                        {
+                            ghDoc?.NewSolution(false);
+                            Instances.RedrawCanvas();
+                        }
+
                         placeTcs.SetResult(true);
                     }
                     catch (Exception ex)
@@ -455,6 +380,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     analysisSections.Add(CanvasProtection.FormatProtectionMessage(protectedPutGuids));
                 }
 
+                var rejectedChanges = changePlan.Session.Items.Count - changePlan.Session.AcceptedCount;
+                if (rejectedChanges > 0)
+                {
+                    analysisSections.Add($"The user rejected {rejectedChanges} of {changePlan.Session.Items.Count} staged change(s).");
+                }
+
                 if (putResult.FailedComponents != null && putResult.FailedComponents.Count > 0)
                 {
                     var lines = new List<string> { "Errors:" };
@@ -485,6 +416,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 {
                     ["components"] = JArray.FromObject(placedNames),
                     ["instanceGuids"] = JArray.FromObject(placedGuids),
+                    ["acceptedChanges"] = changePlan.Session.AcceptedCount,
+                    ["rejectedChanges"] = rejectedChanges,
                     ["analysis"] = combinedAnalysis,
                 };
 
@@ -565,57 +498,23 @@ namespace SmartHopper.Core.Grasshopper.AITools
         }
 
         /// <summary>
-        /// Compares two GhJSON component representations for structural equality,
-        /// ignoring volatile fields such as runtime messages, IDs, and selection state.
+        /// Creates a successful tool result when a staged proposal is cancelled or contains no selected changes.
         /// </summary>
-        private static bool ComponentsAreEqual(GhJsonComponent incoming, GhJsonComponent existing)
+        private static AIReturn CreateNoPlacementResult(AIReturn output, AIToolCall toolCall, string message, int rejectedChanges)
         {
-            var incomingJObj = JObject.FromObject(incoming);
-            var existingJObj = JObject.FromObject(existing);
-
-            // Remove volatile fields that should not affect equality
-            incomingJObj.Remove("id");
-            incomingJObj.Remove("errors");
-            incomingJObj.Remove("warnings");
-            incomingJObj.Remove("remarks");
-
-            existingJObj.Remove("id");
-            existingJObj.Remove("errors");
-            existingJObj.Remove("warnings");
-            existingJObj.Remove("remarks");
-
-            // Remove selection state from componentState if present
-            if (incomingJObj["componentState"] is JObject incomingState)
+            var toolResult = new JObject
             {
-                incomingState.Remove("selected");
-            }
-
-            if (existingJObj["componentState"] is JObject existingState)
-            {
-                existingState.Remove("selected");
-            }
-
-            // Remove runtime data from parameter settings. Runtime data is computed by the
-            // canvas and is not part of the component's structural definition, so including
-            // it makes every existing component look different from an incoming definition.
-            static void RemoveRuntimeData(JObject jObj)
-            {
-                foreach (var settingsKey in new[] { "inputSettings", "outputSettings" })
-                {
-                    if (jObj[settingsKey] is JArray settingsArray)
-                    {
-                        foreach (var itemObj in settingsArray.OfType<JObject>())
-                        {
-                            itemObj.Remove("runtimeData");
-                        }
-                    }
-                }
-            }
-
-            RemoveRuntimeData(incomingJObj);
-            RemoveRuntimeData(existingJObj);
-
-            return JToken.DeepEquals(incomingJObj, existingJObj);
+                ["components"] = new JArray(),
+                ["instanceGuids"] = new JArray(),
+                ["acceptedChanges"] = 0,
+                ["rejectedChanges"] = rejectedChanges,
+                ["analysis"] = message,
+            };
+            var body = AIBodyBuilder.Create()
+                .AddToolResult(toolResult)
+                .Build();
+            output.CreateSuccess(body, toolCall);
+            return output;
         }
 
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
@@ -48,7 +48,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         {
             yield return new AITool(
                 name: this.toolName,
-                description: "Remove components from the Grasshopper canvas by their instance GUIDs. The operation records an undo event so the user can reverse it with Ctrl+Z. Use GUIDs from gh_get or similar tools.",
+                description: "Stage component removals by instance GUID, show the user an in-canvas visual review, and remove only accepted objects. The operation records an undo event so the user can reverse it with Ctrl+Z. Use GUIDs from gh_get or similar tools.",
                 category: "Components",
                 parametersSchema: @"{
                     ""type"": ""object"",
@@ -64,11 +64,11 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 execute: this.GhRemoveToolAsync,
                 mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete" },
-                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""removedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""removedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
         }
 
-        private Task<AIReturn> GhRemoveToolAsync(AIToolCall toolCall)
+        private async Task<AIReturn> GhRemoveToolAsync(AIToolCall toolCall)
         {
             var output = new AIReturn { Request = toolCall };
 
@@ -83,7 +83,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (guidArray == null || guidArray.Count == 0)
                 {
                     output.CreateError("Missing or empty 'instanceGuids' parameter.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var requestedGuids = guidArray
@@ -95,7 +95,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (requestedGuids.Count == 0)
                 {
                     output.CreateError("No valid GUIDs provided in 'instanceGuids'.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var (allowedGuids, protectedGuids) = CanvasProtection.FilterProtectedGuids(requestedGuids);
@@ -108,13 +108,24 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         CanvasProtection.FormatProtectionMessage(protectedGuids));
                 }
 
-                var removedGuids = CanvasAccess.RemoveInstances(allowedGuids);
+                var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
+                var applyReview = reviewSession.Items.Count > 0 &&
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                IReadOnlyList<Guid> acceptedGuids = applyReview
+                    ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
+                    : Array.Empty<Guid>();
+                var rejectedGuids = reviewSession.Items
+                    .Where(item => item.ExistingInstanceGuid.HasValue &&
+                        (!applyReview || !reviewSession.IsEffectivelyAccepted(item)))
+                    .Select(item => item.ExistingInstanceGuid!.Value)
+                    .ToList();
+                var removedGuids = CanvasAccess.RemoveInstances(acceptedGuids);
                 var notFoundGuids = allowedGuids
-                    .Except(removedGuids)
+                    .Except(reviewSession.Items.Where(item => item.ExistingInstanceGuid.HasValue).Select(item => item.ExistingInstanceGuid!.Value))
                     .Select(g => g.ToString())
                     .ToList();
 
-                if (removedGuids.Count == 0 && protectedGuids.Count == 0)
+                if (removedGuids.Count == 0 && protectedGuids.Count == 0 && rejectedGuids.Count == 0)
                 {
                     output.AddRuntimeMessage(
                         SHRuntimeMessageSeverity.Warning,
@@ -125,6 +136,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 var toolResult = new JObject
                 {
                     ["removedGuids"] = JArray.FromObject(removedGuids.Select(g => g.ToString())),
+                    ["rejectedGuids"] = JArray.FromObject(rejectedGuids.Select(g => g.ToString())),
                     ["notFoundGuids"] = JArray.FromObject(notFoundGuids),
                     ["protectedGuids"] = JArray.FromObject(protectedGuids.Select(g => g.ToString())),
                 };
@@ -134,12 +146,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     .Build();
 
                 output.CreateSuccess(body, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_remove.cs
@@ -46,7 +46,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns>Collection of AI tools.</returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Stage component removals by instance GUID, show the user an in-canvas visual review, and remove only accepted objects. The operation records an undo event so the user can reverse it with Ctrl+Z. Use GUIDs from gh_get or similar tools.",
                 category: "Components",
@@ -62,7 +62,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [""instanceGuids""]
                 }",
                 execute: this.GhRemoveToolAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "delete" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""removedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""rejectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }, ""notFoundGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } } } }",
                 annotations: new AIToolAnnotations(destructiveHint: true));
@@ -110,7 +109,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 var reviewSession = CanvasChangeReviewService.CreateRemovalSession(this.toolName, allowedGuids);
                 var applyReview = reviewSession.Items.Count > 0 &&
-                    await CanvasChangeReviewService.ReviewAsync(reviewSession).ConfigureAwait(false);
+                    await CanvasChangeReviewService.ReviewAsync(reviewSession, toolCall.InvocationContext, toolCall.CancellationToken).ConfigureAwait(false);
                 IReadOnlyList<Guid> acceptedGuids = applyReview
                     ? CanvasChangeReviewService.GetAcceptedRemovalGuids(reviewSession)
                     : Array.Empty<Guid>();

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_smart_connect.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_smart_connect.cs
@@ -25,10 +25,7 @@ using System.Threading.Tasks;
 using GhJSON.Core;
 using GhJSON.Core.Serialization;
 using GhJSON.Grasshopper;
-using Grasshopper;
 using Newtonsoft.Json.Linq;
-using Rhino;
-using SmartHopper.Core.Grasshopper.Utils.Canvas;
 using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.Infrastructure.AITools;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
@@ -113,7 +110,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 tags: new[] { "canvas", "components", "mutating", "connect", "ai-generation" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""reasoning"": { ""type"": ""string"" }, ""suggestedConnections"": { ""type"": ""array"" }, ""connectionResult"": { ""type"": ""object"" } } }",
                 requiredCapabilities: AICapability.TextInput | AICapability.TextOutput,
-                annotations: new AIToolAnnotations(destructiveHint: false));
+                annotations: new AIToolAnnotations(destructiveHint: false),
+                surfaces: SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp);
         }
 
         /// <summary>
@@ -171,8 +169,28 @@ namespace SmartHopper.Core.Grasshopper.AITools
 
                 Debug.WriteLine($"[gh_smart_connect] AI suggested {connectionsJson.Count} connection(s)");
 
-                // Step 3: Execute connections directly via ghjson-dotnet facade
-                var connectResult = await ExecuteConnectionsAsync(connectionsJson).ConfigureAwait(false);
+                var connectInteraction = new AIInteractionToolCall
+                {
+                    Id = Guid.NewGuid().ToString("N"),
+                    Name = "gh_connect",
+                    Arguments = new JObject { ["connections"] = connectionsJson },
+                    Agent = AIAgent.Assistant,
+                };
+                var connectCall = new AIToolCall
+                {
+                    Provider = toolCall.Provider,
+                    Model = toolCall.Model,
+                    Endpoint = "gh_connect",
+                    SkipMetricsValidation = true,
+                    ToolSurface = toolCall.ToolSurface,
+                    CancellationToken = toolCall.CancellationToken,
+                    InvocationContext = toolCall.InvocationContext.ForTool(connectInteraction.Id, "gh_connect"),
+                };
+                connectCall.FromToolCallInteraction(connectInteraction, toolCall.Provider, toolCall.Model);
+                var connectReturn = await AIToolManager.ExecuteTool(connectCall).ConfigureAwait(false);
+                var connectResult = connectReturn.Body?.Interactions
+                    .OfType<AIInteractionToolResult>()
+                    .LastOrDefault()?.Result;
 
                 // Build combined result
                 var toolResult = new JObject
@@ -326,134 +344,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 Debug.WriteLine($"[gh_smart_connect] Error parsing AI response: {ex.Message}");
                 return (null, null);
-            }
-        }
-
-        /// <summary>
-        /// Executes the suggested connections directly via the ghjson-dotnet facade.
-        /// Replicates the same logic as the gh_connect tool (CanvasProtection check,
-        /// GhJsonGrasshopper.Connect, solution recompute) without the tool-call indirection.
-        /// </summary>
-        /// <param name="connections">JArray of connection objects with sourceGuid, sourceParam, targetGuid, targetParam.</param>
-        /// <returns>A JObject with successful/failed arrays and counts, or null if no connections.</returns>
-        private static async Task<JObject> ExecuteConnectionsAsync(JArray connections)
-        {
-            if (connections == null || connections.Count == 0)
-            {
-                return null;
-            }
-
-            try
-            {
-                var connectTcs = new TaskCompletionSource<JObject>();
-                Rhino.RhinoApp.InvokeOnUiThread(() =>
-                {
-                    try
-                    {
-                        var doc = GhJsonGrasshopper.GetActiveDocument();
-                        if (doc == null)
-                        {
-                            Debug.WriteLine("[gh_smart_connect] No active Grasshopper document found");
-                            connectTcs.SetResult(null);
-                            return;
-                        }
-
-                        var successfulConnections = new List<JObject>();
-                        var failedConnections = new List<JObject>();
-                        var protectedGuids = CanvasProtection.GetProtectedInstanceGuids();
-
-                        foreach (var connSpec in connections)
-                        {
-                            var sourceGuidStr = connSpec["sourceGuid"]?.ToString();
-                            var targetGuidStr = connSpec["targetGuid"]?.ToString();
-                            var sourceParamName = connSpec["sourceParam"]?.ToString();
-                            var targetParamName = connSpec["targetParam"]?.ToString();
-
-                            if (string.IsNullOrEmpty(sourceGuidStr) || string.IsNullOrEmpty(targetGuidStr))
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Missing sourceGuid or targetGuid",
-                                    ["spec"] = connSpec,
-                                });
-                                continue;
-                            }
-
-                            if (!Guid.TryParse(sourceGuidStr, out var sourceGuid) ||
-                                !Guid.TryParse(targetGuidStr, out var targetGuid))
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Invalid GUID format",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                });
-                                continue;
-                            }
-
-                            if (protectedGuids.Contains(sourceGuid) || protectedGuids.Contains(targetGuid))
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection rejected because it involves a protected component.",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                });
-                                continue;
-                            }
-
-                            bool success = GhJsonGrasshopper.Connect(sourceGuid, targetGuid, sourceParamName, targetParamName);
-
-                            if (success)
-                            {
-                                successfulConnections.Add(new JObject
-                                {
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                    ["sourceParam"] = sourceParamName ?? "(first output)",
-                                    ["targetParam"] = targetParamName ?? "(first input)",
-                                    ["status"] = "connected",
-                                });
-                            }
-                            else
-                            {
-                                failedConnections.Add(new JObject
-                                {
-                                    ["error"] = "Connection failed - check component GUIDs and parameter names",
-                                    ["sourceGuid"] = sourceGuidStr,
-                                    ["targetGuid"] = targetGuidStr,
-                                });
-                            }
-                        }
-
-                        if (successfulConnections.Count > 0)
-                        {
-                            doc.NewSolution(false);
-                            Instances.RedrawCanvas();
-                        }
-
-                        var result = new JObject
-                        {
-                            ["successful"] = JArray.FromObject(successfulConnections),
-                            ["failed"] = JArray.FromObject(failedConnections),
-                            ["successCount"] = successfulConnections.Count,
-                            ["failCount"] = failedConnections.Count,
-                        };
-
-                        connectTcs.SetResult(result);
-                    }
-                    catch (Exception ex)
-                    {
-                        connectTcs.SetException(ex);
-                    }
-                });
-
-                return await connectTcs.Task.ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[gh_smart_connect] Error executing connections: {ex.Message}");
-                return null;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/gh_tidy_up.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/gh_tidy_up.cs
@@ -52,7 +52,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <returns></returns>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Automatically arrange components into a clean grid layout respecting data flow direction. Organizes components left-to-right based on their connections. Use this to clean up messy definitions. Requires component GUIDs from gh_get.",
                 category: "Components",
@@ -81,13 +81,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     ""required"": [ ""guids"" ]
                 }",
                 execute: this.GhTidyUpAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "layout" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""moved"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of components that were moved."" }, ""affectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of components that were moved (alias for moved)."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
 
             // Specialized wrapper: gh_tidy_up_selected
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: "gh_tidy_up_selected",
                 description: "Organize currently selected components into a tidy grid layout. Quick way to clean up selected items without needing to specify GUIDs manually. Arranges components left-to-right based on connections.",
                 category: "Components",
@@ -110,7 +109,6 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     }
                 }",
                 execute: this.GhTidyUpSelectedAsync,
-                mutatesCanvas: true,
                 tags: new[] { "canvas", "components", "mutating", "layout" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""moved"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of components that were moved."" }, ""affectedGuids"": { ""type"": ""array"", ""items"": { ""type"": ""string"" }, ""description"": ""Instance GUIDs of components that were moved (alias for moved)."" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
@@ -119,7 +117,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <summary>
         /// Reorganize selected components into a tidy grid layout by GUID list.
         /// </summary>
-        private Task<AIReturn> GhTidyUpAsync(AIToolCall toolCall)
+        private async Task<AIReturn> GhTidyUpAsync(AIToolCall toolCall)
         {
             // Prepare the output
             var output = new AIReturn()
@@ -168,7 +166,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 {
                     Debug.WriteLine("[GhObjTools] GhTidyUpAsync: No matching components found after filtering.");
                     output.CreateError("No matching components found.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var doc = GhJsonGrasshopper.Serialize(selected, SerializationOptions.Default);
@@ -207,7 +205,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 {
                     Debug.WriteLine("[GhObjTools] GhTidyUpAsync: Layout produced no positions.");
                     output.CreateError("Layout produced no positions for the selected components.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 if (!hasStart)
@@ -220,11 +218,22 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     origin = new PointF(origPivot.X - firstKvp.Value.X, origPivot.Y - firstKvp.Value.Y);
                 }
 
+                var targets = positions.ToDictionary(
+                    pair => pair.Key,
+                    pair => new PointF(origin.X + pair.Value.X, origin.Y + pair.Value.Y));
+                var reviewSession = CanvasChangeReviewService.CreateMoveSession(this.toolName, targets, relative: false);
+                var reviewed = await CanvasChangeReviewService.ReviewAsync(
+                    reviewSession,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                var acceptedGuids = reviewed
+                    ? CanvasChangeReviewService.GetAcceptedComponentGuids(reviewSession)
+                    : new HashSet<Guid>();
                 var moved = new List<string>();
-                foreach (var kvp in positions)
+                foreach (var kvp in targets.Where(pair => acceptedGuids.Contains(pair.Key)))
                 {
                     var guid = kvp.Key;
-                    var target = new PointF(origin.X + kvp.Value.X, origin.Y + kvp.Value.Y);
+                    var target = kvp.Value;
                     var ok = CanvasAccess.MoveInstance(guid, target, relative: false);
                     Debug.WriteLine(ok
                         ? $"[GhObjTools] GhTidyUpAsync: Moved {guid} to ({target.X},{target.Y})"
@@ -241,12 +250,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     .Build();
 
                 output.CreateSuccess(immutableBody, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
 
@@ -311,6 +320,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
             {
                 Provider = toolCall.Provider,
                 Model = toolCall.Model,
+                ToolSurface = toolCall.ToolSurface,
+                CancellationToken = toolCall.CancellationToken,
+                InvocationContext = toolCall.InvocationContext.ForTool(toolInfo.Id, toolInfo.Name ?? this.toolName),
                 Body = AIBodyBuilder.Create()
                     .AddToolCall(
                         id: toolInfo.Id,

--- a/src/SmartHopper.Core.Grasshopper/AITools/plan_propose.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/plan_propose.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/AITools/plan_propose.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/plan_propose.cs
@@ -1,0 +1,173 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using SmartHopper.Infrastructure.AICall.Tools;
+using SmartHopper.Infrastructure.AITools;
+using SmartHopper.Infrastructure.Consent;
+using SmartHopper.ProviderSdk.AICall.Core.Interactions;
+using SmartHopper.ProviderSdk.AICall.Core.Returns;
+using SmartHopper.ProviderSdk.Hosting;
+
+namespace SmartHopper.Core.Grasshopper.AITools
+{
+    /// <summary>
+    /// Provides the Chat-only copilot plan proposal control tool.
+    /// </summary>
+    public sealed class plan_propose : IAIToolProvider
+    {
+        private const int MaxSteps = 20;
+        private const int MaxTextLength = 4000;
+
+        /// <inheritdoc/>
+        public IEnumerable<AITool> GetTools()
+        {
+            yield return new AITool(
+                "plan_propose",
+                "Propose a user-reviewable plan before a non-trivial multi-step task. Call only when planning materially improves clarity. Approval permits continuing with the approach but never pre-approves later canvas changes.",
+                "Control",
+                @"{
+                    ""type"": ""object"",
+                    ""properties"": {
+                        ""goal"": { ""type"": ""string"" },
+                        ""summary"": { ""type"": ""string"" },
+                        ""steps"": {
+                            ""type"": ""array"",
+                            ""minItems"": 1,
+                            ""maxItems"": 20,
+                            ""items"": {
+                                ""type"": ""object"",
+                                ""properties"": {
+                                    ""id"": { ""type"": ""string"" },
+                                    ""description"": { ""type"": ""string"" },
+                                    ""tool"": { ""type"": ""string"" }
+                                },
+                                ""required"": [""id"", ""description""]
+                            }
+                        },
+                        ""assumptions"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } },
+                        ""successCriteria"": { ""type"": ""array"", ""items"": { ""type"": ""string"" } }
+                    },
+                    ""required"": [""goal"", ""summary"", ""steps""]
+                }",
+                this.ExecuteAsync,
+                mutatesCanvas: false,
+                tags: new[] { "control", "planning", "read-only" },
+                outputSchema: @"{ ""type"": ""object"", ""properties"": { ""planId"": { ""type"": ""string"" }, ""status"": { ""type"": ""string"" }, ""steps"": { ""type"": ""array"" } } }",
+                surfaces: AIToolSurface.Chat);
+        }
+
+        private async Task<AIReturn> ExecuteAsync(AIToolCall toolCall)
+        {
+            var output = new AIReturn { Request = toolCall };
+            try
+            {
+                toolCall.SkipMetricsValidation = true;
+                var args = toolCall.GetToolCall().GetArgumentsOrEmpty();
+                var goal = ReadBounded(args, "goal", required: true);
+                var summary = ReadBounded(args, "summary", required: true);
+                var stepsToken = args["steps"] as JArray ?? throw new ArgumentException("A plan requires a steps array.");
+                if (stepsToken.Count == 0 || stepsToken.Count > MaxSteps)
+                {
+                    throw new ArgumentException($"A plan must contain between 1 and {MaxSteps} steps.");
+                }
+
+                var registeredTools = AIToolManager.GetTools();
+                var steps = new List<PlanConsentStep>();
+                var ids = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var token in stepsToken.OfType<JObject>())
+                {
+                    var id = ReadBounded(token, "id", required: true);
+                    if (!ids.Add(id))
+                    {
+                        throw new ArgumentException($"Duplicate plan step id '{id}'.");
+                    }
+
+                    var toolName = ReadBounded(token, "tool", required: false);
+                    AITool? registeredTool = null;
+                    if (!string.IsNullOrWhiteSpace(toolName))
+                    {
+                        if (!registeredTools.TryGetValue(toolName, out registeredTool) ||
+                            (registeredTool.Surfaces & AIToolSurface.Chat) == 0)
+                        {
+                            throw new ArgumentException($"Plan step '{id}' references unavailable Chat tool '{toolName}'.");
+                        }
+                    }
+
+                    steps.Add(new PlanConsentStep
+                    {
+                        Id = id,
+                        Description = ReadBounded(token, "description", required: true),
+                        Tool = string.IsNullOrWhiteSpace(toolName) ? null : toolName,
+                        MutatesCanvas = registeredTool?.MutatesCanvas == true,
+                    });
+                }
+
+                var proposal = new PlanConsentProposal(
+                    goal,
+                    summary,
+                    steps,
+                    ReadStringArray(args["assumptions"]),
+                    ReadStringArray(args["successCriteria"]));
+                var decision = await ConsentGate.RequestAsync(
+                    proposal,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                var result = new JObject
+                {
+                    ["planId"] = proposal.Id,
+                    ["status"] = decision.Status.ToString(),
+                    ["steps"] = JArray.FromObject(steps),
+                    ["reason"] = decision.Reason,
+                };
+                output.CreateSuccess(AIBodyBuilder.Create()
+                    .AddToolResult(result, id: toolCall.GetToolCall().Id, name: "plan_propose")
+                    .Build(), toolCall);
+                return output;
+            }
+            catch (Exception ex)
+            {
+                output.CreateToolError(ex.Message, toolCall);
+                return output;
+            }
+        }
+
+        private static string ReadBounded(JObject source, string name, bool required)
+        {
+            var value = source[name]?.ToString().Trim() ?? string.Empty;
+            if (required && string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"Plan field '{name}' is required.");
+            }
+
+            if (value.Length > MaxTextLength)
+            {
+                throw new ArgumentException($"Plan field '{name}' exceeds {MaxTextLength} characters.");
+            }
+
+            return value;
+        }
+
+        private static IReadOnlyList<string> ReadStringArray(JToken? token)
+        {
+            return token is JArray array
+                ? array.Values<string>()
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Select(value => value!.Length > MaxTextLength ? value.Substring(0, MaxTextLength) : value)
+                    .Take(MaxSteps)
+                    .ToList()
+                : Array.Empty<string>();
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/AITools/script_edit.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/script_edit.cs
@@ -168,7 +168,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 mutatesCanvas: true,
                 tags: new[] { "scripting", "script", "canvas", "mutating", "ghjson" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""ghjson"": { ""type"": ""string"", ""description"": ""GhJSON of the updated component."" }, ""instanceGuid"": { ""type"": ""string"" } } }",
-                annotations: new AIToolAnnotations(destructiveHint: false));
+                annotations: new AIToolAnnotations(destructiveHint: false),
+                surfaces: SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp);
         }
 
         private async Task<AIReturn> ExecuteAsync(AIToolCall toolCall)
@@ -626,6 +627,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     Model = toolCall.Model,
                     Endpoint = "gh_put",
                     SkipMetricsValidation = true,
+                    ToolSurface = toolCall.ToolSurface,
+                    CancellationToken = toolCall.CancellationToken,
+                    InvocationContext = toolCall.InvocationContext.ForTool(ghPutToolCallInteraction.Id, "gh_put"),
                 };
                 ghPutToolCall.Body = AIBodyBuilder.Create()
                     .Add(ghPutToolCallInteraction)

--- a/src/SmartHopper.Core.Grasshopper/AITools/script_generate.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/script_generate.cs
@@ -173,7 +173,8 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 mutatesCanvas: true,
                 tags: new[] { "scripting", "script", "canvas", "mutating", "ghjson" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""ghjson"": { ""type"": ""string"", ""description"": ""GhJSON of the placed component."" }, ""instanceGuid"": { ""type"": ""string"" } } }",
-                annotations: new AIToolAnnotations(destructiveHint: false));
+                annotations: new AIToolAnnotations(destructiveHint: false),
+                surfaces: SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct | SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp);
         }
 
         private async Task<AIReturn> ExecuteAsync(AIToolCall toolCall)
@@ -593,6 +594,9 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     Model = toolCall.Model,
                     Endpoint = "gh_put",
                     SkipMetricsValidation = true,
+                    ToolSurface = toolCall.ToolSurface,
+                    CancellationToken = toolCall.CancellationToken,
+                    InvocationContext = toolCall.InvocationContext.ForTool(ghPutToolCallInteraction.Id, "gh_put"),
                 };
                 ghPutToolCall.Body = AIBodyBuilder.Create()
                     .Add(ghPutToolCallInteraction)

--- a/src/SmartHopper.Core.Grasshopper/AITools/set_ai_provider_and_model.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/set_ai_provider_and_model.cs
@@ -51,7 +51,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
         /// <inheritdoc/>
         public IEnumerable<AITool> GetTools()
         {
-            yield return new AITool(
+            yield return new AIMutatingTool(
                 name: this.toolName,
                 description: "Set the AI provider and/or model for a component that implements IProviderComponent. If a provider is supplied, the component's AI provider selection is updated. If a model is supplied, a new Panel containing the model name is created and wired to the component's Settings input.",
                 category: "Components",
@@ -66,14 +66,13 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 }",
                 execute: this.SetAIProviderAndModelAsync,
                 requiredCapabilities: AICapability.None,
-                mutatesCanvas: true,
                 enabled: true,
                 tags: new[] { "canvas", "components", "mutating", "settings", "provider", "model" },
                 outputSchema: @"{ ""type"": ""object"", ""properties"": { ""success"": { ""type"": ""boolean"" }, ""componentGuid"": { ""type"": ""string"" }, ""providerSet"": { ""type"": ""boolean"" }, ""selectedProvider"": { ""type"": ""string"" }, ""provider"": { ""type"": ""string"" }, ""panelConnected"": { ""type"": ""boolean"" }, ""panelGuid"": { ""type"": ""string"" }, ""model"": { ""type"": ""string"" } } }",
                 annotations: new AIToolAnnotations(destructiveHint: false));
         }
 
-        private Task<AIReturn> SetAIProviderAndModelAsync(AIToolCall toolCall)
+        private async Task<AIReturn> SetAIProviderAndModelAsync(AIToolCall toolCall)
         {
             var output = new AIReturn()
             {
@@ -92,7 +91,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (!Guid.TryParse(componentGuidStr, out var componentGuid))
                 {
                     output.CreateError("componentGuid is required and must be a valid GUID.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var provider = args["provider"]?.ToString()?.Trim();
@@ -101,32 +100,32 @@ namespace SmartHopper.Core.Grasshopper.AITools
                 if (string.IsNullOrWhiteSpace(provider) && string.IsNullOrWhiteSpace(model))
                 {
                     output.CreateError("Either provider or model must be provided.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 var obj = CanvasAccess.FindInstance(componentGuid);
                 if (obj == null)
                 {
                     output.CreateError($"Component {componentGuid} not found on the canvas.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 if (CanvasProtection.IsProtected(componentGuid))
                 {
                     output.CreateError($"Component {componentGuid} is protected and cannot be modified.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 if (!(obj is IProviderComponent providerComp))
                 {
                     output.CreateError($"Component {componentGuid} does not support AI provider selection.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 if (!(obj is GH_Component ghComp))
                 {
                     output.CreateError($"Component {componentGuid} is not a Grasshopper component.");
-                    return Task.FromResult(output);
+                    return output;
                 }
 
                 // Normalize and validate the provider name against registered providers.
@@ -147,7 +146,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                             ", ",
                             registeredProviders.Select(p => p.Name).Append(ProviderSelectionCore.DEFAULT_PROVIDER));
                         output.CreateError($"Unknown provider '{provider}'. Available providers: {available}");
-                        return Task.FromResult(output);
+                        return output;
                     }
 
                     provider = matchingProvider?.Name ?? ProviderSelectionCore.DEFAULT_PROVIDER;
@@ -164,8 +163,29 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     if (settingsParam == null)
                     {
                         output.CreateError("Target component does not have a Settings input.");
-                        return Task.FromResult(output);
+                        return output;
                     }
+                }
+
+                var review = CanvasChangeReviewService.CreateComponentStateSession(
+                    toolInfo.Name ?? this.toolName,
+                    new[] { componentGuid },
+                    $"Set provider/model to {provider ?? "unchanged"} / {model ?? "unchanged"}");
+                var approved = await CanvasChangeReviewService.ReviewAsync(
+                    review,
+                    toolCall.InvocationContext,
+                    toolCall.CancellationToken).ConfigureAwait(false);
+                if (!approved || !CanvasChangeReviewService.GetAcceptedComponentGuids(review).Contains(componentGuid))
+                {
+                    output.CreateSuccess(AIBodyBuilder.Create()
+                        .AddToolResult(new JObject
+                        {
+                            ["componentGuid"] = componentGuidStr,
+                            ["success"] = false,
+                            ["rejected"] = true,
+                        }, toolInfo.Id, toolInfo.Name ?? this.toolName)
+                        .Build(), toolCall);
+                    return output;
                 }
 
                 var toolResult = new JObject()
@@ -257,12 +277,12 @@ namespace SmartHopper.Core.Grasshopper.AITools
                     .Build();
 
                 output.CreateSuccess(body, toolCall);
-                return Task.FromResult(output);
+                return output;
             }
             catch (Exception ex)
             {
                 output.CreateError($"Error executing {this.toolName}: {ex.Message}");
-                return Task.FromResult(output);
+                return output;
             }
         }
     }

--- a/src/SmartHopper.Core.Grasshopper/AITools/smarthopper_tool_help.cs
+++ b/src/SmartHopper.Core.Grasshopper/AITools/smarthopper_tool_help.cs
@@ -118,6 +118,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         ["name"] = t.Name,
                         ["description"] = t.RichDescription,
                         ["category"] = t.Category,
+                        ["surfaces"] = t.Surfaces.ToString(),
                         ["tags"] = new JArray(t.Tags),
                     })
                     .ToList();
@@ -137,6 +138,7 @@ namespace SmartHopper.Core.Grasshopper.AITools
                         ["category"] = targetTool.Category,
                         ["tags"] = new JArray(targetTool.Tags),
                         ["mutates_canvas"] = targetTool.MutatesCanvas,
+                        ["surfaces"] = targetTool.Surfaces.ToString(),
                         ["annotations"] = new JObject
                         {
                             ["readOnlyHint"] = targetTool.Annotations.ReadOnlyHint,

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeConsent.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeConsent.cs
@@ -1,0 +1,97 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SmartHopper.Infrastructure.Consent;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Adapts a graphical canvas change review session to the generic consent pipeline.
+    /// </summary>
+    public sealed class CanvasMutationConsentProposal : IConsentProposal
+    {
+        /// <summary>Initializes a new canvas mutation proposal.</summary>
+        public CanvasMutationConsentProposal(CanvasChangeReviewSession session)
+        {
+            this.Session = session ?? throw new ArgumentNullException(nameof(session));
+            this.Id = Guid.NewGuid().ToString("N");
+            this.ItemKeys = session.Items.Select(item => item.Key).ToList();
+        }
+
+        /// <inheritdoc/>
+        public string Id { get; }
+
+        /// <inheritdoc/>
+        public string Kind => "canvas-change";
+
+        /// <inheritdoc/>
+        public string Title => this.Session.Title;
+
+        /// <inheritdoc/>
+        public IReadOnlyList<string> ItemKeys { get; }
+
+        /// <summary>Gets the graphical review session.</summary>
+        public CanvasChangeReviewSession Session { get; }
+    }
+
+    /// <summary>
+    /// Presents canvas consent through the shared graphical diff dialog.
+    /// </summary>
+    public sealed class CanvasChangeConsentPresenter : IConsentPresenter
+    {
+        /// <summary>Gets the shared presenter instance.</summary>
+        public static CanvasChangeConsentPresenter Instance { get; } = new CanvasChangeConsentPresenter();
+
+        private CanvasChangeConsentPresenter()
+        {
+        }
+
+        /// <inheritdoc/>
+        public bool CanPresent(IConsentProposal proposal, MutationInvocationContext context)
+        {
+            return proposal is CanvasMutationConsentProposal;
+        }
+
+        /// <inheritdoc/>
+        public async Task<ConsentDecision> PresentAsync(
+            IConsentProposal proposal,
+            MutationInvocationContext context,
+            CancellationToken cancellationToken)
+        {
+            var canvasProposal = (CanvasMutationConsentProposal)proposal;
+            var applied = await CanvasChangeReviewService.ShowReviewDialogAsync(
+                canvasProposal.Session,
+                cancellationToken).ConfigureAwait(false);
+            if (!applied)
+            {
+                return ConsentDecision.Cancelled("The user cancelled the staged canvas changes.");
+            }
+
+            var accepted = canvasProposal.Session.Items
+                .Where(canvasProposal.Session.IsEffectivelyAccepted)
+                .Select(item => item.Key)
+                .ToList();
+            return new ConsentDecision
+            {
+                Status = accepted.Count == 0
+                    ? ConsentDecisionStatus.Rejected
+                    : accepted.Count == canvasProposal.Session.Items.Count
+                        ? ConsentDecisionStatus.Approved
+                        : ConsentDecisionStatus.PartiallyApproved,
+                AcceptedItemKeys = accepted,
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeConsent.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeConsent.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
@@ -1,0 +1,462 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+using Grasshopper;
+using Grasshopper.GUI.Canvas;
+using Grasshopper.Kernel;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Paints a non-mutating visual representation of staged changes over the actual Grasshopper canvas.
+    /// </summary>
+    public static class CanvasChangePreviewOverlay
+    {
+        private static readonly Color AddedColor = Color.FromArgb(230, 45, 164, 78);
+        private static readonly Color ModifiedColor = Color.FromArgb(230, 191, 135, 0);
+        private static readonly Color RemovedColor = Color.FromArgb(230, 207, 34, 46);
+        private static readonly Color GroupColor = Color.FromArgb(230, 130, 80, 223);
+        private static readonly Color WireColor = Color.FromArgb(230, 9, 105, 218);
+        private static bool initialized;
+        private static CanvasChangeReviewSession? activeSession;
+        private static string? highlightedKey;
+
+        /// <summary>
+        /// Hooks Grasshopper canvas paint events. Safe to call multiple times.
+        /// </summary>
+        public static void EnsureInitialized()
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            AttachToCanvas(Instances.ActiveCanvas);
+            Instances.CanvasCreated += AttachToCanvas;
+            initialized = true;
+        }
+
+        /// <summary>
+        /// Starts displaying a staged review session.
+        /// </summary>
+        /// <param name="session">Session to display.</param>
+        public static void Begin(CanvasChangeReviewSession session)
+        {
+            EnsureInitialized();
+            End();
+            activeSession = session ?? throw new ArgumentNullException(nameof(session));
+            activeSession.SelectionChanged += OnSelectionChanged;
+            RefreshCanvas();
+        }
+
+        /// <summary>
+        /// Stops displaying the current staged review session.
+        /// </summary>
+        public static void End()
+        {
+            if (activeSession != null)
+            {
+                activeSession.SelectionChanged -= OnSelectionChanged;
+            }
+
+            activeSession = null;
+            highlightedKey = null;
+            RefreshCanvas();
+        }
+
+        /// <summary>
+        /// Highlights one review item on the canvas.
+        /// </summary>
+        /// <param name="key">Item key, or <c>null</c> to clear the highlight.</param>
+        public static void Highlight(string? key)
+        {
+            highlightedKey = key;
+            RefreshCanvas();
+        }
+
+        private static void AttachToCanvas(GH_Canvas? canvas)
+        {
+            if (canvas == null)
+            {
+                return;
+            }
+
+            canvas.CanvasPostPaintOverlay -= OnCanvasPostPaintOverlay;
+            canvas.CanvasPostPaintOverlay += OnCanvasPostPaintOverlay;
+        }
+
+        private static void OnSelectionChanged(object? sender, EventArgs e)
+        {
+            RefreshCanvas();
+        }
+
+        private static void RefreshCanvas()
+        {
+            try
+            {
+                Instances.ActiveCanvas?.Refresh();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.WriteLine($"[CanvasChangePreviewOverlay] Canvas refresh skipped: {ex.Message}");
+            }
+        }
+
+        private static void OnCanvasPostPaintOverlay(GH_Canvas canvas)
+        {
+            var session = activeSession;
+            if (session == null || canvas?.Document == null || canvas.Graphics == null)
+            {
+                return;
+            }
+
+            var graphics = canvas.Graphics;
+            var oldTransform = graphics.Transform;
+            graphics.ResetTransform();
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+            try
+            {
+                foreach (var item in session.Items.OrderBy(GetPaintOrder))
+                {
+                    DrawItem(graphics, canvas, session, item);
+                }
+            }
+            finally
+            {
+                graphics.Transform = oldTransform;
+                oldTransform.Dispose();
+            }
+        }
+
+        private static int GetPaintOrder(CanvasChangeReviewItem item)
+        {
+            return item.Kind switch
+            {
+                CanvasChangeKind.GroupAdded or CanvasChangeKind.GroupModified or CanvasChangeKind.GroupRemoved => 0,
+                CanvasChangeKind.ConnectionAdded or CanvasChangeKind.ConnectionRemoved => 1,
+                _ => 2,
+            };
+        }
+
+        private static void DrawItem(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item)
+        {
+            var effective = session.IsEffectivelyAccepted(item);
+            var highlighted = string.Equals(highlightedKey, item.Key, StringComparison.Ordinal);
+            var alpha = effective ? 230 : 55;
+            var color = Color.FromArgb(alpha, GetColor(item.Kind));
+            var width = highlighted ? 4f : 2.2f;
+
+            switch (item.Kind)
+            {
+                case CanvasChangeKind.ComponentAdded:
+                    DrawAddedComponent(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.ComponentModified:
+                case CanvasChangeKind.ComponentRemoved:
+                    DrawExistingComponent(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.ConnectionAdded:
+                case CanvasChangeKind.ConnectionRemoved:
+                    DrawConnection(graphics, canvas, session, item, color, width);
+                    break;
+                case CanvasChangeKind.GroupAdded:
+                case CanvasChangeKind.GroupModified:
+                case CanvasChangeKind.GroupRemoved:
+                    DrawGroup(graphics, canvas, session, item, color, width);
+                    break;
+            }
+        }
+
+        private static void DrawAddedComponent(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            var component = FindComponent(session, item.ComponentId);
+            if (component?.Pivot == null)
+            {
+                return;
+            }
+
+            var bounds = ProjectProposedBounds(canvas.Viewport, component);
+            using var fill = new SolidBrush(Color.FromArgb(Math.Min((int)color.A, 45), color));
+            using var pen = CreatePen(color, width);
+            graphics.FillRoundedRectangle(fill, bounds, 6f);
+            graphics.DrawRoundedRectangle(pen, bounds, 6f);
+            DrawLabel(graphics, bounds, component.NickName ?? component.Name ?? "Component", color);
+        }
+
+        private static void DrawExistingComponent(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (!item.ExistingInstanceGuid.HasValue)
+            {
+                return;
+            }
+
+            var obj = canvas.Document.FindObject(item.ExistingInstanceGuid.Value, false);
+            if (obj?.Attributes == null)
+            {
+                return;
+            }
+
+            var bounds = ProjectBounds(canvas.Viewport, obj.Attributes.Bounds);
+            bounds.Inflate(4f, 4f);
+            using var fill = new SolidBrush(Color.FromArgb(Math.Min((int)color.A, 35), color));
+            using var pen = CreatePen(color, width);
+            graphics.FillRoundedRectangle(fill, bounds, 6f);
+            graphics.DrawRoundedRectangle(pen, bounds, 6f);
+
+            var proposed = FindComponent(session, item.ComponentId);
+            if (item.Kind == CanvasChangeKind.ComponentModified && proposed?.Pivot != null)
+            {
+                var targetBounds = ProjectProposedBounds(canvas.Viewport, proposed);
+                var currentCenter = new PointF(bounds.Left + (bounds.Width / 2f), bounds.Top + (bounds.Height / 2f));
+                var targetCenter = new PointF(targetBounds.Left + (targetBounds.Width / 2f), targetBounds.Top + (targetBounds.Height / 2f));
+                if (Math.Abs(currentCenter.X - targetCenter.X) > 4f || Math.Abs(currentCenter.Y - targetCenter.Y) > 4f)
+                {
+                    graphics.DrawRoundedRectangle(pen, targetBounds, 6f);
+                    graphics.DrawLine(pen, currentCenter, targetCenter);
+                    DrawLabel(graphics, targetBounds, "Proposed position", color);
+                }
+            }
+
+            if (item.Kind == CanvasChangeKind.ComponentRemoved)
+            {
+                graphics.DrawLine(pen, bounds.Left, bounds.Top, bounds.Right, bounds.Bottom);
+                graphics.DrawLine(pen, bounds.Right, bounds.Top, bounds.Left, bounds.Bottom);
+            }
+
+            DrawLabel(graphics, bounds, item.Kind == CanvasChangeKind.ComponentModified ? "Modified" : "Removed", color);
+        }
+
+        private static void DrawConnection(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (!item.ConnectionIndex.HasValue || session.ProposedDocument.Connections == null ||
+                item.ConnectionIndex.Value >= session.ProposedDocument.Connections.Count)
+            {
+                return;
+            }
+
+            var connection = session.ProposedDocument.Connections[item.ConnectionIndex.Value];
+            if (!TryGetAnchor(canvas, session, connection.From.Id, true, out var from) ||
+                !TryGetAnchor(canvas, session, connection.To.Id, false, out var to))
+            {
+                return;
+            }
+
+            var offset = Math.Max(30f, Math.Abs(to.X - from.X) * 0.45f);
+            using var path = new GraphicsPath();
+            path.AddBezier(from, new PointF(from.X + offset, from.Y), new PointF(to.X - offset, to.Y), to);
+            using var pen = CreatePen(color, width);
+            graphics.DrawPath(pen, path);
+        }
+
+        private static void DrawGroup(
+            Graphics graphics,
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            CanvasChangeReviewItem item,
+            Color color,
+            float width)
+        {
+            if (item.ExistingInstanceGuid.HasValue &&
+                canvas.Document.FindObject(item.ExistingInstanceGuid.Value, false)?.Attributes is IGH_Attributes existingAttributes)
+            {
+                var existingBounds = ProjectBounds(canvas.Viewport, existingAttributes.Bounds);
+                existingBounds.Inflate(4f, 4f);
+                using var existingPen = CreatePen(color, width);
+                graphics.DrawRoundedRectangle(existingPen, existingBounds, 8f);
+                DrawLabel(graphics, existingBounds, item.Title, color);
+                return;
+            }
+
+            if (!item.GroupIndex.HasValue || session.ProposedDocument.Groups == null ||
+                item.GroupIndex.Value >= session.ProposedDocument.Groups.Count)
+            {
+                return;
+            }
+
+            var group = session.ProposedDocument.Groups[item.GroupIndex.Value];
+            RectangleF? groupBounds = null;
+            foreach (var memberId in group.Members)
+            {
+                var component = session.ProposedDocument.Components.FirstOrDefault(candidate => candidate.Id == memberId);
+                if (component == null)
+                {
+                    continue;
+                }
+
+                RectangleF bounds;
+                if (component.InstanceGuid.HasValue &&
+                    canvas.Document.FindObject(component.InstanceGuid.Value, false)?.Attributes is IGH_Attributes attributes)
+                {
+                    bounds = ProjectBounds(canvas.Viewport, attributes.Bounds);
+                }
+                else if (component.Pivot != null)
+                {
+                    bounds = ProjectProposedBounds(canvas.Viewport, component);
+                }
+                else
+                {
+                    continue;
+                }
+
+                groupBounds = groupBounds.HasValue ? RectangleF.Union(groupBounds.Value, bounds) : bounds;
+            }
+
+            if (!groupBounds.HasValue)
+            {
+                return;
+            }
+
+            var result = groupBounds.Value;
+            result.Inflate(16f, 18f);
+            using var pen = CreatePen(color, width);
+            graphics.DrawRoundedRectangle(pen, result, 8f);
+            DrawLabel(graphics, result, group.Name ?? "Group", color);
+        }
+
+        private static bool TryGetAnchor(
+            GH_Canvas canvas,
+            CanvasChangeReviewSession session,
+            int componentId,
+            bool output,
+            out PointF anchor)
+        {
+            var component = session.ProposedDocument.Components.FirstOrDefault(candidate => candidate.Id == componentId);
+            if (component?.InstanceGuid.HasValue == true &&
+                canvas.Document.FindObject(component.InstanceGuid.Value, false)?.Attributes is IGH_Attributes attributes)
+            {
+                var bounds = ProjectBounds(canvas.Viewport, attributes.Bounds);
+                anchor = new PointF(output ? bounds.Right : bounds.Left, bounds.Top + (bounds.Height / 2f));
+                return true;
+            }
+
+            if (component?.Pivot != null)
+            {
+                var bounds = ProjectProposedBounds(canvas.Viewport, component);
+                anchor = new PointF(output ? bounds.Right : bounds.Left, bounds.Top + (bounds.Height / 2f));
+                return true;
+            }
+
+            anchor = PointF.Empty;
+            return false;
+        }
+
+        private static GhJsonComponent? FindComponent(CanvasChangeReviewSession session, int? componentId)
+        {
+            return componentId.HasValue
+                ? session.ProposedDocument.Components.FirstOrDefault(component => component.Id == componentId.Value)
+                : null;
+        }
+
+        private static RectangleF ProjectProposedBounds(GH_Viewport viewport, GhJsonComponent component)
+        {
+            var worldBounds = new RectangleF(
+                (float)component.Pivot!.X,
+                (float)component.Pivot.Y,
+                140f,
+                52f);
+            return ProjectBounds(viewport, worldBounds);
+        }
+
+        private static RectangleF ProjectBounds(GH_Viewport viewport, RectangleF bounds)
+        {
+            var topLeft = new PointF(bounds.Left, bounds.Top);
+            var bottomRight = new PointF(bounds.Right, bounds.Bottom);
+            viewport.Project(ref topLeft);
+            viewport.Project(ref bottomRight);
+            return RectangleF.FromLTRB(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
+        }
+
+        private static Pen CreatePen(Color color, float width)
+        {
+            return new Pen(color, width)
+            {
+                DashStyle = DashStyle.Dash,
+            };
+        }
+
+        private static Color GetColor(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => AddedColor,
+                CanvasChangeKind.ComponentModified => ModifiedColor,
+                CanvasChangeKind.ComponentRemoved => RemovedColor,
+                CanvasChangeKind.ConnectionAdded => WireColor,
+                CanvasChangeKind.ConnectionRemoved => RemovedColor,
+                _ => GroupColor,
+            };
+        }
+
+        private static void DrawLabel(Graphics graphics, RectangleF bounds, string text, Color color)
+        {
+            using var font = new Font("Segoe UI", 8.5f, FontStyle.Bold);
+            var size = graphics.MeasureString(text, font);
+            var labelBounds = new RectangleF(bounds.Left, bounds.Top - size.Height - 3f, size.Width + 10f, size.Height + 2f);
+            using var brush = new SolidBrush(color);
+            using var textBrush = new SolidBrush(Color.White);
+            graphics.FillRoundedRectangle(brush, labelBounds, 5f);
+            graphics.DrawString(text, font, textBrush, labelBounds.Left + 5f, labelBounds.Top + 1f);
+        }
+
+        private static void FillRoundedRectangle(this Graphics graphics, Brush brush, RectangleF bounds, float radius)
+        {
+            using var path = CreateRoundedRectangle(bounds, radius);
+            graphics.FillPath(brush, path);
+        }
+
+        private static void DrawRoundedRectangle(this Graphics graphics, Pen pen, RectangleF bounds, float radius)
+        {
+            using var path = CreateRoundedRectangle(bounds, radius);
+            graphics.DrawPath(pen, path);
+        }
+
+        private static GraphicsPath CreateRoundedRectangle(RectangleF bounds, float radius)
+        {
+            var diameter = radius * 2f;
+            var path = new GraphicsPath();
+            path.AddArc(bounds.Left, bounds.Top, diameter, diameter, 180f, 90f);
+            path.AddArc(bounds.Right - diameter, bounds.Top, diameter, diameter, 270f, 90f);
+            path.AddArc(bounds.Right - diameter, bounds.Bottom - diameter, diameter, diameter, 0f, 90f);
+            path.AddArc(bounds.Left, bounds.Bottom - diameter, diameter, diameter, 90f, 90f);
+            path.CloseFigure();
+            return path;
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangePreviewOverlay.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
@@ -1,0 +1,195 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GhJSON.Core.SchemaModels;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Identifies the visual category of a staged canvas change.
+    /// </summary>
+    public enum CanvasChangeKind
+    {
+        /// <summary>A component will be added.</summary>
+        ComponentAdded,
+
+        /// <summary>An existing component will be replaced with modified state.</summary>
+        ComponentModified,
+
+        /// <summary>A component will be removed.</summary>
+        ComponentRemoved,
+
+        /// <summary>A connection will be added.</summary>
+        ConnectionAdded,
+
+        /// <summary>A connection will be removed.</summary>
+        ConnectionRemoved,
+
+        /// <summary>A group will be added.</summary>
+        GroupAdded,
+
+        /// <summary>An existing group will be modified.</summary>
+        GroupModified,
+
+        /// <summary>A group will be removed.</summary>
+        GroupRemoved,
+    }
+
+    /// <summary>
+    /// Represents one independently selectable change in a staged canvas proposal.
+    /// </summary>
+    public sealed class CanvasChangeReviewItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasChangeReviewItem"/> class.
+        /// </summary>
+        /// <param name="key">Stable key within the proposal.</param>
+        /// <param name="kind">Change category.</param>
+        /// <param name="title">Short user-facing title.</param>
+        /// <param name="detail">Optional user-facing detail.</param>
+        public CanvasChangeReviewItem(string key, CanvasChangeKind kind, string title, string detail = "")
+        {
+            this.Key = key ?? throw new ArgumentNullException(nameof(key));
+            this.Kind = kind;
+            this.Title = title ?? throw new ArgumentNullException(nameof(title));
+            this.Detail = detail ?? string.Empty;
+        }
+
+        /// <summary>Gets the stable key within the proposal.</summary>
+        public string Key { get; }
+
+        /// <summary>Gets the visual change category.</summary>
+        public CanvasChangeKind Kind { get; }
+
+        /// <summary>Gets the short user-facing title.</summary>
+        public string Title { get; }
+
+        /// <summary>Gets the optional user-facing detail.</summary>
+        public string Detail { get; }
+
+        /// <summary>Gets or sets whether this change should be applied.</summary>
+        public bool IsAccepted { get; set; } = true;
+
+        /// <summary>Gets or sets the affected live component instance GUID.</summary>
+        public Guid? ExistingInstanceGuid { get; set; }
+
+        /// <summary>Gets or sets the proposed component ID.</summary>
+        public int? ComponentId { get; set; }
+
+        /// <summary>Gets or sets the index of the proposed connection.</summary>
+        public int? ConnectionIndex { get; set; }
+
+        /// <summary>Gets or sets the index of the proposed group.</summary>
+        public int? GroupIndex { get; set; }
+
+        /// <summary>Gets keys of component changes required by this change.</summary>
+        public IList<string> RequiredItemKeys { get; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Holds an immutable proposal document and mutable user selections for one review operation.
+    /// </summary>
+    public sealed class CanvasChangeReviewSession
+    {
+        private readonly IReadOnlyDictionary<string, CanvasChangeReviewItem> itemsByKey;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasChangeReviewSession"/> class.
+        /// </summary>
+        /// <param name="title">Review title.</param>
+        /// <param name="source">Name of the tool that produced the proposal.</param>
+        /// <param name="proposedDocument">Proposed GhJSON fragment.</param>
+        /// <param name="items">Selectable changes.</param>
+        public CanvasChangeReviewSession(
+            string title,
+            string source,
+            GhJsonDocument proposedDocument,
+            IEnumerable<CanvasChangeReviewItem> items)
+        {
+            this.Title = title ?? throw new ArgumentNullException(nameof(title));
+            this.Source = source ?? throw new ArgumentNullException(nameof(source));
+            this.ProposedDocument = proposedDocument ?? throw new ArgumentNullException(nameof(proposedDocument));
+            this.Items = (items ?? throw new ArgumentNullException(nameof(items))).ToList();
+            this.itemsByKey = this.Items.ToDictionary(item => item.Key, StringComparer.Ordinal);
+        }
+
+        /// <summary>Occurs when an acceptance selection changes.</summary>
+        public event EventHandler? SelectionChanged;
+
+        /// <summary>Gets the review title.</summary>
+        public string Title { get; }
+
+        /// <summary>Gets the proposal source.</summary>
+        public string Source { get; }
+
+        /// <summary>Gets the proposed GhJSON fragment.</summary>
+        public GhJsonDocument ProposedDocument { get; }
+
+        /// <summary>Gets the selectable changes.</summary>
+        public IReadOnlyList<CanvasChangeReviewItem> Items { get; }
+
+        /// <summary>Gets the number of accepted changes whose dependencies are also accepted.</summary>
+        public int AcceptedCount => this.Items.Count(this.IsEffectivelyAccepted);
+
+        /// <summary>
+        /// Determines whether a change and all of its dependencies are accepted.
+        /// </summary>
+        /// <param name="item">Change to inspect.</param>
+        /// <returns><c>true</c> when the change can be applied.</returns>
+        public bool IsEffectivelyAccepted(CanvasChangeReviewItem item)
+        {
+            return item.IsAccepted && item.RequiredItemKeys.All(key =>
+                !this.itemsByKey.TryGetValue(key, out var required) || required.IsAccepted);
+        }
+
+        /// <summary>
+        /// Updates one change selection.
+        /// </summary>
+        /// <param name="key">Change key.</param>
+        /// <param name="isAccepted">Whether the change is accepted.</param>
+        public void SetAccepted(string key, bool isAccepted)
+        {
+            if (!this.itemsByKey.TryGetValue(key, out var item) || item.IsAccepted == isAccepted)
+            {
+                return;
+            }
+
+            item.IsAccepted = isAccepted;
+            this.SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Updates all change selections.
+        /// </summary>
+        /// <param name="isAccepted">Whether all changes are accepted.</param>
+        public void SetAllAccepted(bool isAccepted)
+        {
+            var changed = false;
+            foreach (var item in this.Items)
+            {
+                if (item.IsAccepted == isAccepted)
+                {
+                    continue;
+                }
+
+                item.IsAccepted = isAccepted;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                this.SelectionChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReview.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Eto.Drawing;
 using Eto.Forms;
 using Rhino.UI;
@@ -131,12 +132,15 @@ namespace SmartHopper.Core.Grasshopper.Utils.Canvas
         /// </summary>
         /// <param name="session">Review session.</param>
         /// <returns><c>true</c> when the selected changes should be applied.</returns>
-        public static bool ShowReview(CanvasChangeReviewSession session)
+        public static bool ShowReview(CanvasChangeReviewSession session, CancellationToken cancellationToken = default)
         {
             using var dialog = new CanvasChangeReviewDialog(session);
+            using var registration = cancellationToken.Register(() =>
+                Application.Instance?.AsyncInvoke(() => dialog.Close(false)));
             CanvasChangePreviewOverlay.Begin(session);
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 return dialog.ShowModal(RhinoEtoApp.MainWindow) == true;
             }
             finally

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewDialog.cs
@@ -1,0 +1,275 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using Eto.Drawing;
+using Eto.Forms;
+using Rhino.UI;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Presents a modal checklist for a staged canvas proposal while the proposal is painted over the actual canvas.
+    /// </summary>
+    public sealed class CanvasChangeReviewDialog : Dialog<bool>
+    {
+        private readonly Dictionary<string, CheckBox> checkBoxes = new Dictionary<string, CheckBox>(StringComparer.Ordinal);
+        private readonly Label summaryLabel;
+        private readonly CanvasChangeReviewSession session;
+
+        private CanvasChangeReviewDialog(CanvasChangeReviewSession session)
+        {
+            this.session = session ?? throw new ArgumentNullException(nameof(session));
+            this.Title = session.Title;
+            this.Resizable = true;
+            this.ClientSize = new Size(440, 620);
+            this.MinimumSize = new Size(380, 420);
+            this.Padding = new Padding(16);
+
+            var title = new Label
+            {
+                Text = "Review AI canvas changes",
+                Font = new Font(SystemFont.Bold, 16),
+            };
+            var subtitle = new Label
+            {
+                Text = $"{session.Items.Count} staged change(s) from {session.Source}. The canvas is unchanged until you apply.",
+                Wrap = WrapMode.Word,
+                TextColor = Colors.Gray,
+            };
+
+            var changesLayout = new DynamicLayout
+            {
+                DefaultSpacing = new Size(8, 5),
+                Padding = new Padding(0, 8),
+            };
+            foreach (var item in session.Items)
+            {
+                changesLayout.Add(this.CreateChangeRow(item));
+            }
+
+            var scrollable = new Scrollable
+            {
+                Border = BorderType.None,
+                Content = changesLayout,
+                ExpandContentWidth = true,
+            };
+            this.summaryLabel = new Label
+            {
+                TextColor = Colors.Gray,
+            };
+
+            var acceptAllButton = new Button { Text = "Accept all" };
+            acceptAllButton.Click += (_, _) => this.SetAll(true);
+            var rejectAllButton = new Button { Text = "Reject all" };
+            rejectAllButton.Click += (_, _) => this.SetAll(false);
+            var cancelButton = new Button { Text = "Cancel" };
+            cancelButton.Click += (_, _) => this.Close(false);
+            var applyButton = new Button { Text = "Apply selected" };
+            applyButton.Click += (_, _) => this.Close(true);
+            this.DefaultButton = applyButton;
+            this.AbortButton = cancelButton;
+
+            var selectionButtons = new StackLayout
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                Items = { acceptAllButton, rejectAllButton },
+            };
+            var actionButtons = new StackLayout
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalContentAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Items = { cancelButton, applyButton },
+            };
+
+            this.Content = new TableLayout
+            {
+                Spacing = new Size(8, 10),
+                Rows =
+                {
+                    new TableRow(title),
+                    new TableRow(subtitle),
+                    new TableRow(scrollable) { ScaleHeight = true },
+                    new TableRow(this.summaryLabel),
+                    new TableRow(new TableLayout
+                    {
+                        Spacing = new Size(8, 0),
+                        Rows =
+                        {
+                            new TableRow(
+                                new TableCell(selectionButtons, true),
+                                new TableCell(actionButtons, false)),
+                        },
+                    }),
+                },
+            };
+
+            this.session.SelectionChanged += this.OnSelectionChanged;
+            this.UpdateSummary();
+        }
+
+        /// <summary>
+        /// Shows a staged review and returns whether the user chose to apply the selected changes.
+        /// </summary>
+        /// <param name="session">Review session.</param>
+        /// <returns><c>true</c> when the selected changes should be applied.</returns>
+        public static bool ShowReview(CanvasChangeReviewSession session)
+        {
+            using var dialog = new CanvasChangeReviewDialog(session);
+            CanvasChangePreviewOverlay.Begin(session);
+            try
+            {
+                return dialog.ShowModal(RhinoEtoApp.MainWindow) == true;
+            }
+            finally
+            {
+                CanvasChangePreviewOverlay.End();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+            var referenceWindow = RhinoEtoApp.MainWindow ?? this.Owner;
+            var screen = referenceWindow != null
+                ? Screen.FromRectangle(referenceWindow.Bounds)
+                : Screen.PrimaryScreen;
+            if (screen != null)
+            {
+                var workArea = screen.WorkingArea;
+                this.Location = new Point(
+                    (int)(workArea.Right - this.Width - 24),
+                    (int)(workArea.Top + Math.Max(24, (workArea.Height - this.Height) / 2)));
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.session.SelectionChanged -= this.OnSelectionChanged;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private Control CreateChangeRow(CanvasChangeReviewItem item)
+        {
+            var checkBox = new CheckBox
+            {
+                Checked = item.IsAccepted,
+            };
+            checkBox.CheckedChanged += (_, _) => this.session.SetAccepted(item.Key, checkBox.Checked == true);
+            this.checkBoxes[item.Key] = checkBox;
+
+            var kindLabel = new Label
+            {
+                Text = GetKindLabel(item.Kind),
+                TextColor = GetKindColor(item.Kind),
+                Font = new Font(SystemFont.Bold, 9),
+                VerticalAlignment = VerticalAlignment.Center,
+                Width = 62,
+            };
+            var titleLabel = new Label
+            {
+                Text = item.Title,
+                Font = new Font(SystemFont.Bold, 10),
+                Wrap = WrapMode.Word,
+            };
+            var detailLabel = new Label
+            {
+                Text = item.Detail,
+                TextColor = Colors.Gray,
+                Font = new Font(SystemFont.Default, 9),
+                Wrap = WrapMode.Word,
+            };
+            var textLayout = new DynamicLayout
+            {
+                DefaultSpacing = new Size(0, 2),
+            };
+            textLayout.Add(titleLabel);
+            if (!string.IsNullOrWhiteSpace(item.Detail))
+            {
+                textLayout.Add(detailLabel);
+            }
+
+            var row = new Panel
+            {
+                Padding = new Padding(7),
+                Content = new TableLayout
+                {
+                    Spacing = new Size(8, 0),
+                    Rows =
+                    {
+                        new TableRow(
+                            new TableCell(checkBox, false),
+                            new TableCell(kindLabel, false),
+                            new TableCell(textLayout, true)),
+                    },
+                },
+            };
+            row.MouseEnter += (_, _) => CanvasChangePreviewOverlay.Highlight(item.Key);
+            row.MouseLeave += (_, _) => CanvasChangePreviewOverlay.Highlight(null);
+            return row;
+        }
+
+        private void SetAll(bool isAccepted)
+        {
+            this.session.SetAllAccepted(isAccepted);
+            foreach (var checkBox in this.checkBoxes.Values)
+            {
+                checkBox.Checked = isAccepted;
+            }
+        }
+
+        private void OnSelectionChanged(object? sender, EventArgs e)
+        {
+            this.UpdateSummary();
+        }
+
+        private void UpdateSummary()
+        {
+            this.summaryLabel.Text = $"{this.session.AcceptedCount} of {this.session.Items.Count} changes selected. Applied changes are recorded in Grasshopper's undo history.";
+        }
+
+        private static string GetKindLabel(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => "ADD",
+                CanvasChangeKind.ComponentModified => "MODIFY",
+                CanvasChangeKind.ComponentRemoved => "REMOVE",
+                CanvasChangeKind.ConnectionAdded => "WIRE +",
+                CanvasChangeKind.ConnectionRemoved => "WIRE −",
+                CanvasChangeKind.GroupAdded => "GROUP +",
+                CanvasChangeKind.GroupModified => "GROUP",
+                CanvasChangeKind.GroupRemoved => "GROUP −",
+                _ => "CHANGE",
+            };
+        }
+
+        private static Color GetKindColor(CanvasChangeKind kind)
+        {
+            return kind switch
+            {
+                CanvasChangeKind.ComponentAdded => Color.FromArgb(45, 164, 78),
+                CanvasChangeKind.ComponentModified => Color.FromArgb(191, 135, 0),
+                CanvasChangeKind.ComponentRemoved => Color.FromArgb(207, 34, 46),
+                CanvasChangeKind.ConnectionAdded or CanvasChangeKind.ConnectionRemoved => Color.FromArgb(9, 105, 218),
+                _ => Color.FromArgb(130, 80, 223),
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
@@ -1,0 +1,293 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using GhJSON.Core.SchemaModels;
+using GhJSON.Grasshopper;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Describes a proposed connection or disconnection between two live canvas objects.
+    /// </summary>
+    public sealed class CanvasConnectionReviewProposal
+    {
+        /// <summary>Gets or sets the source object instance GUID.</summary>
+        public Guid SourceGuid { get; set; }
+
+        /// <summary>Gets or sets the target object instance GUID.</summary>
+        public Guid TargetGuid { get; set; }
+
+        /// <summary>Gets or sets the optional source parameter name.</summary>
+        public string? SourceParameter { get; set; }
+
+        /// <summary>Gets or sets the optional target parameter name.</summary>
+        public string? TargetParameter { get; set; }
+    }
+
+    /// <summary>
+    /// Creates and displays reusable review sessions for AI-proposed structural canvas changes.
+    /// </summary>
+    public static class CanvasChangeReviewService
+    {
+        /// <summary>
+        /// Displays a review dialog on the Rhino UI thread.
+        /// </summary>
+        /// <param name="session">Session to review.</param>
+        /// <returns><c>true</c> when the user chooses to apply selected changes.</returns>
+        public static async Task<bool> ReviewAsync(CanvasChangeReviewSession session)
+        {
+            var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            global::Rhino.RhinoApp.InvokeOnUiThread(() =>
+            {
+                try
+                {
+                    completion.SetResult(CanvasChangeReviewDialog.ShowReview(session));
+                }
+                catch (Exception ex)
+                {
+                    completion.SetException(ex);
+                }
+            });
+            return await completion.Task.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a review session for removing live canvas objects.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="instanceGuids">Objects proposed for removal.</param>
+        /// <returns>A session containing objects currently present on the canvas.</returns>
+        public static CanvasChangeReviewSession CreateRemovalSession(string source, IEnumerable<Guid> instanceGuids)
+        {
+            var document = GhJsonGrasshopper.GetByGuids(instanceGuids);
+            var items = document.Components
+                .Where(component => component.InstanceGuid.HasValue)
+                .Select(component => new CanvasChangeReviewItem(
+                    $"remove:{component.InstanceGuid}",
+                    CanvasChangeKind.ComponentRemoved,
+                    component.NickName ?? component.Name ?? "Component",
+                    component.Library ?? "Existing canvas object")
+                {
+                    ComponentId = component.Id,
+                    ExistingInstanceGuid = component.InstanceGuid,
+                })
+                .ToList();
+            if (document.Groups != null)
+            {
+                items.AddRange(document.Groups
+                    .Select((group, index) => new CanvasChangeReviewItem(
+                        $"remove:{group.InstanceGuid}",
+                        CanvasChangeKind.GroupRemoved,
+                        group.Name ?? "Group",
+                        $"{group.Members.Count} member(s)")
+                    {
+                        ExistingInstanceGuid = group.InstanceGuid,
+                        GroupIndex = index,
+                    }));
+            }
+            return new CanvasChangeReviewSession(
+                "Review AI canvas removals",
+                source,
+                document,
+                items);
+        }
+
+        /// <summary>
+        /// Creates a review session for proposed component moves.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="targets">Target positions or offsets by instance GUID.</param>
+        /// <param name="relative">Whether targets are relative offsets.</param>
+        /// <returns>A session containing proposed component pivots.</returns>
+        public static CanvasChangeReviewSession CreateMoveSession(
+            string source,
+            IReadOnlyDictionary<Guid, PointF> targets,
+            bool relative)
+        {
+            var document = GhJsonGrasshopper.GetByGuids(targets.Keys);
+            var proposedComponents = document.Components.Select(component =>
+            {
+                if (!component.InstanceGuid.HasValue ||
+                    !targets.TryGetValue(component.InstanceGuid.Value, out var target))
+                {
+                    return component;
+                }
+
+                var current = component.Pivot ?? new GhJsonPivot();
+                return CopyWithPivot(component, new GhJsonPivot(
+                    relative ? current.X + (int)Math.Round(target.X) : (int)Math.Round(target.X),
+                    relative ? current.Y + (int)Math.Round(target.Y) : (int)Math.Round(target.Y)));
+            }).ToList();
+            var proposedDocument = new GhJsonDocument(
+                document.Schema,
+                document.Metadata,
+                proposedComponents,
+                document.Connections,
+                document.Groups);
+            var items = proposedComponents
+                .Where(component => component.InstanceGuid.HasValue && targets.ContainsKey(component.InstanceGuid.Value))
+                .Select(component => new CanvasChangeReviewItem(
+                    $"move:{component.InstanceGuid}",
+                    CanvasChangeKind.ComponentModified,
+                    component.NickName ?? component.Name ?? "Component",
+                    component.Pivot == null ? "Move component" : $"Move to {component.Pivot.X}, {component.Pivot.Y}")
+                {
+                    ComponentId = component.Id,
+                    ExistingInstanceGuid = component.InstanceGuid,
+                })
+                .ToList();
+            return new CanvasChangeReviewSession(
+                "Review AI component moves",
+                source,
+                proposedDocument,
+                items);
+        }
+
+        /// <summary>
+        /// Gets accepted component instance GUIDs from a review session.
+        /// </summary>
+        /// <param name="session">Reviewed session.</param>
+        /// <returns>Accepted component identifiers.</returns>
+        public static IReadOnlySet<Guid> GetAcceptedComponentGuids(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item => item.ExistingInstanceGuid.HasValue && session.IsEffectivelyAccepted(item))
+                .Select(item => item.ExistingInstanceGuid!.Value)
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Creates a review session for proposed live-object connections or disconnections.
+        /// </summary>
+        /// <param name="source">Tool that produced the proposal.</param>
+        /// <param name="proposals">Connection proposals.</param>
+        /// <param name="kind">Connection change category.</param>
+        /// <returns>A session whose connection indexes align with <paramref name="proposals"/>.</returns>
+        public static CanvasChangeReviewSession CreateConnectionSession(
+            string source,
+            IReadOnlyList<CanvasConnectionReviewProposal> proposals,
+            CanvasChangeKind kind)
+        {
+            if (kind != CanvasChangeKind.ConnectionAdded && kind != CanvasChangeKind.ConnectionRemoved)
+            {
+                throw new ArgumentOutOfRangeException(nameof(kind));
+            }
+
+            var document = GhJsonGrasshopper.GetByGuids(proposals
+                .SelectMany(proposal => new[] { proposal.SourceGuid, proposal.TargetGuid })
+                .Distinct());
+            var idsByGuid = document.Components
+                .Where(component => component.InstanceGuid.HasValue && component.Id.HasValue)
+                .ToDictionary(component => component.InstanceGuid!.Value, component => component.Id!.Value);
+            var connections = new List<GhJsonConnection>();
+            var items = new List<CanvasChangeReviewItem>();
+            for (var index = 0; index < proposals.Count; index++)
+            {
+                var proposal = proposals[index];
+                if (!idsByGuid.TryGetValue(proposal.SourceGuid, out var sourceId) ||
+                    !idsByGuid.TryGetValue(proposal.TargetGuid, out var targetId))
+                {
+                    continue;
+                }
+
+                var connectionIndex = connections.Count;
+                connections.Add(new GhJsonConnection
+                {
+                    From = new GhJsonConnectionEndpoint
+                    {
+                        Id = sourceId,
+                        ParamName = proposal.SourceParameter,
+                    },
+                    To = new GhJsonConnectionEndpoint
+                    {
+                        Id = targetId,
+                        ParamName = proposal.TargetParameter,
+                    },
+                });
+                var sourceComponent = document.Components.First(component => component.Id == sourceId);
+                var targetComponent = document.Components.First(component => component.Id == targetId);
+                items.Add(new CanvasChangeReviewItem(
+                    $"connection:{index}",
+                    kind,
+                    $"{sourceComponent.NickName ?? sourceComponent.Name} → {targetComponent.NickName ?? targetComponent.Name}",
+                    $"{proposal.SourceParameter ?? "first output"} → {proposal.TargetParameter ?? "first input"}")
+                {
+                    ComponentId = index,
+                    ConnectionIndex = connectionIndex,
+                });
+            }
+
+            var reviewDocument = new GhJsonDocument(
+                document.Schema,
+                document.Metadata,
+                document.Components,
+                connections,
+                document.Groups);
+            return new CanvasChangeReviewSession(
+                kind == CanvasChangeKind.ConnectionAdded ? "Review AI connections" : "Review AI disconnections",
+                source,
+                reviewDocument,
+                items);
+        }
+
+        /// <summary>
+        /// Gets accepted proposal indexes from a connection review session.
+        /// </summary>
+        /// <param name="session">Reviewed connection session.</param>
+        /// <returns>Accepted indexes into the caller's proposal list.</returns>
+        public static IReadOnlySet<int> GetAcceptedConnectionProposalIndexes(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item => item.ComponentId.HasValue && session.IsEffectivelyAccepted(item))
+                .Select(item => item.ComponentId!.Value)
+                .ToHashSet();
+        }
+
+        /// <summary>
+        /// Gets accepted instance GUIDs from a component-removal session.
+        /// </summary>
+        /// <param name="session">Reviewed removal session.</param>
+        /// <returns>Accepted live object identifiers.</returns>
+        public static IReadOnlyList<Guid> GetAcceptedRemovalGuids(CanvasChangeReviewSession session)
+        {
+            return session.Items
+                .Where(item =>
+                    item.ExistingInstanceGuid.HasValue &&
+                    session.IsEffectivelyAccepted(item))
+                .Select(item => item.ExistingInstanceGuid!.Value)
+                .ToList();
+        }
+
+        private static GhJsonComponent CopyWithPivot(GhJsonComponent component, GhJsonPivot pivot)
+        {
+            return new GhJsonComponent
+            {
+                Id = component.Id,
+                InstanceGuid = component.InstanceGuid,
+                ComponentGuid = component.ComponentGuid,
+                Name = component.Name,
+                NickName = component.NickName,
+                Library = component.Library,
+                Pivot = pivot,
+                InputSettings = component.InputSettings,
+                OutputSettings = component.OutputSettings,
+                ComponentState = component.ComponentState,
+                Errors = component.Errors,
+                Warnings = component.Warnings,
+                Remarks = component.Remarks,
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
@@ -20,9 +20,11 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GhJSON.Core.SchemaModels;
 using GhJSON.Grasshopper;
+using SmartHopper.Infrastructure.Consent;
 
 namespace SmartHopper.Core.Grasshopper.Utils.Canvas
 {
@@ -54,18 +56,49 @@ namespace SmartHopper.Core.Grasshopper.Utils.Canvas
         /// </summary>
         /// <param name="session">Session to review.</param>
         /// <returns><c>true</c> when the user chooses to apply selected changes.</returns>
-        public static async Task<bool> ReviewAsync(CanvasChangeReviewSession session)
+        public static async Task<bool> ReviewAsync(
+            CanvasChangeReviewSession session,
+            MutationInvocationContext? context = null,
+            CancellationToken cancellationToken = default)
+        {
+            ConsentGate.RegisterPresenter(CanvasChangeConsentPresenter.Instance);
+            var decision = await MutatingOperationExecutor.ReviewAsync(
+                new CanvasMutationConsentProposal(session),
+                context,
+                cancellationToken).ConfigureAwait(false);
+            if (!decision.IsApproved)
+            {
+                session.SetAllAccepted(false);
+                return false;
+            }
+
+            var accepted = decision.AcceptedItemKeys.ToHashSet(StringComparer.Ordinal);
+            foreach (var item in session.Items)
+            {
+                session.SetAccepted(item.Key, accepted.Contains(item.Key));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Shows the underlying graphical review dialog on Rhino's UI thread.
+        /// </summary>
+        internal static async Task<bool> ShowReviewDialogAsync(
+            CanvasChangeReviewSession session,
+            CancellationToken cancellationToken)
         {
             var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
             global::Rhino.RhinoApp.InvokeOnUiThread(() =>
             {
                 try
                 {
-                    completion.SetResult(CanvasChangeReviewDialog.ShowReview(session));
+                    completion.TrySetResult(CanvasChangeReviewDialog.ShowReview(session, cancellationToken));
                 }
                 catch (Exception ex)
                 {
-                    completion.SetException(ex);
+                    completion.TrySetException(ex);
                 }
             });
             return await completion.Task.ConfigureAwait(false);
@@ -276,6 +309,34 @@ namespace SmartHopper.Core.Grasshopper.Utils.Canvas
                     session.IsEffectivelyAccepted(item))
                 .Select(item => item.ExistingInstanceGuid!.Value)
                 .ToList();
+        }
+
+        /// <summary>
+        /// Creates a selectable review for non-geometric component state changes.
+        /// </summary>
+        public static CanvasChangeReviewSession CreateComponentStateSession(
+            string source,
+            IEnumerable<Guid> instanceGuids,
+            string detail)
+        {
+            var document = GhJsonGrasshopper.GetByGuids(instanceGuids);
+            var items = document.Components
+                .Where(component => component.InstanceGuid.HasValue)
+                .Select(component => new CanvasChangeReviewItem(
+                    $"state:{component.InstanceGuid}",
+                    CanvasChangeKind.ComponentModified,
+                    component.NickName ?? component.Name ?? "Component",
+                    detail)
+                {
+                    ComponentId = component.Id,
+                    ExistingInstanceGuid = component.InstanceGuid,
+                })
+                .ToList();
+            return new CanvasChangeReviewSession(
+                "Review AI component state changes",
+                source,
+                document,
+                items);
         }
 
         private static GhJsonComponent CopyWithPivot(GhJsonComponent component, GhJsonPivot pivot)

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/CanvasChangeReviewService.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
@@ -1,0 +1,117 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Rhino;
+using SmartHopper.Infrastructure.AITools;
+using SmartHopper.ProviderSdk.AICall.Core.Returns;
+using SmartHopper.ProviderSdk.Diagnostics;
+
+namespace SmartHopper.Core.Grasshopper.Utils.Canvas
+{
+    /// <summary>
+    /// Verifies that mutating tools create Grasshopper undo records and coalesces multi-record calls.
+    /// </summary>
+    public sealed class GrasshopperMutationUndoCoordinator : IMutationUndoCoordinator
+    {
+        private static readonly SemaphoreSlim _mutationLock = new SemaphoreSlim(1, 1);
+
+        /// <inheritdoc/>
+        public async Task<IMutationUndoScope> BeginAsync(string toolName, CancellationToken cancellationToken)
+        {
+            await _mutationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var completion = new TaskCompletionSource<IMutationUndoScope>(TaskCreationOptions.RunContinuationsAsynchronously);
+                RhinoApp.InvokeOnUiThread(() =>
+                {
+                    var document = CanvasAccess.GetCurrentCanvas();
+                    completion.TrySetResult(new Scope(toolName, document, document?.UndoServer.UndoCount ?? 0));
+                });
+                using var registration = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
+                return await completion.Task.ConfigureAwait(false);
+            }
+            catch
+            {
+                _mutationLock.Release();
+                throw;
+            }
+        }
+
+        private sealed class Scope : IMutationUndoScope
+        {
+            private readonly Grasshopper.Kernel.GH_Document? document;
+            private readonly int initialUndoCount;
+            private readonly string toolName;
+            private int completed;
+
+            public Scope(string toolName, Grasshopper.Kernel.GH_Document? document, int initialUndoCount)
+            {
+                this.toolName = toolName;
+                this.document = document;
+                this.initialUndoCount = initialUndoCount;
+            }
+
+            public async Task CompleteAsync(AIReturn result, CancellationToken cancellationToken)
+            {
+                if (Interlocked.Exchange(ref this.completed, 1) != 0)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (this.document == null)
+                    {
+                        return;
+                    }
+
+                    var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    RhinoApp.InvokeOnUiThread(() =>
+                    {
+                        try
+                        {
+                            var addedRecords = Math.Max(0, this.document.UndoServer.UndoCount - this.initialUndoCount);
+                            if (addedRecords > 1)
+                            {
+                                this.document.UndoUtil.MergeRecords(addedRecords);
+                            }
+                            else if (addedRecords == 0 && result.Success)
+                            {
+                                result.AddRuntimeMessage(
+                                    SHRuntimeMessageSeverity.Warning,
+                                    SHRuntimeMessageOrigin.Tool,
+                                    $"Mutating tool '{this.toolName}' produced no Grasshopper undo record; the operation may have been a no-op.");
+                            }
+
+                            completion.TrySetResult(true);
+                        }
+                        catch (Exception ex)
+                        {
+                            result.AddRuntimeMessage(
+                                SHRuntimeMessageSeverity.Warning,
+                                SHRuntimeMessageOrigin.Tool,
+                                $"Undo verification failed for '{this.toolName}': {ex.Message}");
+                            completion.TrySetResult(false);
+                        }
+                    });
+                    using var registration = cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
+                    await completion.Task.ConfigureAwait(false);
+                }
+                finally
+                {
+                    _mutationLock.Release();
+                }
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
+++ b/src/SmartHopper.Core.Grasshopper/Utils/Canvas/GrasshopperMutationUndoCoordinator.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Grasshopper.Kernel;
 using Rhino;
 using SmartHopper.Infrastructure.AITools;
 using SmartHopper.ProviderSdk.AICall.Core.Returns;
@@ -49,12 +50,12 @@ namespace SmartHopper.Core.Grasshopper.Utils.Canvas
 
         private sealed class Scope : IMutationUndoScope
         {
-            private readonly Grasshopper.Kernel.GH_Document? document;
+            private readonly GH_Document? document;
             private readonly int initialUndoCount;
             private readonly string toolName;
             private int completed;
 
-            public Scope(string toolName, Grasshopper.Kernel.GH_Document? document, int initialUndoCount)
+            public Scope(string toolName, GH_Document? document, int initialUndoCount)
             {
                 this.toolName = toolName;
                 this.document = document;

--- a/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.AI.cs
+++ b/src/SmartHopper.Core/ComponentBase/AIStatefulAsyncComponentBase.AI.cs
@@ -29,6 +29,7 @@ using SmartHopper.Core.ComponentBase.Batch;
 using SmartHopper.Core.DataTree;
 using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.Infrastructure.AITools;
+using SmartHopper.Infrastructure.Consent;
 using SmartHopper.ProviderSdk.AICall.Batch;
 using SmartHopper.ProviderSdk.AICall.Core;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
@@ -230,10 +231,24 @@ namespace SmartHopper.Core.ComponentBase
             };
 
             // Create the tool call request with proper body
-            var toolCall = new AIToolCall();
-            toolCall.Provider = providerName;
-            toolCall.Model = model;
-            toolCall.Endpoint = toolName;
+            var surface = this.IsBatchRequest()
+                ? SmartHopper.ProviderSdk.Hosting.AIToolSurface.Batch
+                : SmartHopper.ProviderSdk.Hosting.AIToolSurface.Direct;
+            var toolCall = new AIToolCall
+            {
+                Provider = providerName,
+                Model = model,
+                Endpoint = toolName,
+                ToolSurface = surface,
+                InvocationContext = new MutationInvocationContext
+                {
+                    Source = MutationInvocationSource.GrasshopperComponent,
+                    OwnerId = this.InstanceGuid.ToString(),
+                    ToolCallId = toolCallInteraction.Id,
+                    ToolName = toolName,
+                    Surface = surface,
+                },
+            };
             toolCall.Parameters = this.GetParameters();
             toolCall.CancellationToken = cancellationToken;
             var immutableBody = AIBodyBuilder.Create()
@@ -249,6 +264,12 @@ namespace SmartHopper.Core.ComponentBase
             if (this.IsBatchRequest())
             {
                 var tools = AIToolManager.GetTools();
+                if (tools.TryGetValue(toolName, out var unavailableBatchTool) &&
+                    (unavailableBatchTool.Surfaces & SmartHopper.ProviderSdk.Hosting.AIToolSurface.Batch) == 0)
+                {
+                    return ToolCallResult.FromError($"Tool '{toolName}' is not available in batch mode.");
+                }
+
                 if (tools.TryGetValue(toolName, out var batchTool) && batchTool.BuildRequest != null)
                 {
                     var batchRequest = batchTool.BuildRequest(toolCall);

--- a/src/SmartHopper.Core/UI/Chat/Resources/css/chat-styles.css
+++ b/src/SmartHopper.Core/UI/Chat/Resources/css/chat-styles.css
@@ -568,3 +568,38 @@ hr {
 #scroll-bottom-btn.hidden {
     display: none !important;
 }
+
+.plan-consent-card {
+    margin: 12px;
+    padding: 16px;
+    border: 1px solid #8b5cf6;
+    border-radius: 8px;
+    background: rgba(139, 92, 246, 0.08);
+}
+
+.plan-consent-card h3 {
+    margin: 0 0 8px;
+}
+
+.plan-consent-card ol {
+    padding-left: 24px;
+}
+
+.plan-consent-card code {
+    color: #8b5cf6;
+}
+
+.plan-consent-note {
+    font-size: 0.9em;
+    opacity: 0.75;
+}
+
+.plan-consent-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.plan-consent-card.resolved {
+    opacity: 0.7;
+}

--- a/src/SmartHopper.Core/UI/Chat/Resources/js/chat-script.js
+++ b/src/SmartHopper.Core/UI/Chat/Resources/js/chat-script.js
@@ -1256,3 +1256,85 @@ document.addEventListener('copy', function(e) {
       e.preventDefault();
     }
   });
+
+function showPlanConsent(plan) {
+    const container = document.getElementById('chat-container');
+    if (!container || !plan || !plan.id) return;
+    const existing = Array.from(document.querySelectorAll('.plan-consent-card'))
+        .find(node => node.dataset.consentId === plan.id);
+    if (existing) return;
+
+    const card = document.createElement('section');
+    card.className = 'plan-consent-card';
+    card.dataset.consentId = plan.id;
+
+    const title = document.createElement('h3');
+    title.textContent = plan.goal || 'Proposed plan';
+    card.appendChild(title);
+
+    const summary = document.createElement('p');
+    summary.textContent = plan.summary || '';
+    card.appendChild(summary);
+
+    const list = document.createElement('ol');
+    (plan.steps || []).forEach(step => {
+        const item = document.createElement('li');
+        item.textContent = step.description || step.id || 'Step';
+        if (step.tool) {
+            const tool = document.createElement('code');
+            tool.textContent = ` ${step.tool}${step.mutatesCanvas ? ' (canvas change)' : ''}`;
+            item.appendChild(tool);
+        }
+        list.appendChild(item);
+    });
+    card.appendChild(list);
+
+    const appendDetails = (label, values) => {
+        if (!values || values.length === 0) return;
+        const heading = document.createElement('strong');
+        heading.textContent = label;
+        card.appendChild(heading);
+        const details = document.createElement('ul');
+        values.forEach(value => {
+            const item = document.createElement('li');
+            item.textContent = value;
+            details.appendChild(item);
+        });
+        card.appendChild(details);
+    };
+    appendDetails('Assumptions', plan.assumptions);
+    appendDetails('Success criteria', plan.successCriteria);
+
+    const note = document.createElement('p');
+    note.className = 'plan-consent-note';
+    note.textContent = 'Approving this approach does not approve canvas changes. Each concrete change receives a graphical review.';
+    card.appendChild(note);
+
+    const actions = document.createElement('div');
+    actions.className = 'plan-consent-actions';
+    const reject = document.createElement('button');
+    reject.type = 'button';
+    reject.textContent = 'Reject';
+    reject.addEventListener('click', () => {
+        window.location.href = `sh://event?type=consent&id=${encodeURIComponent(plan.id)}&decision=reject`;
+    });
+    const approve = document.createElement('button');
+    approve.type = 'button';
+    approve.textContent = 'Approve plan';
+    approve.addEventListener('click', () => {
+        window.location.href = `sh://event?type=consent&id=${encodeURIComponent(plan.id)}&decision=approve`;
+    });
+    actions.appendChild(reject);
+    actions.appendChild(approve);
+    card.appendChild(actions);
+    insertAboveThinkingIfPresent(container, card);
+    scrollToBottom();
+}
+
+function resolvePlanConsent(id) {
+    const card = Array.from(document.querySelectorAll('.plan-consent-card'))
+        .find(node => node.dataset.consentId === id);
+    if (!card) return;
+    card.classList.add('resolved');
+    card.querySelectorAll('button').forEach(button => { button.disabled = true; });
+}

--- a/src/SmartHopper.Core/UI/Chat/WebChatConsent.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatConsent.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Core/UI/Chat/WebChatConsent.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatConsent.cs
@@ -1,0 +1,106 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SmartHopper.Infrastructure.Consent;
+
+namespace SmartHopper.Core.UI.Chat
+{
+    internal partial class WebChatDialog
+    {
+        private readonly ConcurrentDictionary<string, TaskCompletionSource<ConsentDecision>> _pendingPlanConsents =
+            new ConcurrentDictionary<string, TaskCompletionSource<ConsentDecision>>(StringComparer.Ordinal);
+
+        private async Task<ConsentDecision> ShowPlanConsentAsync(
+            PlanConsentProposal proposal,
+            CancellationToken cancellationToken)
+        {
+            var completion = new TaskCompletionSource<ConsentDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!this._pendingPlanConsents.TryAdd(proposal.Id, completion))
+            {
+                return ConsentDecision.Cancelled("This plan is already awaiting review.");
+            }
+
+            using var registration = cancellationToken.Register(() =>
+                completion.TrySetResult(ConsentDecision.Cancelled("Plan review was cancelled.")));
+            var payload = new
+            {
+                id = proposal.Id,
+                goal = proposal.Goal,
+                summary = proposal.Summary,
+                steps = proposal.Steps.Select(step => new
+                {
+                    id = step.Id,
+                    description = step.Description,
+                    tool = step.Tool,
+                    mutatesCanvas = step.MutatesCanvas,
+                }),
+                assumptions = proposal.Assumptions,
+                successCriteria = proposal.SuccessCriteria,
+            };
+            this.RunWhenWebViewReady(() => this.ExecuteScript(
+                $"showPlanConsent({JsonConvert.SerializeObject(payload)});"));
+
+            try
+            {
+                return await completion.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                this._pendingPlanConsents.TryRemove(proposal.Id, out _);
+                this.RunWhenWebViewReady(() => this.ExecuteScript(
+                    $"resolvePlanConsent({JsonConvert.SerializeObject(proposal.Id)});"));
+            }
+        }
+
+        private void ResolvePlanConsent(string requestId, bool approved)
+        {
+            if (!this._pendingPlanConsents.TryGetValue(requestId, out var completion))
+            {
+                return;
+            }
+
+            completion.TrySetResult(new ConsentDecision
+            {
+                Status = approved ? ConsentDecisionStatus.Approved : ConsentDecisionStatus.Rejected,
+                AcceptedItemKeys = approved ? new[] { requestId } : Array.Empty<string>(),
+                Reason = approved ? null : "The user rejected the proposed plan.",
+            });
+        }
+
+        private sealed class WebChatPlanConsentPresenter : IConsentPresenter
+        {
+            private readonly WebChatDialog dialog;
+
+            public WebChatPlanConsentPresenter(WebChatDialog dialog)
+            {
+                this.dialog = dialog;
+            }
+
+            public bool CanPresent(IConsentProposal proposal, MutationInvocationContext context)
+            {
+                return proposal is PlanConsentProposal;
+            }
+
+            public Task<ConsentDecision> PresentAsync(
+                IConsentProposal proposal,
+                MutationInvocationContext context,
+                CancellationToken cancellationToken)
+            {
+                return this.dialog.ShowPlanConsentAsync((PlanConsentProposal)proposal, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Core/UI/Chat/WebChatDialog.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatDialog.cs
@@ -144,9 +144,6 @@ namespace SmartHopper.Core.UI.Chat
                     this.ShowInTaskbar = false;
                 }
 
-                // Create session with attached observer from the start
-                this._currentSession = new ConversationSession(request, new WebChatObserver(this), generateGreeting: this._generateGreeting);
-
                 // Window basics
                 this.ClientSize = new Size(720, 640);
                 this.MinimumSize = new Size(560, 420);
@@ -157,6 +154,13 @@ namespace SmartHopper.Core.UI.Chat
                 this._webView.DocumentLoaded += this.WebView_DocumentLoaded;
                 this._webView.DocumentLoading += this.WebView_DocumentLoading;
                 this.Content = this._webView;
+
+                // Create the session after the WebView so its consent presenter can render plan cards.
+                this._currentSession = new ConversationSession(
+                    request,
+                    new WebChatObserver(this),
+                    generateGreeting: this._generateGreeting,
+                    consentPresenter: new WebChatPlanConsentPresenter(this));
 
                 // If the user drags/resizes the dialog while we are rendering/upserting messages,
                 // defer DOM work to keep Rhino/Eto responsive.
@@ -1249,6 +1253,15 @@ namespace SmartHopper.Core.UI.Chat
                                         DebugLog($"[WebChatDialog] Deferred SendMessage error: {ex.Message}");
                                     }
                                 });
+                                break;
+                            }
+
+                        case "consent":
+                            {
+                                var requestId = query.TryGetValue("id", out var id) ? id : string.Empty;
+                                var approved = query.TryGetValue("decision", out var decision) &&
+                                    string.Equals(decision, "approve", StringComparison.OrdinalIgnoreCase);
+                                Application.Instance?.AsyncInvoke(() => this.ResolvePlanConsent(requestId, approved));
                                 break;
                             }
 

--- a/src/SmartHopper.Core/UI/Chat/WebChatUtils.Helpers.cs
+++ b/src/SmartHopper.Core/UI/Chat/WebChatUtils.Helpers.cs
@@ -223,7 +223,10 @@ namespace SmartHopper.Core.UI.Chat
             var requiredCapabilities = ComputeRequiredCapabilities(toolFilter);
             var composedSystemPrompt = AgentKnowledgeCatalog.ComposeGrasshopperSystemPrompt(systemPrompt);
 
-            var request = new AIRequestCall();
+            var request = new AIRequestCall
+            {
+                ToolSurface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat,
+            };
             request.Initialize(
                 provider: providerName,
                 model: modelName,

--- a/src/SmartHopper.Infrastructure.Tests/AIToolManagerExecutionTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/AIToolManagerExecutionTests.cs
@@ -28,6 +28,7 @@ namespace SmartHopper.Infrastructure.Tests
     using SmartHopper.ProviderSdk.AICall.Core.Requests;
     using SmartHopper.ProviderSdk.AICall.Core.Returns;
     using SmartHopper.ProviderSdk.Diagnostics;
+    using SmartHopper.ProviderSdk.Hosting;
     using Xunit;
 
     /// <summary>
@@ -250,9 +251,117 @@ namespace SmartHopper.Infrastructure.Tests
             Assert.True(result.Messages.Exists(m => m.Severity == SHRuntimeMessageSeverity.Error));
         }
 
+        [Fact]
+        public async Task ExecuteTool_ToolUnavailableOnSurface_ReturnsErrorWithoutExecuting()
+        {
+            this.ResetTools();
+            var executed = false;
+            var tool = new AITool(
+                "chat_only",
+                "Chat only",
+                "Control",
+                "{}",
+                _ =>
+                {
+                    executed = true;
+                    return Task.FromResult(new AIReturn());
+                },
+                surfaces: AIToolSurface.Chat);
+            AIToolManager.RegisterTool(tool);
+            var toolCall = new AIToolCall
+            {
+                Provider = "test",
+                Model = "test-model",
+                ToolSurface = AIToolSurface.Mcp,
+                InvocationContext = new SmartHopper.Infrastructure.Consent.MutationInvocationContext
+                {
+                    Surface = AIToolSurface.Mcp,
+                },
+                Body = AIBodyBuilder.Create()
+                    .Add(new AIInteractionToolCall
+                    {
+                        Id = "call-1",
+                        Name = tool.Name,
+                        Arguments = new JObject(),
+                    })
+                    .Build(),
+            };
+
+            var result = await AIToolManager.ExecuteTool(toolCall);
+
+            Assert.False(executed);
+            Assert.Contains(result.Messages, message => message.Message?.Contains("not available") == true);
+        }
+
+        [Fact]
+        public async Task ExecuteTool_MutatingTool_CompletesUndoScope()
+        {
+            this.ResetTools();
+            var coordinator = new RecordingUndoCoordinator();
+            MutationUndoCoordinator.Current = coordinator;
+            try
+            {
+                var tool = new AIMutatingTool(
+                    "mutation",
+                    "Mutation",
+                    "Test",
+                    "{}",
+                    call =>
+                    {
+                        var result = new AIReturn { Request = call };
+                        result.SetBody(AIBodyBuilder.Create()
+                            .AddToolResult(new JObject { ["success"] = true })
+                            .Build());
+                        return Task.FromResult(result);
+                    });
+                AIToolManager.RegisterTool(tool);
+                var interaction = new AIInteractionToolCall
+                {
+                    Id = "mutation-call",
+                    Name = tool.Name,
+                    Arguments = new JObject(),
+                };
+                var call = new AIToolCall
+                {
+                    Provider = "test",
+                    Model = "test-model",
+                };
+                call.FromToolCallInteraction(interaction);
+
+                await AIToolManager.ExecuteTool(call);
+
+                Assert.True(coordinator.Scope.Completed);
+            }
+            finally
+            {
+                MutationUndoCoordinator.Current = null;
+            }
+        }
+
         private void ResetTools()
         {
             typeof(AIToolManager).GetMethod("ResetTools", BindingFlags.Static | BindingFlags.NonPublic)?.Invoke(null, null);
+        }
+
+        private sealed class RecordingUndoCoordinator : IMutationUndoCoordinator
+        {
+            public RecordingUndoScope Scope { get; } = new RecordingUndoScope();
+
+            public Task<IMutationUndoScope> BeginAsync(string toolName, System.Threading.CancellationToken cancellationToken)
+            {
+                return Task.FromResult<IMutationUndoScope>(this.Scope);
+            }
+        }
+
+        private sealed class RecordingUndoScope : IMutationUndoScope
+        {
+            public bool Completed { get; private set; }
+
+            public Task CompleteAsync(AIReturn result, System.Threading.CancellationToken cancellationToken)
+            {
+                this.Completed = true;
+                return Task.CompletedTask;
+            }
         }
 
         #endregion

--- a/src/SmartHopper.Infrastructure.Tests/Consent/ConsentGateTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/Consent/ConsentGateTests.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure.Tests/Consent/ConsentGateTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/Consent/ConsentGateTests.cs
@@ -1,0 +1,101 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SmartHopper.Infrastructure.Consent;
+using Xunit;
+
+namespace SmartHopper.Infrastructure.Tests.Consent
+{
+    /// <summary>
+    /// Tests single-use consent lifecycle behavior without Rhino dependencies.
+    /// </summary>
+    public class ConsentGateTests
+    {
+        [Fact]
+        public async Task RequestAsync_UsesInvocationPresenter()
+        {
+            var presenter = new StubPresenter(new ConsentDecision { Status = ConsentDecisionStatus.Approved });
+            var context = new MutationInvocationContext { Presenter = presenter };
+
+            var result = await ConsentGate.RequestAsync(new StubProposal(), context);
+
+            Assert.True(result.IsApproved);
+            Assert.Equal(1, presenter.CallCount);
+            Assert.False(ConsentGate.IsPending(context.InvocationId));
+        }
+
+        [Fact]
+        public async Task RequestAsync_CancellationClearsPendingRequest()
+        {
+            var presenter = new BlockingPresenter();
+            var context = new MutationInvocationContext { Presenter = presenter };
+            using var cancellation = new CancellationTokenSource();
+            var request = ConsentGate.RequestAsync(new StubProposal(), context, cancellation.Token);
+            cancellation.Cancel();
+
+            var result = await request;
+
+            Assert.Equal(ConsentDecisionStatus.Cancelled, result.Status);
+            Assert.False(ConsentGate.IsPending(context.InvocationId));
+        }
+
+        private sealed class StubProposal : IConsentProposal
+        {
+            public string Id { get; } = Guid.NewGuid().ToString("N");
+
+            public string Kind => "test";
+
+            public string Title => "Test";
+
+            public IReadOnlyList<string> ItemKeys { get; } = new[] { "item" };
+        }
+
+        private sealed class StubPresenter : IConsentPresenter
+        {
+            private readonly ConsentDecision decision;
+
+            public StubPresenter(ConsentDecision decision)
+            {
+                this.decision = decision;
+            }
+
+            public int CallCount { get; private set; }
+
+            public bool CanPresent(IConsentProposal proposal, MutationInvocationContext context) => true;
+
+            public Task<ConsentDecision> PresentAsync(
+                IConsentProposal proposal,
+                MutationInvocationContext context,
+                CancellationToken cancellationToken)
+            {
+                this.CallCount++;
+                return Task.FromResult(this.decision);
+            }
+        }
+
+        private sealed class BlockingPresenter : IConsentPresenter
+        {
+            public bool CanPresent(IConsentProposal proposal, MutationInvocationContext context) => true;
+
+            public async Task<ConsentDecision> PresentAsync(
+                IConsentProposal proposal,
+                MutationInvocationContext context,
+                CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return new ConsentDecision { Status = ConsentDecisionStatus.Approved };
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Infrastructure.Tests/Mcp/AIToolMcpAdapterTests.cs
+++ b/src/SmartHopper.Infrastructure.Tests/Mcp/AIToolMcpAdapterTests.cs
@@ -235,6 +235,27 @@ namespace SmartHopper.Infrastructure.Tests.Mcp
         }
 
         [Fact]
+        public void BuildDescriptors_OmitsChatOnlyControlToolsEvenWhenAllowListed()
+        {
+            var control = new AITool(
+                "plan_propose",
+                "Plan",
+                "Control",
+                ReadOnlySchema,
+                _ => Task.FromResult(new AIReturn()),
+                mutatesCanvas: false,
+                surfaces: SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat);
+            var tools = new Dictionary<string, AITool> { [control.Name] = control };
+            var adapter = new AIToolMcpAdapter(
+                new McpServerOptions { EnabledTools = new[] { control.Name } },
+                () => tools,
+                _ => Task.FromResult(new AIReturn()));
+
+            Assert.Empty(adapter.BuildDescriptors());
+            Assert.False(adapter.IsExposed(control.Name));
+        }
+
+        [Fact]
         public void BuildDescriptors_PrefixesDescriptionWithMutability()
         {
             var tools = BuildCatalog(("gh_get", ReadOnlySchema, false));

--- a/src/SmartHopper.Infrastructure/AICall/Sessions/ConversationSession.cs
+++ b/src/SmartHopper.Infrastructure/AICall/Sessions/ConversationSession.cs
@@ -28,6 +28,7 @@ namespace SmartHopper.Infrastructure.AICall.Sessions
     using SmartHopper.Infrastructure.AICall.Execution;
     using SmartHopper.Infrastructure.AICall.Policies;
     using SmartHopper.Infrastructure.AICall.Utilities;
+    using SmartHopper.Infrastructure.Consent;
     using SmartHopper.Infrastructure.Settings;
     using SmartHopper.ProviderSdk.AICall.Core.Base;
     using SmartHopper.ProviderSdk.AICall.Core.Interactions;
@@ -113,14 +114,21 @@ namespace SmartHopper.Infrastructure.AICall.Sessions
         /// <param name="observer">The observer to notify of events.</param>
         /// <param name="executor">The provider executor to use for tool calls.</param>
         /// <param name="generateGreeting">Whether to generate an AI greeting when the conversation is initialized.</param>
+        /// <param name="consentPresenter">Optional presenter for invocation-specific consent requests.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="request"/> is null.</exception>
-        public ConversationSession(AIRequestCall request, IConversationObserver? observer = null, IProviderExecutor? executor = null, bool generateGreeting = false)
+        public ConversationSession(
+            AIRequestCall request,
+            IConversationObserver? observer = null,
+            IProviderExecutor? executor = null,
+            bool generateGreeting = false,
+            IConsentPresenter? consentPresenter = null)
         {
             this.Request = request ?? throw new ArgumentNullException(nameof(request));
             this._initialRequest = request;
             this.Observer = observer;
             this.executor = executor ?? new DefaultProviderExecutor();
             this._generateGreeting = generateGreeting;
+            this.ConsentPresenter = consentPresenter;
 
             // Initialize _lastReturn with initial request body
             this._lastReturn.SetBody(request.Body);
@@ -551,6 +559,11 @@ namespace SmartHopper.Infrastructure.AICall.Sessions
         /// Gets the observer for this session.
         /// </summary>
         public IConversationObserver? Observer { get; }
+
+        /// <summary>
+        /// Gets the invocation-specific consent presenter.
+        /// </summary>
+        public IConsentPresenter? ConsentPresenter { get; }
 
         /// <summary>
         /// Adds a new user interaction to the conversation.

--- a/src/SmartHopper.Infrastructure/AICall/Sessions/ConversationSessionHelpers.cs
+++ b/src/SmartHopper.Infrastructure/AICall/Sessions/ConversationSessionHelpers.cs
@@ -29,6 +29,7 @@ namespace SmartHopper.Infrastructure.AICall.Sessions
     using Newtonsoft.Json.Linq;
     using SmartHopper.Infrastructure.AICall.Tools;
     using SmartHopper.Infrastructure.AICall.Utilities;
+    using SmartHopper.Infrastructure.Consent;
     using SmartHopper.ProviderSdk.AICall.Core.Base;
     using SmartHopper.ProviderSdk.AICall.Core.Interactions;
     using SmartHopper.ProviderSdk.AICall.Core.Requests;
@@ -262,9 +263,23 @@ namespace SmartHopper.Infrastructure.AICall.Sessions
                 Debug.WriteLine($"[ConversationSession] Warning: failed to persist tool_call before execution: {ex.Message}");
             }
 
-            var toolRq = new AIToolCall();
+            var toolRq = new AIToolCall
+            {
+                CancellationToken = ct,
+                ToolSurface = this.Request.ToolSurface,
+                InvocationContext = new MutationInvocationContext
+                {
+                    Source = this.Request.ToolSurface == SmartHopper.ProviderSdk.Hosting.AIToolSurface.Chat
+                        ? MutationInvocationSource.WebChat
+                        : MutationInvocationSource.DirectTool,
+                    OwnerId = this.GetHashCode().ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    ToolCallId = tc.Id,
+                    ToolName = tc.Name,
+                    Surface = this.Request.ToolSurface,
+                    Presenter = this.ConsentPresenter,
+                },
+            };
             toolRq.FromToolCallInteraction(tc, this.Request.Provider, this.Request.Model);
-            toolRq.CancellationToken = ct;
 
             // Measure tool execution time
             var stopwatch = Stopwatch.StartNew();

--- a/src/SmartHopper.Infrastructure/AICall/Tools/AIToolCall.cs
+++ b/src/SmartHopper.Infrastructure/AICall/Tools/AIToolCall.cs
@@ -24,6 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using SmartHopper.Infrastructure.AICall.Validation;
 using SmartHopper.Infrastructure.AITools;
+using SmartHopper.Infrastructure.Consent;
 using SmartHopper.ProviderSdk.AICall.Core;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
@@ -47,6 +48,11 @@ namespace SmartHopper.Infrastructure.AICall.Tools
         /// Gets or sets the cancellation token for this tool execution.
         /// </summary>
         public CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the invocation context used by consent-controlled tools.
+        /// </summary>
+        public MutationInvocationContext InvocationContext { get; set; } = new MutationInvocationContext();
 
         /// <summary>
         /// Gets a value indicating whether the tool call is valid.
@@ -136,40 +142,44 @@ namespace SmartHopper.Infrastructure.AICall.Tools
 
             try
             {
-                // Respect per-request timeout. We cannot cancel the underlying work if the tool ignores cancellation,
-                // but we do return a standardized timeout error when exceeded.
+                // Respect per-request timeout with a linked token. Tools must honor CancellationToken
+                // so side effects cannot continue after a timeout is reported.
                 // Resolution chain: explicit per-request value (when > 0) -> shared default.
                 // RequestTimeoutPolicy normally resolves this from settings before Exec() runs.
                 var timeoutSec = (this.TimeoutSeconds.HasValue && this.TimeoutSeconds.Value > 0)
                     ? this.TimeoutSeconds.Value
                     : DEFAULT_TIMEOUT_SECONDS;
                 var clampedTimeout = Math.Min(Math.Max(timeoutSec, MIN_TIMEOUT_SECONDS), MAX_TIMEOUT_SECONDS);
+                using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(clampedTimeout));
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    this.CancellationToken,
+                    cancellationToken,
+                    timeoutCts.Token);
+                this.CancellationToken = linkedCts.Token;
                 var execTask = AIToolManager.ExecuteTool(this);
-                var completed = await Task.WhenAny(
-                    execTask,
-                    Task.Delay(TimeSpan.FromSeconds(clampedTimeout))).ConfigureAwait(false);
-                if (completed != execTask)
+                try
+                {
+                    var result = await execTask.ConfigureAwait(false);
+                    if (result == null)
+                    {
+                        var none = new AIReturn();
+                        none.CreateToolError("Tool execution returned no result", this);
+                        return none;
+                    }
+
+                    if (result.Body == null && !result.Messages.Any(m => m.Severity == SHRuntimeMessageSeverity.Error))
+                    {
+                        result.CreateToolError("Tool execution returned no result", this);
+                    }
+
+                    return result;
+                }
+                catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
                 {
                     var timed = new AIReturn();
-                    timed.CreateToolError($"Tool execution exceeded {timeoutSec} seconds", this);
+                    timed.CreateToolError($"Tool execution exceeded {clampedTimeout} seconds", this);
                     return timed;
                 }
-
-                var result = await execTask.ConfigureAwait(false);
-                if (result == null)
-                {
-                    var none = new AIReturn();
-                    none.CreateToolError("Tool execution returned no result", this);
-                    return none;
-                }
-
-                // If the tool didn't provide a body and no error messages, standardize it
-                if (result.Body == null && !result.Messages.Any(m => m.Severity == SHRuntimeMessageSeverity.Error))
-                {
-                    result.CreateToolError("Tool execution returned no result", this);
-                }
-
-                return result;
             }
             catch (TaskCanceledException)
             {

--- a/src/SmartHopper.Infrastructure/AITools/AIMutatingTool.cs
+++ b/src/SmartHopper.Infrastructure/AITools/AIMutatingTool.cs
@@ -1,0 +1,58 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SmartHopper.Infrastructure.AICall.Tools;
+using SmartHopper.ProviderSdk.AICall.Core.Returns;
+using SmartHopper.ProviderSdk.AIModels;
+using SmartHopper.ProviderSdk.Hosting;
+
+namespace SmartHopper.Infrastructure.AITools
+{
+    /// <summary>
+    /// Represents an AI tool that mutates canvas or document state and cannot run in batch mode.
+    /// </summary>
+    public sealed class AIMutatingTool : AITool
+    {
+        /// <summary>
+        /// Initializes a new mutating tool.
+        /// </summary>
+        public AIMutatingTool(
+            string name,
+            string description,
+            string category,
+            string parametersSchema,
+            Func<AIToolCall, Task<AIReturn>> execute,
+            AICapability requiredCapabilities = AICapability.None,
+            bool enabled = true,
+            IReadOnlyList<string>? tags = null,
+            string? outputSchema = null,
+            AIToolAnnotations? annotations = null,
+            AIToolSurface surfaces = AIToolSurface.Chat | AIToolSurface.Direct | AIToolSurface.Mcp)
+            : base(
+                name,
+                description,
+                category,
+                parametersSchema,
+                execute,
+                requiredCapabilities,
+                null,
+                true,
+                enabled,
+                tags,
+                outputSchema,
+                annotations,
+                surfaces & ~AIToolSurface.Batch)
+        {
+        }
+    }
+}

--- a/src/SmartHopper.Infrastructure/AITools/AIMutatingTool.cs
+++ b/src/SmartHopper.Infrastructure/AITools/AIMutatingTool.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure/AITools/AITool.cs
+++ b/src/SmartHopper.Infrastructure/AITools/AITool.cs
@@ -25,6 +25,8 @@ using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.ProviderSdk.AICall.Core.Requests;
 using SmartHopper.ProviderSdk.AICall.Core.Returns;
 using SmartHopper.ProviderSdk.AIModels;
+using SmartHopper.ProviderSdk.Hosting;
+
 namespace SmartHopper.Infrastructure.AITools
 {
     /// <summary>
@@ -88,6 +90,11 @@ namespace SmartHopper.Infrastructure.AITools
         /// Defaults to <c>true</c>; set to <c>false</c> to hide experimental or unsupported tools.
         /// </summary>
         public bool Enabled { get; }
+
+        /// <summary>
+        /// Gets the execution surfaces on which this tool is available.
+        /// </summary>
+        public AIToolSurface Surfaces { get; }
 
         /// <summary>
         /// Gets name of the tool (used for tool calls).
@@ -171,6 +178,7 @@ namespace SmartHopper.Infrastructure.AITools
         /// <param name="tags">Category tags for the tool.</param>
         /// <param name="outputSchema">JSON schema describing the tool's result payload.</param>
         /// <param name="annotations">MCP-style annotations for the tool.</param>
+        /// <param name="surfaces">Execution surfaces on which the tool is available.</param>
         public AITool(
             string name,
             string description,
@@ -183,7 +191,8 @@ namespace SmartHopper.Infrastructure.AITools
             bool enabled = true,
             IReadOnlyList<string>? tags = null,
             string? outputSchema = null,
-            AIToolAnnotations? annotations = null)
+            AIToolAnnotations? annotations = null,
+            AIToolSurface surfaces = AIToolSurface.All)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Description = description ?? throw new ArgumentNullException(nameof(description));
@@ -194,6 +203,7 @@ namespace SmartHopper.Infrastructure.AITools
             this.BuildRequest = buildRequest;
             this.MutatesCanvas = mutatesCanvas;
             this.Enabled = enabled;
+            this.Surfaces = surfaces;
             this.Tags = tags ?? BuildDefaultTags(category, mutatesCanvas);
             this.OutputSchema = outputSchema ?? "{ \"type\": \"object\" }";
             this.Annotations = annotations ?? new AIToolAnnotations(

--- a/src/SmartHopper.Infrastructure/AITools/MutationUndoCoordinator.cs
+++ b/src/SmartHopper.Infrastructure/AITools/MutationUndoCoordinator.cs
@@ -1,0 +1,43 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using SmartHopper.ProviderSdk.AICall.Core.Returns;
+
+namespace SmartHopper.Infrastructure.AITools
+{
+    /// <summary>
+    /// Coordinates host-specific undo records around one mutating tool invocation.
+    /// </summary>
+    public interface IMutationUndoCoordinator
+    {
+        /// <summary>Captures the undo state before a mutating tool executes.</summary>
+        Task<IMutationUndoScope> BeginAsync(string toolName, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Completes host-specific undo handling after one mutating tool invocation.
+    /// </summary>
+    public interface IMutationUndoScope
+    {
+        /// <summary>Validates and coalesces undo records produced by the invocation.</summary>
+        Task CompleteAsync(AIReturn result, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Stores the undo coordinator supplied by the Grasshopper host.
+    /// </summary>
+    public static class MutationUndoCoordinator
+    {
+        /// <summary>Gets or sets the active host coordinator.</summary>
+        public static IMutationUndoCoordinator? Current { get; set; }
+    }
+}

--- a/src/SmartHopper.Infrastructure/AITools/MutationUndoCoordinator.cs
+++ b/src/SmartHopper.Infrastructure/AITools/MutationUndoCoordinator.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System.Threading;

--- a/src/SmartHopper.Infrastructure/AITools/ToolManager.cs
+++ b/src/SmartHopper.Infrastructure/AITools/ToolManager.cs
@@ -147,6 +147,14 @@ namespace SmartHopper.Infrastructure.AITools
                 }
             }
 
+            var surface = toolCall.ToolSurface;
+            toolCall.InvocationContext.Surface = surface;
+            if ((tool.Surfaces & surface) == 0)
+            {
+                output.CreateToolError($"Tool '{toolInfo.Name}' is not available on the {surface} surface.", toolCall);
+                return output;
+            }
+
             // Normalize a null arguments object to an empty JObject when the tool schema has no
             // required parameters. ToolJsonSchemaValidator validates this case but cannot return the
             // normalized instance because IValidator<T> is side-effect free, so the normalization
@@ -163,8 +171,16 @@ namespace SmartHopper.Infrastructure.AITools
                 }
             }
 
+            IMutationUndoScope? undoScope = null;
             try
             {
+                if (tool is AIMutatingTool && MutationUndoCoordinator.Current != null)
+                {
+                    undoScope = await MutationUndoCoordinator.Current
+                        .BeginAsync(toolInfo.Name, toolCall.CancellationToken)
+                        .ConfigureAwait(false);
+                }
+
                 // Execute the tool
                 Debug.WriteLine($"[AIToolManager] Tool found, executing: {toolInfo.Name}");
 
@@ -229,6 +245,11 @@ namespace SmartHopper.Infrastructure.AITools
                     output.Messages = result.Messages;
                 }
 
+                if (undoScope != null)
+                {
+                    await undoScope.CompleteAsync(output, System.Threading.CancellationToken.None).ConfigureAwait(false);
+                }
+
                 return output;
             }
             catch (Exception ex)
@@ -237,6 +258,11 @@ namespace SmartHopper.Infrastructure.AITools
 
                 // Standardize as a tool error and add a structured message tagged with Tool origin
                 output.CreateToolError($"Error executing tool '{toolInfo.Name}': {ex.Message}", toolCall);
+                if (undoScope != null)
+                {
+                    await undoScope.CompleteAsync(output, System.Threading.CancellationToken.None).ConfigureAwait(false);
+                }
+
                 return output;
             }
         }

--- a/src/SmartHopper.Infrastructure/Consent/ConsentContracts.cs
+++ b/src/SmartHopper.Infrastructure/Consent/ConsentContracts.cs
@@ -1,0 +1,171 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SmartHopper.ProviderSdk.Hosting;
+
+namespace SmartHopper.Infrastructure.Consent
+{
+    /// <summary>
+    /// Identifies the caller that initiated a consent-controlled operation.
+    /// </summary>
+    public enum MutationInvocationSource
+    {
+        /// <summary>The source is unknown.</summary>
+        Unknown,
+
+        /// <summary>The operation originated in WebChat.</summary>
+        WebChat,
+
+        /// <summary>The operation originated in a Grasshopper component.</summary>
+        GrasshopperComponent,
+
+        /// <summary>The operation originated through MCP.</summary>
+        Mcp,
+
+        /// <summary>The operation was called directly as an AI tool.</summary>
+        DirectTool,
+
+        /// <summary>The operation is internal.</summary>
+        Internal,
+    }
+
+    /// <summary>
+    /// Identifies the terminal outcome of a consent request.
+    /// </summary>
+    public enum ConsentDecisionStatus
+    {
+        /// <summary>All proposed changes were approved.</summary>
+        Approved,
+
+        /// <summary>Only part of the proposal was approved.</summary>
+        PartiallyApproved,
+
+        /// <summary>The proposal was rejected.</summary>
+        Rejected,
+
+        /// <summary>The request was cancelled.</summary>
+        Cancelled,
+
+        /// <summary>No presenter was available.</summary>
+        Unavailable,
+    }
+
+    /// <summary>
+    /// Describes one immutable proposal that requires user consent.
+    /// </summary>
+    public interface IConsentProposal
+    {
+        /// <summary>Gets the unique proposal identifier.</summary>
+        string Id { get; }
+
+        /// <summary>Gets the proposal kind used to select a presenter.</summary>
+        string Kind { get; }
+
+        /// <summary>Gets the user-facing proposal title.</summary>
+        string Title { get; }
+
+        /// <summary>Gets all independently selectable item keys.</summary>
+        IReadOnlyList<string> ItemKeys { get; }
+    }
+
+    /// <summary>
+    /// Presents a consent request to the user without owning its lifecycle.
+    /// </summary>
+    public interface IConsentPresenter
+    {
+        /// <summary>Returns whether this presenter can display the proposal.</summary>
+        bool CanPresent(IConsentProposal proposal, MutationInvocationContext context);
+
+        /// <summary>Presents the proposal and returns one terminal decision.</summary>
+        Task<ConsentDecision> PresentAsync(
+            IConsentProposal proposal,
+            MutationInvocationContext context,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Carries caller identity and cancellation through a consent-controlled invocation.
+    /// </summary>
+    public sealed class MutationInvocationContext
+    {
+        /// <summary>Gets or sets the unique invocation identifier.</summary>
+        public string InvocationId { get; set; } = Guid.NewGuid().ToString("N");
+
+        /// <summary>Gets or sets the invocation source.</summary>
+        public MutationInvocationSource Source { get; set; } = MutationInvocationSource.DirectTool;
+
+        /// <summary>Gets or sets the optional owner identifier.</summary>
+        public string? OwnerId { get; set; }
+
+        /// <summary>Gets or sets the optional tool-call identifier.</summary>
+        public string? ToolCallId { get; set; }
+
+        /// <summary>Gets or sets the optional tool name.</summary>
+        public string? ToolName { get; set; }
+
+        /// <summary>Gets or sets the execution surface.</summary>
+        public AIToolSurface Surface { get; set; } = AIToolSurface.Direct;
+
+        /// <summary>Gets or sets an invocation-specific presenter.</summary>
+        public IConsentPresenter? Presenter { get; set; }
+
+        /// <summary>Creates a defensive copy for one tool call.</summary>
+        public MutationInvocationContext ForTool(string? toolCallId, string? toolName)
+        {
+            return new MutationInvocationContext
+            {
+                InvocationId = Guid.NewGuid().ToString("N"),
+                Source = this.Source,
+                OwnerId = this.OwnerId,
+                ToolCallId = toolCallId,
+                ToolName = toolName,
+                Surface = this.Surface,
+                Presenter = this.Presenter,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Represents one terminal, single-use consent decision.
+    /// </summary>
+    public sealed class ConsentDecision
+    {
+        /// <summary>Gets or sets the terminal decision status.</summary>
+        public ConsentDecisionStatus Status { get; set; }
+
+        /// <summary>Gets or sets the accepted proposal item keys.</summary>
+        public IReadOnlyList<string> AcceptedItemKeys { get; set; } = Array.Empty<string>();
+
+        /// <summary>Gets or sets an optional user-facing reason.</summary>
+        public string? Reason { get; set; }
+
+        /// <summary>Gets or sets when the decision was made.</summary>
+        public DateTime DecidedAtUtc { get; set; } = DateTime.UtcNow;
+
+        /// <summary>Gets whether at least one change was approved.</summary>
+        public bool IsApproved =>
+            this.Status == ConsentDecisionStatus.Approved ||
+            this.Status == ConsentDecisionStatus.PartiallyApproved;
+
+        /// <summary>Creates a cancelled decision.</summary>
+        public static ConsentDecision Cancelled(string? reason = null)
+        {
+            return new ConsentDecision
+            {
+                Status = ConsentDecisionStatus.Cancelled,
+                Reason = reason,
+            };
+        }
+    }
+}

--- a/src/SmartHopper.Infrastructure/Consent/ConsentContracts.cs
+++ b/src/SmartHopper.Infrastructure/Consent/ConsentContracts.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure/Consent/ConsentGate.cs
+++ b/src/SmartHopper.Infrastructure/Consent/ConsentGate.cs
@@ -1,0 +1,115 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartHopper.Infrastructure.Consent
+{
+    /// <summary>
+    /// Coordinates single-use consent requests and prevents late or duplicate decisions.
+    /// </summary>
+    public static class ConsentGate
+    {
+        private static readonly ConcurrentDictionary<string, byte> _pending = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+        private static readonly object _presentersLock = new object();
+        private static readonly List<IConsentPresenter> _presenters = new List<IConsentPresenter>();
+
+        /// <summary>
+        /// Registers a fallback presenter.
+        /// </summary>
+        public static void RegisterPresenter(IConsentPresenter presenter)
+        {
+            if (presenter == null)
+            {
+                throw new ArgumentNullException(nameof(presenter));
+            }
+
+            lock (_presentersLock)
+            {
+                if (!_presenters.Contains(presenter))
+                {
+                    _presenters.Add(presenter);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Requests a one-call consent decision.
+        /// </summary>
+        public static async Task<ConsentDecision> RequestAsync(
+            IConsentProposal proposal,
+            MutationInvocationContext? context,
+            CancellationToken cancellationToken = default)
+        {
+            if (proposal == null)
+            {
+                throw new ArgumentNullException(nameof(proposal));
+            }
+
+            var actualContext = context ?? new MutationInvocationContext();
+            if (!_pending.TryAdd(actualContext.InvocationId, 0))
+            {
+                return ConsentDecision.Cancelled("A consent request with this invocation ID is already pending.");
+            }
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var presenter = ResolvePresenter(proposal, actualContext);
+                if (presenter == null)
+                {
+                    return new ConsentDecision
+                    {
+                        Status = ConsentDecisionStatus.Unavailable,
+                        Reason = "No consent presenter is available for this operation.",
+                    };
+                }
+
+                var decision = await presenter.PresentAsync(proposal, actualContext, cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                return decision ?? ConsentDecision.Cancelled("The consent presenter returned no decision.");
+            }
+            catch (OperationCanceledException)
+            {
+                return ConsentDecision.Cancelled("The consent request was cancelled.");
+            }
+            finally
+            {
+                _pending.TryRemove(actualContext.InvocationId, out _);
+            }
+        }
+
+        /// <summary>
+        /// Gets whether an invocation currently has a pending consent request.
+        /// </summary>
+        internal static bool IsPending(string invocationId)
+        {
+            return !string.IsNullOrWhiteSpace(invocationId) && _pending.ContainsKey(invocationId);
+        }
+
+        private static IConsentPresenter? ResolvePresenter(IConsentProposal proposal, MutationInvocationContext context)
+        {
+            if (context.Presenter?.CanPresent(proposal, context) == true)
+            {
+                return context.Presenter;
+            }
+
+            lock (_presentersLock)
+            {
+                return _presenters.LastOrDefault(presenter => presenter.CanPresent(proposal, context));
+            }
+        }
+    }
+}

--- a/src/SmartHopper.Infrastructure/Consent/ConsentGate.cs
+++ b/src/SmartHopper.Infrastructure/Consent/ConsentGate.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure/Consent/MutatingOperationExecutor.cs
+++ b/src/SmartHopper.Infrastructure/Consent/MutatingOperationExecutor.cs
@@ -1,0 +1,63 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartHopper.Infrastructure.Consent
+{
+    /// <summary>
+    /// Provides the shared prepare-review-apply boundary for consent-controlled operations.
+    /// </summary>
+    public static class MutatingOperationExecutor
+    {
+        /// <summary>
+        /// Reviews a prepared proposal without applying state changes.
+        /// </summary>
+        public static Task<ConsentDecision> ReviewAsync(
+            IConsentProposal proposal,
+            MutationInvocationContext? context,
+            CancellationToken cancellationToken = default)
+        {
+            return ConsentGate.RequestAsync(proposal, context, cancellationToken);
+        }
+
+        /// <summary>
+        /// Reviews a prepared proposal and invokes apply only when at least one item is approved.
+        /// </summary>
+        public static async Task<TResult> ExecuteAsync<TResult>(
+            IConsentProposal proposal,
+            MutationInvocationContext? context,
+            Func<ConsentDecision, CancellationToken, Task<TResult>> applyAsync,
+            Func<ConsentDecision, TResult> rejectedResult,
+            CancellationToken cancellationToken = default)
+        {
+            if (applyAsync == null)
+            {
+                throw new ArgumentNullException(nameof(applyAsync));
+            }
+
+            if (rejectedResult == null)
+            {
+                throw new ArgumentNullException(nameof(rejectedResult));
+            }
+
+            var decision = await ReviewAsync(proposal, context, cancellationToken).ConfigureAwait(false);
+            if (!decision.IsApproved)
+            {
+                return rejectedResult(decision);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return await applyAsync(decision, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/SmartHopper.Infrastructure/Consent/MutatingOperationExecutor.cs
+++ b/src/SmartHopper.Infrastructure/Consent/MutatingOperationExecutor.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure/Consent/PlanConsentProposal.cs
+++ b/src/SmartHopper.Infrastructure/Consent/PlanConsentProposal.cs
@@ -6,6 +6,14 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
 using System;

--- a/src/SmartHopper.Infrastructure/Consent/PlanConsentProposal.cs
+++ b/src/SmartHopper.Infrastructure/Consent/PlanConsentProposal.cs
@@ -1,0 +1,84 @@
+/*
+ * SmartHopper - AI-powered Grasshopper Plugin
+ * Copyright (C) 2024-2026 Marc Roca Musach
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SmartHopper.Infrastructure.Consent
+{
+    /// <summary>
+    /// Represents one user-reviewable copilot plan.
+    /// </summary>
+    public sealed class PlanConsentProposal : IConsentProposal
+    {
+        /// <summary>Initializes a new plan proposal.</summary>
+        public PlanConsentProposal(
+            string goal,
+            string summary,
+            IReadOnlyList<PlanConsentStep> steps,
+            IReadOnlyList<string> assumptions,
+            IReadOnlyList<string> successCriteria)
+        {
+            this.Id = Guid.NewGuid().ToString("N");
+            this.Goal = goal;
+            this.Summary = summary;
+            this.Steps = steps;
+            this.Assumptions = assumptions;
+            this.SuccessCriteria = successCriteria;
+            this.ItemKeys = steps.Select(step => step.Id).ToList();
+        }
+
+        /// <inheritdoc/>
+        public string Id { get; }
+
+        /// <inheritdoc/>
+        public string Kind => "copilot-plan";
+
+        /// <inheritdoc/>
+        public string Title => "Review copilot plan";
+
+        /// <inheritdoc/>
+        public IReadOnlyList<string> ItemKeys { get; }
+
+        /// <summary>Gets the requested goal.</summary>
+        public string Goal { get; }
+
+        /// <summary>Gets the plan summary.</summary>
+        public string Summary { get; }
+
+        /// <summary>Gets the ordered plan steps.</summary>
+        public IReadOnlyList<PlanConsentStep> Steps { get; }
+
+        /// <summary>Gets the stated assumptions.</summary>
+        public IReadOnlyList<string> Assumptions { get; }
+
+        /// <summary>Gets the success criteria.</summary>
+        public IReadOnlyList<string> SuccessCriteria { get; }
+    }
+
+    /// <summary>
+    /// Represents one normalized step in a copilot plan.
+    /// </summary>
+    public sealed class PlanConsentStep
+    {
+        /// <summary>Gets or sets the stable step identifier.</summary>
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the user-facing description.</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the optional registered tool name.</summary>
+        public string? Tool { get; set; }
+
+        /// <summary>Gets or sets whether the registered tool mutates the canvas.</summary>
+        public bool MutatesCanvas { get; set; }
+    }
+}

--- a/src/SmartHopper.Infrastructure/Hosting/ProviderSdkHostAdapters.cs
+++ b/src/SmartHopper.Infrastructure/Hosting/ProviderSdkHostAdapters.cs
@@ -119,8 +119,9 @@ namespace SmartHopper.Infrastructure.Hosting
                 result[kvp.Key] = new ProviderToolDefinition
                 {
                     Name = tool.Name,
-                    Description = tool.Description,
+                    Description = tool.RichDescription,
                     Enabled = tool.Enabled,
+                    Surfaces = tool.Surfaces,
                     Category = tool.Category,
                     ParametersSchema = tool.ParametersSchema,
                 };

--- a/src/SmartHopper.Infrastructure/Mcp/AIToolMcpAdapter.cs
+++ b/src/SmartHopper.Infrastructure/Mcp/AIToolMcpAdapter.cs
@@ -32,6 +32,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SmartHopper.Infrastructure.AICall.Tools;
 using SmartHopper.Infrastructure.AITools;
+using SmartHopper.Infrastructure.Consent;
 using SmartHopper.ProviderSdk.AICall.Core.Base;
 using SmartHopper.ProviderSdk.AICall.Core.Interactions;
 using SmartHopper.ProviderSdk.AICall.Core.Returns;
@@ -124,7 +125,7 @@ namespace SmartHopper.Infrastructure.Mcp
                 return false;
             }
 
-            if (!tool.Enabled)
+            if (!tool.Enabled || (tool.Surfaces & SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp) == 0)
             {
                 return false;
             }
@@ -174,7 +175,18 @@ namespace SmartHopper.Infrastructure.Mcp
                 Arguments = arguments ?? new JObject(),
             };
 
-            var toolCall = new AIToolCall { SkipMetricsValidation = true };
+            var toolCall = new AIToolCall
+            {
+                SkipMetricsValidation = true,
+                ToolSurface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp,
+                InvocationContext = new MutationInvocationContext
+                {
+                    Source = MutationInvocationSource.Mcp,
+                    Surface = SmartHopper.ProviderSdk.Hosting.AIToolSurface.Mcp,
+                    ToolCallId = interaction.Id,
+                    ToolName = toolName,
+                },
+            };
             toolCall.FromToolCallInteraction(interaction);
 
             AIReturn result;

--- a/src/SmartHopper.Infrastructure/Resources/Mcp/Docs/assistant-core.md
+++ b/src/SmartHopper.Infrastructure/Resources/Mcp/Docs/assistant-core.md
@@ -8,4 +8,6 @@ You are a SmartHopper assistant operating inside Rhino 8 and Grasshopper 1.
 - When modifying the canvas, preserve component identity, connections, layout, user-authored content, and data-tree topology unless changing them is required. Verify errors and relevant outputs afterward.
 - Avoid exposing internal GUIDs unless the user requests them or needs them to identify an object.
 - Retrieve focused guidance with `smarthopper_readme`; retrieve canonical tool chains with `smarthopper_workflows`; inspect individual tools with `smarthopper_tool_help`; use `smarthopper_ghjson_reference` before manually constructing or editing GhJSON or GhPatch.
+- For non-trivial multi-step tasks, call `plan_propose` before acting. Do not use it for simple read-only questions. Plan approval permits continuing with the approach but never approves later canvas changes.
+- Every concrete canvas mutation is reviewed independently. Honor partial acceptance, rejection, and cancellation; do not repeat an unchanged rejected proposal without new user direction.
 - Distinguish verified runtime evidence, official documentation, community convention, and inference. Admit uncertainty and ask focused questions instead of guessing.

--- a/src/SmartHopper.ProviderSdk/AICall/Core/Requests/AIRequestBase.cs
+++ b/src/SmartHopper.ProviderSdk/AICall/Core/Requests/AIRequestBase.cs
@@ -91,6 +91,11 @@ namespace SmartHopper.ProviderSdk.AICall.Core.Requests
         public virtual AIRequestKind RequestKind { get; set; } = AIRequestKind.Generation;
 
         /// <summary>
+        /// Gets or sets the surface that owns tool discovery and execution for this request.
+        /// </summary>
+        public virtual AIToolSurface ToolSurface { get; set; } = AIToolSurface.Direct;
+
+        /// <summary>
         /// Per-request timeout in seconds applied to provider HTTP calls and tool execution wrappers.
         /// When null, the timeout is resolved from settings by RequestTimeoutPolicy.
         /// When set, this value takes precedence over settings.

--- a/src/SmartHopper.ProviderSdk/AIProviders/AIProvider.cs
+++ b/src/SmartHopper.ProviderSdk/AIProviders/AIProvider.cs
@@ -793,6 +793,17 @@ namespace SmartHopper.ProviderSdk.AIProviders
         /// <returns>A JArray of formatted tool function definitions matching the filter, or null if an error occurs.</returns>
         protected JArray GetFormattedTools(string toolFilter)
         {
+            return this.GetFormattedTools(toolFilter, AIToolSurface.Direct);
+        }
+
+        /// <summary>
+        /// Common tool formatting for function definitions on a specific execution surface.
+        /// </summary>
+        /// <param name="toolFilter">The filter to apply to tool categories.</param>
+        /// <param name="surface">The requesting execution surface.</param>
+        /// <returns>A JArray of formatted tool function definitions matching the filter and surface.</returns>
+        protected JArray GetFormattedTools(string toolFilter, AIToolSurface surface)
+        {
             try
             {
                 ProviderSdkHost.ToolRegistry.DiscoverTools();
@@ -807,9 +818,8 @@ namespace SmartHopper.ProviderSdk.AIProviders
                 var toolFilterObj = Filtering.Parse(toolFilter);
                 foreach (var tool in tools)
                 {
-                    if (!tool.Value.Enabled)
+                    if (!tool.Value.Enabled || (tool.Value.Surfaces & surface) == 0)
                     {
-                        // Skip tools that are disabled (e.g., experimental or unsupported)
                         continue;
                     }
 

--- a/src/SmartHopper.ProviderSdk/Hosting/IToolRegistryHost.cs
+++ b/src/SmartHopper.ProviderSdk/Hosting/IToolRegistryHost.cs
@@ -20,6 +20,31 @@ using System.Collections.Generic;
 namespace SmartHopper.ProviderSdk.Hosting
 {
     /// <summary>
+    /// Identifies the execution surfaces on which an AI tool may be exposed.
+    /// </summary>
+    [System.Flags]
+    public enum AIToolSurface
+    {
+        /// <summary>The tool is unavailable on every surface.</summary>
+        None = 0,
+
+        /// <summary>The tool is available to the in-process WebChat assistant.</summary>
+        Chat = 1,
+
+        /// <summary>The tool is available to direct component and API callers.</summary>
+        Direct = 2,
+
+        /// <summary>The tool is available during provider batch collection.</summary>
+        Batch = 4,
+
+        /// <summary>The tool is available through the MCP server.</summary>
+        Mcp = 8,
+
+        /// <summary>The tool is available on every execution surface.</summary>
+        All = Chat | Direct | Batch | Mcp,
+    }
+
+    /// <summary>
     /// Minimal projection of a tool exposed by the host's tool manager, scoped to the
     /// fields a provider needs when formatting tools for an LLM request.
     /// </summary>
@@ -36,6 +61,9 @@ namespace SmartHopper.ProviderSdk.Hosting
 
         /// <summary>Whether the tool is enabled and available for use.</summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>Gets or sets the surfaces on which this tool is available.</summary>
+        public AIToolSurface Surfaces { get; set; } = AIToolSurface.All;
 
         /// <summary>Tool category (e.g. <c>knowledge</c>, <c>script</c>); free-form.</summary>
         public string Category { get; set; }

--- a/src/SmartHopper.Providers.Anthropic/AnthropicProvider.cs
+++ b/src/SmartHopper.Providers.Anthropic/AnthropicProvider.cs
@@ -704,7 +704,7 @@ namespace SmartHopper.Providers.Anthropic
             {
                 try
                 {
-                    var toolsOpenAI = this.GetFormattedTools(toolFilter);
+                    var toolsOpenAI = this.GetFormattedTools(toolFilter, request.ToolSurface);
                     if (toolsOpenAI != null && toolsOpenAI.Count > 0)
                     {
                         var toolsAnthropic = new JArray();

--- a/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
+++ b/src/SmartHopper.Providers.DeepSeek/DeepSeekProvider.cs
@@ -463,7 +463,7 @@ namespace SmartHopper.Providers.DeepSeek
             // Add tools if requested
             if (!string.IsNullOrWhiteSpace(toolFilter))
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = tools;

--- a/src/SmartHopper.Providers.Gemini/GeminiProvider.cs
+++ b/src/SmartHopper.Providers.Gemini/GeminiProvider.cs
@@ -518,7 +518,7 @@ namespace SmartHopper.Providers.Gemini
 
             if (!string.IsNullOrWhiteSpace(request.Body?.ToolFilter))
             {
-                var toolsArray = this.GetFormattedTools(request.Body.ToolFilter);
+                var toolsArray = this.GetFormattedTools(request.Body.ToolFilter, request.ToolSurface);
                 if (toolsArray != null)
                 {
                     jObject["tools"] = new JArray
@@ -731,11 +731,11 @@ namespace SmartHopper.Providers.Gemini
             return !string.IsNullOrWhiteSpace(model) && Regex.IsMatch(model, @"^gemini-2\.0", RegexOptions.IgnoreCase);
         }
 
-        private JArray GetFormattedTools(string toolFilter)
+        private JArray GetFormattedTools(string toolFilter, SmartHopper.ProviderSdk.Hosting.AIToolSurface surface)
         {
             try
             {
-                var tools = base.GetFormattedTools(toolFilter);
+                var tools = base.GetFormattedTools(toolFilter, surface);
                 if (tools == null || tools.Count == 0)
                 {
                     return null;

--- a/src/SmartHopper.Providers.LocalAI/LocalAIProvider.cs
+++ b/src/SmartHopper.Providers.LocalAI/LocalAIProvider.cs
@@ -249,7 +249,7 @@ namespace SmartHopper.Providers.LocalAI
             // Add tools if requested
             if (!string.IsNullOrWhiteSpace(toolFilter))
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = tools;

--- a/src/SmartHopper.Providers.MistralAI/MistralAIProvider.cs
+++ b/src/SmartHopper.Providers.MistralAI/MistralAIProvider.cs
@@ -416,7 +416,7 @@ namespace SmartHopper.Providers.MistralAI
             // Add tools if requested
             if (!string.IsNullOrWhiteSpace(toolFilter))
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = tools;

--- a/src/SmartHopper.Providers.Ollama/OllamaProvider.cs
+++ b/src/SmartHopper.Providers.Ollama/OllamaProvider.cs
@@ -255,7 +255,7 @@ namespace SmartHopper.Providers.Ollama
             // Add tools if requested
             if (!string.IsNullOrWhiteSpace(toolFilter))
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = tools;

--- a/src/SmartHopper.Providers.OpenAI/OpenAIProvider.cs
+++ b/src/SmartHopper.Providers.OpenAI/OpenAIProvider.cs
@@ -784,7 +784,7 @@ namespace SmartHopper.Providers.OpenAI
             // Add tools if requested
             if (hasTools)
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = tools;
@@ -926,7 +926,7 @@ namespace SmartHopper.Providers.OpenAI
             // Add tools if requested
             if (hasTools)
             {
-                var tools = this.GetFormattedTools(toolFilter);
+                var tools = this.GetFormattedTools(toolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     requestBody["tools"] = this.ConvertToolsToResponsesFormat(tools);

--- a/src/SmartHopper.Providers.OpenRouter/OpenRouterProvider.cs
+++ b/src/SmartHopper.Providers.OpenRouter/OpenRouterProvider.cs
@@ -263,7 +263,7 @@ namespace SmartHopper.Providers.OpenRouter
             // Add tools if requested
             if (!string.IsNullOrWhiteSpace(request.Body.ToolFilter))
             {
-                var tools = this.GetFormattedTools(request.Body.ToolFilter);
+                var tools = this.GetFormattedTools(request.Body.ToolFilter, request.ToolSurface);
                 if (tools != null && tools.Count > 0)
                 {
                     body["tools"] = tools;

--- a/tools/Build-Solution.ps1
+++ b/tools/Build-Solution.ps1
@@ -133,9 +133,10 @@ if ($OutErrors -and $OutWarnings) {
 } elseif ($OutWarnings) {
     $dotnetBuildArgs += "-clp:WarningsOnly;Summary"
 } else {
-    # Quiet verbosity hides warnings and informational output; Summary keeps the
-    # final build result block. Note: MSBuild always prints errors if they occur.
-    $dotnetBuildArgs += "-v:q", "-clp:Summary"
+    # ErrorsOnly keeps the build output readable (the solution has thousands of
+    # analyzer/style warnings) while ensuring compile errors are always visible.
+    # Summary keeps the final build result block.
+    $dotnetBuildArgs += "-clp:ErrorsOnly;Summary"
 }
 & dotnet build @dotnetBuildArgs
 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Description
Adds an agentic WebChat copilot with explicit planning and one-call consent for canvas mutations. The model can now propose multi-step plans via a Chat-only `plan_propose` tool that pauses for user approval. Each canvas-mutating tool call is gated by a centralized `ConsentGate` that presents a graphical review of staged changes over the live Grasshopper canvas, applying only user-accepted changes. Explicit `AIToolSurface` flags control tool exposure across Chat, Direct, Batch, and MCP surfaces, ensuring control tools like `plan_propose` remain unavailable outside WebChat. Existing mutating tools are migrated to the new `AIMutatingTool` type, which standardizes two-phase prepare/consent/apply execution and automatic undo coordination.

## Breaking Changes
No breaking changes.

## Testing Done

_Not verified by automation — to be completed by the author._

## Checklist

- [ ] This PR is focused on a single feature or bug fix
- [ ] CHANGELOG.md has been updated with relevant information to end user